### PR TITLE
chore: release v0.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ What actually happened.
 
 - OS: [e.g., Ubuntu 22.04, macOS 14, Windows 11]
 - Python version: [e.g., 3.11]
-- mmgpy version: [e.g., 0.5.0]
+- mmgpy version: [e.g., 0.6.0]
 
 ## Additional Context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-08
+
+### Added
+
+- Conda-forge package support with `rattler-build` recipe ([#179](https://github.com/kmarchais/mmgpy/pull/179))
+- Lightweight CLI module for faster entry point startup ([#179](https://github.com/kmarchais/mmgpy/pull/179))
+
+### Fixed
+
+- Release GIL during remeshing, detect mesh corruption, fix stderr capture ([#177](https://github.com/kmarchais/mmgpy/pull/177))
+
+## [0.5.2] - 2026-01-21
+
+### Fixed
+
+- Set execute permissions on bundled executables for `uvx` installs ([#174](https://github.com/kmarchais/mmgpy/pull/174))
+
 ## [0.5.1] - 2026-01-20
 
 ### Added
@@ -142,7 +159,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimized wheel sizes (under 100MB) for PyPI upload
 - Linux manylinux wheels with proper platform tags
 
-[Unreleased]: https://github.com/kmarchais/mmgpy/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/kmarchais/mmgpy/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/kmarchais/mmgpy/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/kmarchais/mmgpy/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/kmarchais/mmgpy/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/kmarchais/mmgpy/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/kmarchais/mmgpy/compare/v0.3.0...v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.6.0.dev0"
+version = "0.6.0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.6.0.dev0"
+    assert mmgpy.__version__ == "0.6.0"
 
 
 def test_mmg_version() -> None:


### PR DESCRIPTION
## Summary

- Bump version from `0.6.0.dev0` to `0.6.0`
- Add v0.6.0 and v0.5.2 changelog entries
- Update bug report template version example

## Changelog

### Added
- Conda-forge package support with `rattler-build` recipe (#179)
- Lightweight CLI module for faster entry point startup (#179)

### Fixed
- Release GIL during remeshing, detect mesh corruption, fix stderr capture (#177)

## Test plan
- [ ] CI passes (version test updated to `0.6.0`)
- [ ] Tag `v0.6.0` after merge to trigger release workflow