### PR TITLE
chore: bump version to 0.6.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.5.0.dev8"
+version = "0.6.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.5.0.dev8"
+    assert mmgpy.__version__ == "0.6.0.dev0"
 
 
 def test_mmg_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1371,7 +1371,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.5.0.dev8"
+version = "0.6.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "meshio" },


### PR DESCRIPTION
## Summary
- Bump version to 0.6.0.dev0 for development after v0.5.0 release