### PR TITLE
Use tmp_path fixture in test_load_mesh for cleanup

### DIFF
--- a/tests/mesh_test.py
+++ b/tests/mesh_test.py
@@ -116,18 +116,19 @@ def test_mmg_mesh() -> None:
     npt.assert_array_almost_equal(mesh["tensor"], tensor)
 
 
-def test_load_mesh() -> None:
+def test_load_mesh(tmp_path: Path) -> None:
     """Test loading a mesh from file."""
     vertices, elements = create_test_mesh()
 
     # Save mesh to file
     mesh = MmgMesh(vertices, elements)
-    mesh.save(Path(__file__).parent / "test_mesh.mesh")
+    mesh_file = tmp_path / "test_mesh.mesh"
+    mesh.save(mesh_file)
 
     # Load mesh from file
-    mesh = MmgMesh(Path(__file__).parent / "test_mesh.mesh")
-    npt.assert_array_almost_equal(mesh.get_vertices(), vertices)
-    npt.assert_array_equal(mesh.get_elements(), elements)
+    loaded = MmgMesh(mesh_file)
+    npt.assert_array_almost_equal(loaded.get_vertices(), vertices)
+    npt.assert_array_equal(loaded.get_elements(), elements)
 
 
 def test_load_nonexistent_file_no_crash(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Use pytest's `tmp_path` fixture for automatic cleanup of test mesh files.

## Changes

- `test_load_mesh` now uses `tmp_path` instead of saving to `tests/test_mesh.mesh`
- Ensures consistent cleanup behavior with other file I/O tests in the module

## Test Plan

- [x] All 37 mesh tests pass
- [x] Pre-commit hooks pass