### PR TITLE
refactor: reduce more per-file ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ ignore = [
     "PLC0415", # imports inside functions are intentional for fixtures
     "N806",    # uppercase variable names for matrices (M, D, H) standard in math
     "PLR2004", # magic values allowed in tests
-    "NPY002",  # legacy numpy random is fine for tests
     "S603",    # subprocess calls allowed in tests
     "S607",    # partial executable paths allowed in tests
     "TC003",   # pathlib import in runtime allowed for test fixtures
@@ -116,7 +115,6 @@ ignore = [
     "N803",    # uppercase argument names for matrices standard in math
     "PLR2004", # magic values (2, 3, 6) are dimension constants in math code
     "C901",    # complex functions acceptable for mathematical algorithms
-    "E501",    # long lines acceptable in docstrings
 ]
 "examples/**/*.py" = [
     "T201",    # print statements essential for example output
@@ -151,7 +149,6 @@ ignore = [
     "BLE001", # broad exception catching is acceptable for non-critical RPATH fixing
     "E402",   # imports inside functions are intentional for lazy loading
     "C901",   # complex functions are acceptable for RPATH fixing logic
-    "PTH207", # glob usage is fine for file discovery
     "D417",   # self parameter doesn't need documenting for methods
     "PLR0915", # wrapper functions that patch multiple mesh classes have many statements
 ]

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -5,7 +5,8 @@ metric tensors used in anisotropic mesh adaptation with MMG.
 
 Metric tensors define the desired element size and shape at each vertex:
 - **Isotropic metric**: Single scalar h → equilateral elements of size h
-- **Anisotropic metric**: Symmetric tensor → stretched elements aligned with principal directions
+- **Anisotropic metric**: Symmetric tensor → stretched elements aligned with
+  principal directions
 
 Tensor storage format (row-major, upper triangular):
 - **3D**: [m11, m12, m13, m22, m23, m33] (6 components)

--- a/tests/lagrangian_test.py
+++ b/tests/lagrangian_test.py
@@ -112,7 +112,8 @@ class TestPropagateDisplacement:
         n = len(vertices)
 
         boundary_mask = np.ones(n, dtype=bool)
-        displacement = np.random.rand(n, 2).astype(np.float64)
+        rng = np.random.default_rng(42)
+        displacement = rng.random((n, 2)).astype(np.float64)
 
         result = propagate_displacement(
             vertices,
@@ -128,7 +129,8 @@ class TestPropagateDisplacement:
         n = len(vertices)
 
         boundary_mask = np.zeros(n, dtype=bool)
-        displacement = np.random.rand(n, 2).astype(np.float64)
+        rng = np.random.default_rng(42)
+        displacement = rng.random((n, 2)).astype(np.float64)
 
         result = propagate_displacement(
             vertices,
@@ -217,7 +219,8 @@ class TestPropagateDisplacement:
         n = len(vertices)
 
         boundary_mask = np.ones(n, dtype=bool)
-        displacement = np.random.rand(n, 2).astype(np.float64)
+        rng = np.random.default_rng(42)
+        displacement = rng.random((n, 2)).astype(np.float64)
 
         # Wrong boundary_mask size
         with pytest.raises(ValueError, match="boundary_mask length"):

--- a/tests/mesh_test.py
+++ b/tests/mesh_test.py
@@ -1311,7 +1311,8 @@ def test_mmg_mesh_2d_displacement_field() -> None:
     mesh = MmgMesh2D(vertices, triangles)
 
     n_vertices = vertices.shape[0]
-    displacement = np.random.rand(n_vertices, 2).astype(np.float64) * 0.1
+    rng = np.random.default_rng(42)
+    displacement = rng.random((n_vertices, 2)).astype(np.float64) * 0.1
 
     mesh["displacement"] = displacement
     retrieved = mesh["displacement"]

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -112,7 +112,8 @@ class TestCreateAnisotropicMetric:
     def test_batch_metrics(self) -> None:
         """Test creating multiple metrics at once."""
         n_vertices = 10
-        sizes = np.random.uniform(0.1, 1.0, (n_vertices, 3))
+        rng = np.random.default_rng(42)
+        sizes = rng.uniform(0.1, 1.0, (n_vertices, 3))
         metric = metrics.create_anisotropic_metric(sizes)
 
         assert metric.shape == (n_vertices, 6)
@@ -165,7 +166,8 @@ class TestTensorMatrixConversion:
 
     def test_batch_conversion(self) -> None:
         """Test batch tensor/matrix conversion."""
-        tensors = np.random.uniform(0.1, 2.0, (5, 6))
+        rng = np.random.default_rng(42)
+        tensors = rng.uniform(0.1, 2.0, (5, 6))
         matrices = metrics.tensor_to_matrix(tensors)
         assert matrices.shape == (5, 3, 3)
 


### PR DESCRIPTION
## Summary
Continue reducing per-file ignores for #44.

## Changes

| File | Ignore Removed | Method |
|------|----------------|--------|
| `__init__.py` | PTH207 | No violations existed |
| `metrics.py` | E501 | Wrapped long docstring line |
| `tests/` | NPY002 | Converted to modern `np.random.default_rng()` |

## Ignore count

| Area | Before | After |
|------|--------|-------|
| `__init__.py` | 8 | **7** |
| `metrics.py` | 5 | **4** |
| `tests/` | 11 | **10** |

## Test plan
- [x] `ruff check` passes
- [x] Affected tests pass