### PR TITLE
Initialize success variable to prevent undefined behavior

### DIFF
--- a/DEVELOPMENT_ROADMAP.md
+++ b/DEVELOPMENT_ROADMAP.md
@@ -4,11 +4,11 @@
 
 ## Open GitHub Issues
 
-| Issue                                               | Description                    |
-| --------------------------------------------------- | ------------------------------ |
-| [#47](https://github.com/kmarchais/mmgpy/issues/47) | Migrate to Trusted Publishing  |
-| [#44](https://github.com/kmarchais/mmgpy/issues/44) | Reduce pre-commit rule ignores |
-| [#41](https://github.com/kmarchais/mmgpy/issues/41) | Optimize wheel sizes           |
+| Issue                                               | Description                    | Status    |
+| --------------------------------------------------- | ------------------------------ | --------- |
+| [#47](https://github.com/kmarchais/mmgpy/issues/47) | Migrate to Trusted Publishing  |           |
+| [#44](https://github.com/kmarchais/mmgpy/issues/44) | Reduce pre-commit rule ignores |           |
+| [#41](https://github.com/kmarchais/mmgpy/issues/41) | Optimize wheel sizes           | ✅ PR #61 |
 
 ---
 
@@ -78,9 +78,8 @@ mmg3d.remesh_with_motion(mesh, displacement)
 
 ## Code Quality Items
 
-| Priority | Item                                   | Location                                         |
-| -------- | -------------------------------------- | ------------------------------------------------ |
-| 🟡       | Initialize `success = false` in switch | `mmg3d.cpp:187`, `mmg2d.cpp:215`, `mmgs.cpp:195` |
-| 🟡       | Centralize VTK version string          | Multiple files                                   |
-| 🟡       | Add CI dependency caching              | Workflows                                        |
-| 🟢       | Use `logging` module                   | `__init__.py`                                    |
+| Priority | Item                                       | Location                                 | Status    |
+| -------- | ------------------------------------------ | ---------------------------------------- | --------- |
+| 🟡       | ~~Initialize `success = false` in switch~~ | ~~`mmg3d.cpp`, `mmg2d.cpp`, `mmgs.cpp`~~ | ✅ Done   |
+| 🟡       | ~~Centralize VTK version string~~          | ~~Multiple files~~                       | ✅ PR #61 |
+| 🟢       | Use `logging` module                       | `__init__.py`                            |           |

--- a/src/bindings/mmg2d.cpp
+++ b/src/bindings/mmg2d.cpp
@@ -212,7 +212,7 @@ void set_mesh_options_2D(MMG5_pMesh mesh, MMG5_pSol met,
     }
 
     const ParamInfo &info = it->second;
-    bool success;
+    bool success = false;
 
     switch (info.type) {
     case ParamType::Double:

--- a/src/bindings/mmg3d.cpp
+++ b/src/bindings/mmg3d.cpp
@@ -184,7 +184,7 @@ void set_mesh_options_3D(MMG5_pMesh mesh, MMG5_pSol met,
     }
 
     const ParamInfo &info = it->second;
-    bool success;
+    bool success = false;
 
     switch (info.type) {
     case ParamType::Double:

--- a/src/bindings/mmgs.cpp
+++ b/src/bindings/mmgs.cpp
@@ -190,7 +190,7 @@ void set_mesh_options_surface(MMG5_pMesh mesh, MMG5_pSol met,
     }
 
     const ParamInfo &info = it->second;
-    bool success;
+    bool success = false;
 
     switch (info.type) {
     case ParamType::Double:


### PR DESCRIPTION
## Summary

Initialize `bool success = false` in switch statements to ensure defined behavior if new `ParamType` values are added without updating the switch cases.

## Changes

- `mmg3d.cpp:187`: `bool success;` → `bool success = false;`
- `mmg2d.cpp:215`: `bool success;` → `bool success = false;`
- `mmgs.cpp:193`: `bool success;` → `bool success = false;`

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI builds pass