### PR TITLE
chore: remove unused NPY002 ignore from benchmarks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ ignore = [
     "S101",    # asserts allowed in benchmarks
     "PLR2004", # magic values allowed in benchmarks
     "INP001",  # benchmarks directory is not a package
-    "NPY002",  # legacy numpy random is fine for benchmarks
     "TC002",   # third-party imports in runtime for type annotations
     "TC003",   # stdlib imports in runtime for type annotations
     "S603",    # subprocess calls are safe (calling our own executables)


### PR DESCRIPTION
## Summary
Remove NPY002 ignore from benchmarks - no violations exist.

Benchmarks ignores: 10 → 9

Part of #44.