### PR TITLE
Fix wheel RECORD mismatch and remove invalid skip selector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ unresolved-import = "ignore"
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
-skip = "pp* *-win32 *-manylinux_i686 *-musllinux_i686 *-musllinux*"
+skip = "*-win32 *-manylinux_i686 *-musllinux*"
 test-command = 'python -c "import mmgpy"'
 build-verbosity = 1
 


### PR DESCRIPTION
## Summary

Fixes #47 (partial - remaining item is Trusted Publishing setup on PyPI)

## Changes

### 1. Regenerate RECORD file after wheel optimization

The `optimize_wheels.py` script removes VTK duplicates and dev files from wheels, but the RECORD manifest still listed the deleted files. PyPI will reject non-compliant uploads starting February 2026.

- Added `update_record()` function to regenerate RECORD with correct hashes
- Called after file removal but before recreating the wheel ZIP
- Reference: https://blog.pypi.org/posts/2025-08-07-wheel-archive-confusion-attacks/

### 2. Remove 'pp*' from cibuildwheel skip selector

PyPy builds aren't enabled, so the `pp*` skip selector was invalid and caused warnings on all platforms.

## Test Plan

- [x] Pre-commit hooks pass
- [ ] CI wheel build succeeds (will verify in CI)

## Remaining from #47

- [ ] Set up Trusted Publishing on PyPI (requires PyPI web configuration)