### PR TITLE
chore: bump version to 0.7.0.dev0

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.6.0.dev0"
+  version: "0.7.0.dev0"
 
 package:
   name: mmgpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.6.0"
+version = "0.7.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.6.0"
+    assert mmgpy.__version__ == "0.7.0.dev0"
 
 
 def test_mmg_version() -> None:


### PR DESCRIPTION
## Summary

- Bump dev version to `0.7.0.dev0` after v0.6.0 release

## Files changed
- `pyproject.toml`
- `tests/mmgpy_test.py`
- `conda/recipe.yaml`