### PR TITLE
chore: release v0.7.0

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.7.0"
+  version: "0.8.0.dev0"
 
 package:
   name: mmgpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.7.0"
+version = "0.8.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.7.0"
+    assert mmgpy.__version__ == "0.8.0.dev0"
 
 
 def test_mmg_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.7.0"
+version = "0.8.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "meshio" },


### PR DESCRIPTION
## Summary

- Bump version from 0.7.0.dev0 to 0.7.0 in pyproject.toml, conda recipe, uv.lock, and version test