### PR TITLE
feat(build): enable editable install with automatic C++ rebuild

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -213,6 +213,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
 
+      - name: Install build dependencies
+        run: |
+          uv venv -p 3.13
+          uv pip install scikit-build-core pybind11 numpy
+
       - name: Build source distribution
         run: uv build --sdist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ cd mmgpy
 uv sync
 
 # Build C++ extension (editable install)
-uv pip install -e . --no-build-isolation
+uv pip install -e .
 
 # Verify installation
 uv run pytest tests/ -v
@@ -238,16 +238,16 @@ class TestNewFeature:
        def new_method(self, param: float) -> None: ...
    ```
 
-4. **Rebuild**:
+4. **Rebuild**: C++ changes are automatically rebuilt on import. For faster incremental builds:
    ```bash
-   uv pip install -e . --no-build-isolation
+   cmake --build build  # Fast incremental rebuild
    ```
 
 ### Debugging C++ Code
 
 ```bash
 # Build with debug symbols
-CMAKE_BUILD_TYPE=Debug uv pip install -e . --no-build-isolation
+CMAKE_BUILD_TYPE=Debug uv pip install -e .
 
 # Run with gdb
 gdb --args python -c "import mmgpy; ..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ ui = [
 mmg_version = "5.8.0"
 vtk_version = "9.5.2"
 
+[tool.uv]
+# Allow editable installs without --no-build-isolation flag
+no-build-isolation-package = ["mmgpy"]
+
 [tool.scikit-build]
 # Build configuration
 build.verbose = true
@@ -60,6 +64,10 @@ cmake.args = ["-DCMAKE_BUILD_TYPE=Release"]
 cmake.define = { BUILD_TESTING = "OFF", BUILD_SHARED_LIBS = "ON", MMGPY_SKIP_EXECUTABLES = "OFF" }
 
 build-dir = "build"
+
+# Editable install configuration (auto-rebuild when C++ files change)
+editable.rebuild = true
+editable.verbose = false
 
 # Wheel configuration
 wheel.packages = ["src/mmgpy"]
@@ -87,6 +95,11 @@ mmgpy-ui = "mmgpy.ui.__main__:main"
 
 [dependency-groups]
 dev = [
+    # Build dependencies (needed for editable installs without build isolation)
+    "scikit-build-core>=0.11.5",
+    "pybind11>=3.0.0",
+    "numpy>=2.0.2",
+    # Dev tools
     "build>=1.4.0",
     "imageio>=2.37.2",
     "mypy>=1.19.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1491,11 +1491,15 @@ dev = [
     { name = "build" },
     { name = "imageio" },
     { name = "mypy" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pre-commit" },
+    { name = "pybind11" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scikit-build-core" },
 ]
 docs = [
     { name = "mkdocs-material" },
@@ -1531,11 +1535,14 @@ dev = [
     { name = "build", specifier = ">=1.4.0" },
     { name = "imageio", specifier = ">=2.37.2" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "numpy", specifier = ">=2.0.2" },
     { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "pybind11", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.14.10" },
+    { name = "scikit-build-core", specifier = ">=0.11.5" },
 ]
 docs = [
     { name = "mkdocs-material", specifier = ">=9.5.0" },
@@ -2286,6 +2293,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pybind11"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/7b/a6d8dcb83c457e24a9df1e4d8fd5fb8034d4bbc62f3c324681e8a9ba57c2/pybind11-3.0.1.tar.gz", hash = "sha256:9c0f40056a016da59bab516efb523089139fcc6f2ba7e4930854c61efb932051", size = 546914, upload-time = "2025-08-22T20:09:27.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/8a/37362fc2b949d5f733a8b0f2ff51ba423914cabefe69f1d1b6aab710f5fe/pybind11-3.0.1-py3-none-any.whl", hash = "sha256:aa8f0aa6e0a94d3b64adfc38f560f33f15e589be2175e103c0a33c6bce55ee89", size = 293611, upload-time = "2025-08-22T20:09:25.235Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -2687,6 +2703,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c5/abd840d4132fd51a12f594934af5eba1d5d27298a6f5b5d6c3be45301caf/ruff-0.14.13-py3-none-win32.whl", hash = "sha256:ef720f529aec113968b45dfdb838ac8934e519711da53a0456038a0efecbd680", size = 12919024, upload-time = "2026-01-15T20:14:43.647Z" },
     { url = "https://files.pythonhosted.org/packages/c2/55/6384b0b8ce731b6e2ade2b5449bf07c0e4c31e8a2e68ea65b3bafadcecc5/ruff-0.14.13-py3-none-win_amd64.whl", hash = "sha256:6070bd026e409734b9257e03e3ef18c6e1a216f0435c6751d7a8ec69cb59abef", size = 14097887, upload-time = "2026-01-15T20:15:01.48Z" },
     { url = "https://files.pythonhosted.org/packages/4d/e1/7348090988095e4e39560cfc2f7555b1b2a7357deba19167b600fdf5215d/ruff-0.14.13-py3-none-win_arm64.whl", hash = "sha256:7ab819e14f1ad9fe39f246cfcc435880ef7a9390d81a2b6ac7e01039083dd247", size = 13080224, upload-time = "2026-01-15T20:14:45.853Z" },
+]
+
+[[package]]
+name = "scikit-build-core"
+version = "0.11.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/b2/c11aaa746f3dfcdb46499affbc5f9784c991d354a80ca92f96a0f0f5aadf/scikit_build_core-0.11.6.tar.gz", hash = "sha256:5982ccd839735be99cfd3b92a8847c6c196692f476c215da84b79d2ad12f9f1b", size = 286006, upload-time = "2025-08-22T22:11:56.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/49/ec16b3db6893db788ae35f98506ff5a9c25dca7eb18cc38ada8a4c1dc944/scikit_build_core-0.11.6-py3-none-any.whl", hash = "sha256:ce6d8fe64e6b4c759ea0fb95d2f8a68f60d2df31c2989838633b8ec930736360", size = 185764, upload-time = "2025-08-22T22:11:52.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `editable.rebuild = true` and `editable.verbose = true` to scikit-build-core config for automatic C++ rebuilds on import
- Add `no-build-isolation-package = ["mmgpy"]` to `[tool.uv]` so `uv pip install -e .` works without `--no-build-isolation` flag
- Add build dependencies (scikit-build-core, pybind11, numpy) to dev group (required for no-build-isolation)
- Update CONTRIBUTING.md to reflect simplified development workflow

## Test plan

- [x] Verified `uv sync` works and builds without explicit `--no-build-isolation`
- [x] Verified `uv pip install -e .` works without `--no-build-isolation`
- [x] Verified auto-rebuild on import by modifying C++ file and importing mmgpy
- [x] Verified `cmake --build build` works for fast incremental rebuilds
- [x] All 768 tests pass

Closes #169