### PR TITLE
feat(lagrangian): add Lagrangian motion support for surface meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Lagrangian motion support for surface meshes (`MmgMeshS.remesh_lagrangian()`) via Python implementation using Laplacian smoothing ([#117](https://github.com/kmarchais/mmgpy/issues/117))
+- New `remesh_lagrangian_surface()` function in `mmgpy.lagrangian` module
+- Surface mesh Lagrangian motion example with animated GIF generation
 - Comprehensive MMGS (surface mesh) test suite with PyVista quality validation ([#55](https://github.com/kmarchais/mmgpy/pull/55))
 - Tensor metric support for anisotropic mesh adaptation ([#54](https://github.com/kmarchais/mmgpy/pull/54))
 - Low-level mesh construction API exposing MMG internal functions ([#52](https://github.com/kmarchais/mmgpy/pull/52))

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -265,6 +265,36 @@ result = mesh.remesh_levelset(levelset)
 
 ---
 
+### Lagrangian Motion (Surface)
+
+Apply displacement to surface mesh while maintaining quality.
+
+```python
+"""Surface mesh Lagrangian motion remeshing."""
+import mmgpy
+import numpy as np
+
+mesh = mmgpy.MmgMeshS(vertices, triangles)
+original_vertices = mesh.get_vertices()
+
+# Create radial expansion displacement
+center = original_vertices.mean(axis=0)
+directions = original_vertices - center
+norms = np.linalg.norm(directions, axis=1, keepdims=True)
+displacement = directions / (norms + 1e-10) * 0.1
+
+# Remesh with motion (Python implementation for surface meshes)
+result = mesh.remesh_lagrangian(
+    displacement,
+    n_steps=2,
+    hausd=0.01,
+)
+```
+
+[View full example](https://github.com/kmarchais/mmgpy/blob/main/examples/mmgs/lagrangian_motion.py)
+
+---
+
 ## Running Examples
 
 Clone the repository and run examples:

--- a/examples/mmgs/lagrangian_motion.py
+++ b/examples/mmgs/lagrangian_motion.py
@@ -1,0 +1,292 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "mmgpy",
+#     "numpy",
+#     "pyvista",
+#     "scipy",
+#     "imageio",
+# ]
+#
+# [tool.uv.sources]
+# mmgpy = { path = "../.." }
+# ///
+"""Surface mesh Lagrangian motion remeshing example.
+
+This example demonstrates how to use the `remesh_lagrangian` method on surface
+meshes (MmgMeshS). Since MMGS does not natively support Lagrangian motion,
+mmgpy provides a Python implementation using Laplacian smoothing for
+displacement propagation combined with standard MMGS remeshing.
+
+The example shows:
+1. Creating a sphere surface mesh
+2. Applying a "breathing" (radial expansion/contraction) displacement
+3. Visualizing the deformation with an animated GIF
+
+Use cases for surface mesh Lagrangian motion:
+- Morphing between surface shapes
+- Fluid-structure interaction simulations on surfaces
+- Shape optimization with surface constraints
+- Medical image registration with anatomical surfaces
+"""
+
+from pathlib import Path
+
+import imageio.v3 as iio
+import numpy as np
+import pyvista as pv
+
+from mmgpy import MmgMeshS
+
+
+def create_sphere_mesh(radius: float = 1.0, n_subdivisions: int = 2) -> MmgMeshS:
+    """Create a sphere surface mesh using PyVista.
+
+    Args:
+        radius: Sphere radius.
+        n_subdivisions: Number of subdivisions for mesh refinement.
+
+    Returns:
+        MmgMeshS surface mesh object.
+
+    """
+    sphere = pv.Sphere(radius=radius, theta_resolution=16, phi_resolution=16)
+    sphere = sphere.subdivide(n_subdivisions)
+    sphere = sphere.triangulate()
+
+    vertices = np.array(sphere.points, dtype=np.float64)
+    triangles = sphere.cells_dict[pv.CellType.TRIANGLE].astype(np.int32)
+
+    return MmgMeshS(vertices, triangles)
+
+
+def create_radial_displacement(
+    vertices: np.ndarray,
+    scale: float,
+    center: np.ndarray | None = None,
+) -> np.ndarray:
+    """Create radial displacement field (expansion/contraction from center).
+
+    Args:
+        vertices: Nx3 array of vertex positions.
+        scale: Displacement magnitude (positive = expansion, negative = contraction).
+        center: Center point for radial displacement. Defaults to origin.
+
+    Returns:
+        Nx3 array of displacement vectors.
+
+    """
+    if center is None:
+        center = np.array([0.0, 0.0, 0.0])
+
+    n_vertices = len(vertices)
+    displacement = np.zeros((n_vertices, 3), dtype=np.float64)
+
+    for i in range(n_vertices):
+        r_vec = vertices[i] - center
+        r = np.linalg.norm(r_vec)
+        if r > 1e-10:
+            direction = r_vec / r
+            displacement[i] = direction * scale
+
+    return displacement
+
+
+def pyvista_mesh_from_mmgmeshs(mesh: MmgMeshS) -> pv.PolyData:
+    """Convert MmgMeshS to PyVista PolyData for visualization."""
+    vertices = mesh.get_vertices()
+    triangles = mesh.get_triangles()
+    faces = np.hstack([np.full((len(triangles), 1), 3), triangles]).ravel()
+    return pv.PolyData(vertices, faces)
+
+
+def generate_animation_frames(
+    mesh: MmgMeshS,
+    output_dir: Path,
+    n_frames: int = 20,
+    max_scale: float = 0.15,
+) -> list[Path]:
+    """Generate animation frames showing the breathing motion.
+
+    Args:
+        mesh: Initial MmgMeshS mesh.
+        output_dir: Directory to save frame images.
+        n_frames: Number of frames in the animation cycle.
+        max_scale: Maximum radial displacement scale.
+
+    Returns:
+        List of paths to frame images.
+
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    frame_paths = []
+
+    original_vertices = mesh.get_vertices().copy()
+    original_triangles = mesh.get_triangles().copy()
+
+    # Generate frames for one complete breathing cycle
+    for frame_idx in range(n_frames):
+        # Sinusoidal breathing motion
+        t = frame_idx / n_frames
+        scale = max_scale * np.sin(2 * np.pi * t)
+
+        # Reset mesh to original state
+        mesh_copy = MmgMeshS(original_vertices, original_triangles)
+
+        # Apply displacement
+        displacement = create_radial_displacement(original_vertices, scale)
+
+        # Use n_steps=2 for smoother deformation
+        result = mesh_copy.remesh_lagrangian(
+            displacement,
+            n_steps=2,
+            hausd=0.02,
+            verbose=False,
+        )
+
+        # Create visualization
+        pv_mesh = pyvista_mesh_from_mmgmeshs(mesh_copy)
+
+        pl = pv.Plotter(off_screen=True, window_size=[800, 600])
+        pl.add_mesh(
+            pv_mesh,
+            show_edges=True,
+            edge_color="gray",
+            color="lightblue",
+            opacity=1.0,
+        )
+        pl.add_title(
+            f"Surface Lagrangian Motion\n"
+            f"Scale: {scale:.3f}, Vertices: {result['after']['vertices']}",
+        )
+        pl.camera_position = "iso"
+        pl.camera.zoom(1.2)
+
+        frame_path = output_dir / f"frame_{frame_idx:03d}.png"
+        pl.screenshot(frame_path)
+        pl.close()
+
+        frame_paths.append(frame_path)
+        print(
+            f"  Frame {frame_idx + 1}/{n_frames} - Duration: {result['duration']:.3f}s",
+        )
+
+    return frame_paths
+
+
+def create_gif(
+    frame_paths: list[Path],
+    output_path: Path,
+    duration: float = 0.1,
+) -> None:
+    """Create animated GIF from frame images.
+
+    Args:
+        frame_paths: List of paths to frame images.
+        output_path: Output GIF path.
+        duration: Duration per frame in seconds.
+
+    """
+    images = [iio.imread(str(p)) for p in frame_paths]
+    iio.imwrite(
+        str(output_path),
+        images,
+        duration=int(duration * 1000),  # milliseconds
+        loop=0,  # infinite loop
+    )
+
+
+def main() -> None:
+    """Demonstrate surface mesh Lagrangian motion."""
+    print("=" * 60)
+    print("Surface Mesh Lagrangian Motion Example")
+    print("=" * 60)
+
+    # Create initial sphere mesh
+    print("\n1. Creating sphere surface mesh...")
+    mesh = create_sphere_mesh(radius=1.0, n_subdivisions=2)
+    initial_vertices = mesh.get_vertices()
+    initial_triangles = mesh.get_triangles()
+    n_init_v, n_init_t = len(initial_vertices), len(initial_triangles)
+    print(f"   Initial mesh: {n_init_v} vertices, {n_init_t} triangles")
+
+    # Simple demonstration: single expansion
+    print("\n2. Applying radial expansion...")
+    displacement = create_radial_displacement(initial_vertices, scale=0.1)
+
+    result = mesh.remesh_lagrangian(
+        displacement,
+        n_steps=2,
+        hausd=0.02,
+        verbose=False,
+    )
+
+    final_vertices = mesh.get_vertices()
+    final_triangles = mesh.get_triangles()
+    n_final_v, n_final_t = len(final_vertices), len(final_triangles)
+    print(f"   Expanded mesh: {n_final_v} vertices, {n_final_t} triangles")
+    print(f"   Duration: {result['duration']:.3f}s")
+    print(
+        f"   Quality - Before: min={result['before']['quality_min']:.3f}, "
+        f"mean={result['before']['quality_mean']:.3f}",
+    )
+    print(
+        f"   Quality - After:  min={result['after']['quality_min']:.3f}, "
+        f"mean={result['after']['quality_mean']:.3f}",
+    )
+
+    # Visualization
+    print("\n3. Creating visualization...")
+
+    # Create PyVista meshes
+    original_pv = pv.PolyData(
+        initial_vertices,
+        np.hstack([np.full((len(initial_triangles), 1), 3), initial_triangles]).ravel(),
+    )
+    expanded_pv = pyvista_mesh_from_mmgmeshs(mesh)
+
+    # Side-by-side comparison
+    pl = pv.Plotter(shape=(1, 2), window_size=[1200, 600])
+
+    pl.subplot(0, 0)
+    pl.add_mesh(original_pv, show_edges=True, color="lightblue")
+    pl.add_title(f"Original Sphere\n{len(initial_vertices)} vertices")
+    pl.camera_position = "iso"
+
+    pl.subplot(0, 1)
+    pl.add_mesh(expanded_pv, show_edges=True, color="lightgreen")
+    pl.add_title(f"Expanded (10%)\n{len(final_vertices)} vertices")
+    pl.camera_position = "iso"
+
+    pl.link_views()
+
+    # Generate animation
+    print("\n4. Generating animation frames...")
+    output_dir = Path(__file__).parent / "output"
+    mesh_fresh = create_sphere_mesh(radius=1.0, n_subdivisions=2)
+    frame_paths = generate_animation_frames(
+        mesh_fresh,
+        output_dir,
+        n_frames=20,
+        max_scale=0.15,
+    )
+
+    print("\n5. Creating animated GIF...")
+    gif_path = output_dir / "surface_lagrangian_motion.gif"
+    create_gif(frame_paths, gif_path, duration=0.1)
+    print(f"   GIF saved to: {gif_path}")
+
+    # Clean up frame files
+    for p in frame_paths:
+        p.unlink()
+    print("   Frame files cleaned up.")
+
+    print("\n" + "=" * 60)
+    print("Example completed!")
+    print("=" * 60)
+
+    pl.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -2107,3 +2107,74 @@ class MmgMeshS:
             Statistics dictionary with before/after metrics.
 
         """
+
+    def remesh_lagrangian(
+        self,
+        displacement: NDArray[np.float64],
+        *,
+        boundary_mask: NDArray[np.bool_] | None = None,
+        propagate: bool = True,
+        n_steps: int = 1,
+        hmin: float | None = None,
+        hmax: float | None = None,
+        hsiz: float | None = None,
+        hausd: float | None = None,
+        hgrad: float | None = None,
+        verbose: int | bool | None = None,
+        **kwargs: float | bool | None,
+    ) -> dict[str, Any]:
+        """Remesh following Lagrangian motion (Python implementation).
+
+        Since MMGS does not natively support Lagrangian motion, this method
+        provides an equivalent capability using a pure Python implementation
+        with Laplacian smoothing for displacement propagation and standard
+        MMGS remeshing for quality maintenance.
+
+        This method is added for API consistency with MmgMesh3D and MmgMesh2D.
+
+        Parameters
+        ----------
+        displacement : NDArray[np.float64]
+            Displacement vectors, shape (n_vertices, 3).
+        boundary_mask : NDArray[np.bool_] | None
+            Optional boolean array indicating which vertices have prescribed
+            displacement. If None, all vertices are displaced directly.
+        propagate : bool
+            If True and boundary_mask is provided, propagate boundary
+            displacement to interior using Laplacian smoothing.
+        n_steps : int
+            Number of incremental steps to apply displacement.
+            Use more steps for large displacements to avoid mesh inversion.
+        hmin : float | None
+            Minimum edge size.
+        hmax : float | None
+            Maximum edge size.
+        hsiz : float | None
+            Uniform target edge size.
+        hausd : float | None
+            Hausdorff distance for geometry approximation.
+        hgrad : float | None
+            Gradation parameter (controls size transition).
+        verbose : int | bool | None
+            Verbosity level. True/False converted to 1/-1.
+        **kwargs : float | int | bool | None
+            Additional MMG options.
+
+        Returns
+        -------
+        dict[str, Any]
+            Statistics dictionary with keys:
+            - before: dict with mesh statistics before remeshing
+            - after: dict with mesh statistics after remeshing
+            - duration: float, time in seconds
+            - return_code: int, 1 for success
+            - warnings: list[str], any warnings
+
+        Note
+        ----
+        Unlike the native MMG3D/MMG2D Lagrangian implementations which use
+        the ELAS library for displacement propagation, this implementation
+        uses Laplacian smoothing. This provides comparable results for
+        smooth displacement fields but may differ for complex deformations.
+
+        """

--- a/tests/lagrangian_test.py
+++ b/tests/lagrangian_test.py
@@ -4,12 +4,13 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D
+from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 from mmgpy.lagrangian import (
     _build_adjacency_from_elements,
     detect_boundary_vertices,
     move_mesh,
     propagate_displacement,
+    remesh_lagrangian_surface,
 )
 
 
@@ -490,3 +491,286 @@ class TestIntegration:
         # Verify mesh is valid
         assert len(output_vertices) > 0
         assert len(output_elements) > 0
+
+
+def create_surface_mesh() -> tuple[np.ndarray, np.ndarray]:
+    """Create a simple surface mesh (sphere approximation) for testing.
+
+    Returns vertices and triangles for a small icosahedron-based sphere.
+    """
+    # Create a simple octahedron (6 vertices, 8 triangles)
+    # This is a minimal surface mesh that works well for testing
+    vertices = np.array(
+        [
+            [1.0, 0.0, 0.0],  # +X
+            [-1.0, 0.0, 0.0],  # -X
+            [0.0, 1.0, 0.0],  # +Y
+            [0.0, -1.0, 0.0],  # -Y
+            [0.0, 0.0, 1.0],  # +Z
+            [0.0, 0.0, -1.0],  # -Z
+        ],
+        dtype=np.float64,
+    )
+
+    triangles = np.array(
+        [
+            [0, 2, 4],  # +X +Y +Z
+            [0, 4, 3],  # +X -Y +Z
+            [0, 3, 5],  # +X -Y -Z
+            [0, 5, 2],  # +X +Y -Z
+            [1, 4, 2],  # -X +Y +Z
+            [1, 3, 4],  # -X -Y +Z
+            [1, 5, 3],  # -X -Y -Z
+            [1, 2, 5],  # -X +Y -Z
+        ],
+        dtype=np.int32,
+    )
+
+    return vertices, triangles
+
+
+class TestSurfaceMeshLagrangian:
+    """Tests for surface mesh Lagrangian motion."""
+
+    def test_move_mesh_surface(self) -> None:
+        """Test moving a surface mesh with uniform displacement."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        n = len(vertices)
+        # Small uniform displacement
+        displacement = np.full((n, 3), [0.05, 0.0, 0.0], dtype=np.float64)
+
+        move_mesh(mesh, displacement, hausd=0.1, verbose=False)
+
+        output_vertices = mesh.get_vertices()
+        output_triangles = mesh.get_triangles()
+
+        # Mesh should still be valid
+        assert len(output_vertices) > 0
+        assert len(output_triangles) > 0
+
+    def test_remesh_lagrangian_surface_function(self) -> None:
+        """Test remesh_lagrangian_surface function returns proper stats."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        n = len(vertices)
+        displacement = np.full((n, 3), [0.05, 0.0, 0.0], dtype=np.float64)
+
+        result = remesh_lagrangian_surface(mesh, displacement, hausd=0.1, verbose=False)
+
+        # Check result structure
+        assert "before" in result
+        assert "after" in result
+        assert "duration" in result
+        assert "return_code" in result
+        assert "warnings" in result
+
+        # Check stats content
+        assert result["before"]["vertices"] > 0
+        assert result["before"]["triangles"] > 0
+        assert result["after"]["vertices"] > 0
+        assert result["after"]["triangles"] > 0
+        assert result["duration"] >= 0
+        assert result["return_code"] == 1
+
+    def test_mmgmeshs_remesh_lagrangian_method(self) -> None:
+        """Test MmgMeshS.remesh_lagrangian method (monkey-patched)."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        n = len(vertices)
+        displacement = np.full((n, 3), [0.05, 0.0, 0.0], dtype=np.float64)
+
+        # Use the method directly on MmgMeshS (monkey-patched)
+        result = mesh.remesh_lagrangian(displacement, hausd=0.1, verbose=False)
+
+        # Check result structure
+        assert "before" in result
+        assert "after" in result
+        assert "duration" in result
+        assert result["return_code"] == 1
+
+    def test_radial_expansion_surface(self) -> None:
+        """Test radial expansion displacement on surface mesh."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        # Create radial expansion: move vertices outward from center
+        center = np.array([0.0, 0.0, 0.0])
+        n = len(vertices)
+        displacement = np.zeros((n, 3), dtype=np.float64)
+
+        for i in range(n):
+            r = np.linalg.norm(vertices[i] - center)
+            if r > 0.01:
+                direction = (vertices[i] - center) / r
+                displacement[i] = direction * 0.1  # 10% expansion
+
+        result = mesh.remesh_lagrangian(displacement, hausd=0.1, verbose=False)
+
+        output_vertices = mesh.get_vertices()
+
+        # After expansion, mesh should still be valid
+        assert len(output_vertices) > 0
+        assert result["after"]["triangles"] > 0
+
+    def test_surface_mesh_with_n_steps(self) -> None:
+        """Test surface mesh Lagrangian with multiple steps."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        n = len(vertices)
+        # Larger displacement that benefits from multiple steps
+        displacement = np.full((n, 3), [0.2, 0.0, 0.0], dtype=np.float64)
+
+        result = mesh.remesh_lagrangian(
+            displacement,
+            n_steps=3,
+            hausd=0.1,
+            verbose=False,
+        )
+
+        output_vertices = mesh.get_vertices()
+        output_triangles = mesh.get_triangles()
+
+        assert len(output_vertices) > 0
+        assert len(output_triangles) > 0
+        assert result["return_code"] == 1
+
+    def test_surface_with_remesh_options(self) -> None:
+        """Test surface mesh Lagrangian with various remesh options."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        n = len(vertices)
+        displacement = np.full((n, 3), [0.05, 0.0, 0.0], dtype=np.float64)
+
+        result = mesh.remesh_lagrangian(
+            displacement,
+            hausd=0.05,
+            hmax=0.5,
+            verbose=False,
+        )
+
+        assert result["return_code"] == 1
+        assert result["after"]["vertices"] > 0
+
+    def test_displacement_validation_surface(self) -> None:
+        """Test that displacement validation works for surface meshes."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        n = len(vertices)
+
+        # Wrong displacement rows
+        with pytest.raises(ValueError, match="Displacement rows"):
+            mesh.remesh_lagrangian(np.zeros((n + 1, 3)))
+
+        # Wrong displacement columns
+        with pytest.raises(ValueError, match="Displacement columns"):
+            mesh.remesh_lagrangian(np.zeros((n, 2)))
+
+    def test_quality_stats_surface(self) -> None:
+        """Test that quality statistics are collected for surface mesh."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        n = len(vertices)
+        displacement = np.full((n, 3), [0.03, 0.0, 0.0], dtype=np.float64)
+
+        result = mesh.remesh_lagrangian(displacement, hausd=0.1, verbose=False)
+
+        # Check quality stats
+        assert "quality_min" in result["before"]
+        assert "quality_mean" in result["before"]
+        assert "quality_min" in result["after"]
+        assert "quality_mean" in result["after"]
+
+        # Quality should be in valid range [0, 1]
+        assert 0 <= result["before"]["quality_min"] <= 1
+        assert 0 <= result["before"]["quality_mean"] <= 1
+        assert 0 <= result["after"]["quality_min"] <= 1
+        assert 0 <= result["after"]["quality_mean"] <= 1
+
+
+class TestSurfaceMeshIntegration:
+    """Integration tests for surface mesh Lagrangian motion."""
+
+    def test_complete_workflow(self) -> None:
+        """Test complete surface mesh Lagrangian motion workflow."""
+        # Create a slightly more complex surface mesh (subdivided octahedron)
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        original_vertices = mesh.get_vertices().copy()
+
+        # Apply displacement
+        n = len(original_vertices)
+        center = np.array([0.0, 0.0, 0.0])
+        displacement = np.zeros((n, 3), dtype=np.float64)
+
+        for i in range(n):
+            r = np.linalg.norm(original_vertices[i] - center)
+            if r > 0.01:
+                direction = (original_vertices[i] - center) / r
+                displacement[i] = direction * 0.15  # 15% expansion
+
+        # Perform Lagrangian motion
+        result = mesh.remesh_lagrangian(
+            displacement,
+            n_steps=2,
+            hausd=0.1,
+            verbose=False,
+        )
+
+        final_vertices = mesh.get_vertices()
+        final_triangles = mesh.get_triangles()
+
+        # Verify mesh is valid
+        assert len(final_vertices) > 0
+        assert len(final_triangles) > 0
+        assert result["return_code"] == 1
+        assert result["duration"] > 0
+
+    def test_api_consistency_with_3d(self) -> None:
+        """Test that surface mesh API is consistent with 3D mesh API."""
+        # Create both surface and 3D meshes
+        surface_vertices, surface_triangles = create_surface_mesh()
+        surface_mesh = MmgMeshS(surface_vertices, surface_triangles)
+
+        volume_vertices, volume_elements = create_3d_test_mesh()
+        volume_mesh = MmgMesh3D(volume_vertices, volume_elements)
+
+        # Both should have remesh_lagrangian method
+        assert hasattr(surface_mesh, "remesh_lagrangian")
+        assert hasattr(volume_mesh, "remesh_lagrangian")
+
+        # Surface mesh method signature should work similarly
+        n_surface = len(surface_vertices)
+        disp_value = [0.05, 0.0, 0.0]
+        surface_displacement = np.full((n_surface, 3), disp_value, dtype=np.float64)
+
+        surface_result = surface_mesh.remesh_lagrangian(
+            surface_displacement,
+            hausd=0.1,
+            verbose=False,
+        )
+
+        # Check that result has similar structure
+        assert "before" in surface_result
+        assert "after" in surface_result
+        assert "duration" in surface_result
+
+    def test_detect_boundary_surface(self) -> None:
+        """Test boundary detection for surface mesh."""
+        vertices, triangles = create_surface_mesh()
+        mesh = MmgMeshS(vertices, triangles)
+
+        # For surface meshes, detect_boundary should work via triangles fallback
+        boundary_mask = detect_boundary_vertices(mesh)
+
+        # Should return a boolean array
+        assert boundary_mask.dtype == bool
+        assert len(boundary_mask) == len(vertices)


### PR DESCRIPTION
## Summary

- Adds `remesh_lagrangian` method to `MmgMeshS` for API consistency with `MmgMesh3D` and `MmgMesh2D`
- Since MMGS does not natively support Lagrangian motion, this implements it using a pure Python approach with Laplacian smoothing for displacement propagation
- Includes comprehensive tests, documentation updates, and an example with animated GIF generation

## Changes

- Add `remesh_lagrangian_surface()` function in `lagrangian.py` that provides surface mesh Lagrangian motion with quality statistics
- Add `MmgMeshS.remesh_lagrangian()` method via monkey-patching for consistent API across all mesh types
- Add 11 new tests covering surface mesh Lagrangian motion functionality
- Add example `examples/mmgs/lagrangian_motion.py` demonstrating surface mesh deformation with GIF animation
- Update documentation in `docs/api/lagrangian.md` with surface mesh section and usage examples
- Update type stubs in `_mmgpy.pyi` with new method signature

## Test plan

- [x] Add comprehensive tests for `remesh_lagrangian_surface()` function
- [x] Add tests for `MmgMeshS.remesh_lagrangian()` method
- [x] Test radial expansion, multi-step deformation, and quality statistics
- [x] Verify API consistency with 3D mesh implementation
- [x] All pre-commit hooks passing

## Use cases

Surface mesh Lagrangian motion is useful for:
- Morphing between surface shapes
- Fluid-structure interaction simulations on surfaces  
- Shape optimization with surface constraints
- Medical image registration with anatomical surfaces

Closes #117