### PR TITLE
refactor: reduce per-file ignores by fixing violations

### DIFF
--- a/benchmarks/bench_comparison.py
+++ b/benchmarks/bench_comparison.py
@@ -159,12 +159,10 @@ class TestRemesh3DComparison:
         print("RESULT VALIDATION:")
         print(f"  Vertices:    exe={exe_n_vertices}, api={api_n_vertices}")
         print(f"  Tetrahedra:  exe={exe_n_tetrahedra}, api={api_n_tetrahedra}")
-        print(
-            f"  Quality min: exe={exe_qualities.min():.3f}, api={api_qualities.min():.3f}",
-        )
-        print(
-            f"  Quality avg: exe={exe_qualities.mean():.3f}, api={api_qualities.mean():.3f}",
-        )
+        exe_min, api_min = exe_qualities.min(), api_qualities.min()
+        exe_avg, api_avg = exe_qualities.mean(), api_qualities.mean()
+        print(f"  Quality min: exe={exe_min:.3f}, api={api_min:.3f}")
+        print(f"  Quality avg: exe={exe_avg:.3f}, api={api_avg:.3f}")
         print("=" * 60)
 
         # Verify results are equivalent (within 5% tolerance)
@@ -174,8 +172,8 @@ class TestRemesh3DComparison:
         assert abs(exe_n_tetrahedra - api_n_tetrahedra) / exe_n_tetrahedra < 0.05, (
             f"Tetrahedra count differs: exe={exe_n_tetrahedra}, api={api_n_tetrahedra}"
         )
-        assert abs(exe_qualities.mean() - api_qualities.mean()) < 0.05, (
-            f"Quality differs: exe={exe_qualities.mean():.3f}, api={api_qualities.mean():.3f}"
+        assert abs(exe_avg - api_avg) < 0.05, (
+            f"Quality differs: exe={exe_avg:.3f}, api={api_avg:.3f}"
         )
 
         # Basic assertion - API shouldn't be drastically slower
@@ -442,16 +440,16 @@ class TestAutoDetectionOverhead:
         print("EXECUTABLE (subprocess):")
         print(f"  mmg3d_O3 (direct): {exe_direct_avg:.3f}s")
         print(f"  mmg (autodetect):  {exe_auto_avg:.3f}s")
-        print(
-            f"  Overhead:          {(exe_auto_avg - exe_direct_avg) * 1000:.1f}ms ({(exe_auto_avg / exe_direct_avg - 1) * 100:.1f}%)",
-        )
+        exe_oh_ms = (exe_auto_avg - exe_direct_avg) * 1000
+        exe_oh_pct = (exe_auto_avg / exe_direct_avg - 1) * 100
+        print(f"  Overhead:          {exe_oh_ms:.1f}ms ({exe_oh_pct:.1f}%)")
         print("-" * 60)
         print("PYTHON API (in-memory):")
         print(f"  MmgMesh3D (direct): {api_direct_avg:.3f}s")
         print(f"  Mesh (autodetect):  {api_auto_avg:.3f}s")
-        print(
-            f"  Overhead:           {(api_auto_avg - api_direct_avg) * 1000:.1f}ms ({(api_auto_avg / api_direct_avg - 1) * 100:.1f}%)",
-        )
+        api_oh_ms = (api_auto_avg - api_direct_avg) * 1000
+        api_oh_pct = (api_auto_avg / api_direct_avg - 1) * 100
+        print(f"  Overhead:           {api_oh_ms:.1f}ms ({api_oh_pct:.1f}%)")
         print("=" * 60)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ ignore = [
     "S607",    # partial executable paths are intentional for benchmarks
     "PLC0415", # imports in functions are fine for benchmarks
     "T201",    # print statements used for timing reports
-    "E501",    # long lines acceptable in benchmark output formatting
 ]
 "src/mmgpy/__init__.py" = [
     "S603",   # subprocess calls with absolute paths to system tools are safe
@@ -152,7 +151,6 @@ ignore = [
     "BLE001", # broad exception catching is acceptable for non-critical RPATH fixing
     "E402",   # imports inside functions are intentional for lazy loading
     "C901",   # complex functions are acceptable for RPATH fixing logic
-    "RUF005", # list concatenation is fine here for subprocess args
     "PTH207", # glob usage is fine for file discovery
     "D417",   # self parameter doesn't need documenting for methods
     "PLR0915", # wrapper functions that patch multiple mesh classes have many statements

--- a/src/mmgpy/__init__.py
+++ b/src/mmgpy/__init__.py
@@ -98,7 +98,7 @@ def _run_mmg2d() -> None:
     exe_path = site_packages / scripts_dir / exe_name
 
     if exe_path.exists():
-        subprocess.run([str(exe_path)] + sys.argv[1:], check=False)
+        subprocess.run([str(exe_path), *sys.argv[1:]], check=False)
     else:
         _logger.error("mmg2d_O3 executable not found at %s", exe_path)
         sys.exit(1)
@@ -117,7 +117,7 @@ def _run_mmg3d() -> None:
     exe_path = site_packages / scripts_dir / exe_name
 
     if exe_path.exists():
-        subprocess.run([str(exe_path)] + sys.argv[1:], check=False)
+        subprocess.run([str(exe_path), *sys.argv[1:]], check=False)
     else:
         _logger.error("mmg3d_O3 executable not found at %s", exe_path)
         sys.exit(1)
@@ -136,7 +136,7 @@ def _run_mmgs() -> None:
     exe_path = site_packages / scripts_dir / exe_name
 
     if exe_path.exists():
-        subprocess.run([str(exe_path)] + sys.argv[1:], check=False)
+        subprocess.run([str(exe_path), *sys.argv[1:]], check=False)
     else:
         _logger.error("mmgs_O3 executable not found at %s", exe_path)
         sys.exit(1)


### PR DESCRIPTION
## Summary
Further reduce per-file ignores for #44 by fixing actual code violations.

## Changes

### `src/mmgpy/__init__.py`
- Fixed RUF005: Use list unpacking `[str(exe_path), *sys.argv[1:]]` instead of concatenation
- Removed RUF005 from ignores (9 → 8 rules)

### `benchmarks/bench_comparison.py`
- Fixed E501: Extract inline calculations to variables for shorter lines
- Removed E501 from ignores (11 → 10 rules)

## Ignore count progression

| Area | Before PR #101 | After PR #101 | After this PR |
|------|----------------|---------------|---------------|
| `__init__.py` | 9 | 9 | **8** |
| `benchmarks/` | 11 | 11 | **10** |
| **Total per-file** | ~60 | ~48 | **~46** |

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Pre-commit hooks pass