### PR TITLE
Update README to reflect Linux PyPI availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,28 +14,21 @@ Example from [`examples/mmg3d/mesh_quality_improvement.py`](https://github.com/k
 
 ## Installation
 
-To install the package, run the following command (from Windows or MacOS), the Linux package is not available on PyPI yet and needs the next command to be installed:
+Install from PyPI (Windows, macOS, and Linux):
 
 ```bash
 pip install mmgpy
 ```
 
-Or directly from this repository:
-
-```bash
-pip install git+https://github.com/kmarchais/mmgpy.git
-```
-
-for `uv` users:
+Or with `uv`:
 
 ```bash
 uv pip install mmgpy
 ```
 
-On Linux:
+To install directly from the repository:
 
 ```bash
-sudo apt install build-essential libvtk9-dev
 pip install git+https://github.com/kmarchais/mmgpy.git
 ```
 


### PR DESCRIPTION
## Summary

- Simplify installation instructions now that Linux wheels are on PyPI
- Remove outdated statement about Linux not being available on PyPI
- Linux wheels have been available since v0.1.5

## Test Plan

- [x] README renders correctly