### PR TITLE
fix(tests): prefix unused unpacked variables with underscore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ ignore = [
     "SLF001",  # accessing private members allowed in tests
     "BLE001",  # broad exception catching allowed in tests
     "PLC0415", # imports inside functions are intentional for fixtures
-    "RUF059",  # unused unpacked variables are intentional fixtures
     "N806",    # uppercase variable names for matrices (M, D, H) standard in math
     "PLR2004", # magic values allowed in tests
     "NPY002",  # legacy numpy random is fine for tests

--- a/tests/mesh_test.py
+++ b/tests/mesh_test.py
@@ -343,7 +343,7 @@ def test_programmatic_mesh_construction() -> None:
     mesh.set_triangles(triangles)
 
     # Verify mesh construction
-    np_v, ne, nprism, nt, nquad, na = mesh.get_mesh_size()
+    np_v, ne, _nprism, nt, _nquad, _na = mesh.get_mesh_size()
     assert np_v == len(vertices)
     assert ne == len(tetrahedra)
     assert nt == len(triangles)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -187,7 +187,7 @@ class TestValidateMetricTensor:
         """Test that anisotropic positive-definite metric is valid."""
         sizes = np.array([0.1, 0.5, 1.0])
         tensor = metrics.create_anisotropic_metric(sizes)
-        is_valid, msg = metrics.validate_metric_tensor(tensor)
+        is_valid, _msg = metrics.validate_metric_tensor(tensor)
         assert is_valid
 
     def test_invalid_negative_diagonal(self) -> None:
@@ -206,7 +206,7 @@ class TestValidateMetricTensor:
     def test_batch_validation(self) -> None:
         """Test validating multiple tensors at once."""
         tensors = metrics.create_isotropic_metric(0.1, 5, dim=3)
-        is_valid, msg = metrics.validate_metric_tensor(tensors)
+        is_valid, _msg = metrics.validate_metric_tensor(tensors)
         assert is_valid
 
 
@@ -217,7 +217,7 @@ class TestComputeMetricEigenpairs:
         """Test eigenpair extraction from isotropic metric."""
         h = 0.1
         tensor = metrics.create_isotropic_metric(h, 1, dim=3)[0]
-        sizes, directions = metrics.compute_metric_eigenpairs(tensor)
+        sizes, _directions = metrics.compute_metric_eigenpairs(tensor)
 
         # All sizes should be h
         npt.assert_array_almost_equal(sizes, [h, h, h])

--- a/tests/mmg2d_test.py
+++ b/tests/mmg2d_test.py
@@ -81,7 +81,7 @@ def generated_meshes(
 
 def test_mesh_files_exist(mesh_paths: tuple[Path, Path, Path]) -> None:
     """Test that input mesh file exists."""
-    input_mesh, test_path, ref_path = mesh_paths
+    input_mesh, _test_path, _ref_path = mesh_paths
     assert input_mesh.exists(), f"Input mesh file not found: {input_mesh}"
 
 
@@ -91,7 +91,7 @@ def test_mesh_generation(
 ) -> None:
     """Test that both meshes are generated successfully."""
     test_mesh, ref_mesh = generated_meshes
-    input_mesh, test_path, ref_path = mesh_paths
+    _input_mesh, test_path, ref_path = mesh_paths
 
     # Check files were created
     assert test_path.exists(), f"Test mesh file not created: {test_path}"

--- a/tests/mmg3d_test.py
+++ b/tests/mmg3d_test.py
@@ -85,7 +85,7 @@ def generated_meshes(
 
 def test_mesh_files_exist(mesh_paths: tuple[Path, Path, Path]) -> None:
     """Test that input mesh file exists."""
-    input_mesh, test_path, ref_path = mesh_paths
+    input_mesh, _test_path, _ref_path = mesh_paths
     assert input_mesh.exists(), f"Input mesh file not found: {input_mesh}"
 
 
@@ -95,7 +95,7 @@ def test_mesh_generation(
 ) -> None:
     """Test that both meshes are generated successfully."""
     test_mesh, ref_mesh = generated_meshes
-    input_mesh, test_path, ref_path = mesh_paths
+    _input_mesh, test_path, ref_path = mesh_paths
 
     # Check files were created
     assert test_path.exists(), f"Test mesh file not created: {test_path}"

--- a/tests/mmgs_test.py
+++ b/tests/mmgs_test.py
@@ -99,7 +99,7 @@ def generated_meshes(
 
 def test_mesh_files_exist(mesh_paths: tuple[Path, Path, Path]) -> None:
     """Test that input mesh file exists."""
-    input_mesh, test_path, ref_path = mesh_paths
+    input_mesh, _test_path, _ref_path = mesh_paths
     assert input_mesh.exists(), f"Input mesh file not found: {input_mesh}"
 
 
@@ -109,7 +109,7 @@ def test_mesh_generation(
 ) -> None:
     """Test that both meshes are generated successfully."""
     test_mesh, ref_mesh = generated_meshes
-    input_mesh, test_path, ref_path = mesh_paths
+    _input_mesh, test_path, ref_path = mesh_paths
 
     # Check files were created
     assert test_path.exists(), f"Test mesh file not created: {test_path}"


### PR DESCRIPTION
## Summary
Remove `RUF059` ignore from tests by fixing 15 violations where unpacked variables were unused.

## Changes
- Prefix unused unpacked variables with underscore (e.g., `nprism` → `_nprism`)
- Remove `RUF059` from test per-file ignores in pyproject.toml

## Files changed
- `tests/mesh_test.py`
- `tests/metrics_test.py`
- `tests/mmg2d_test.py`
- `tests/mmg3d_test.py`
- `tests/mmgs_test.py`
- `pyproject.toml`

## Related
Closes #99 (part of #44)

## Test plan
- [x] Linting passes
- [x] Affected tests pass