### PR TITLE
test: add pytest-codeblocks testing for documentation code snippets

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,6 +97,13 @@ jobs:
       - name: Run tests with coverage
         run: uv run pytest --cov=src/mmgpy --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
+      - name: Test documentation code blocks
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        env:
+          PYVISTA_OFF_SCREEN: "true"
+          MPLBACKEND: Agg
+        run: uv run pytest --codeblocks docs/ -v
+
       - name: Run examples
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         env:

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -94,12 +94,16 @@ pv_mesh.plot(show_edges=True)
 
 Meshes are saved using the `save()` method:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
+# Volume meshes: .mesh, .vtk, .vtu
 mesh.save("output.mesh")  # MMG native
 mesh.save("output.vtk")   # VTK format
-mesh.save("output.stl")   # STL (surface only)
+
+# Surface meshes: also support .stl
+surface = mmgpy.read("model.stl")
+surface.save("output.stl")
 ```
 
 Format is inferred from the file extension.

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -54,6 +54,8 @@ show_root_heading: true
 
 ### From PyVista
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import pyvista as pv
@@ -75,6 +77,8 @@ mesh_2d = mmgpy.from_pyvista(plane, mesh_type="2d")
 
 ### To PyVista
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 
@@ -93,6 +97,8 @@ pv_mesh.plot(show_edges=True)
 ## Saving Meshes
 
 Meshes are saved using the `save()` method:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 mesh.save("output.mesh")  # MMG native
@@ -120,6 +126,8 @@ mesh_s = mmgpy.Mesh("surface.stl")
 ```
 
 ## Complete Example
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -54,8 +54,6 @@ show_root_heading: true
 
 ### From PyVista
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import pyvista as pv
@@ -64,20 +62,18 @@ import pyvista as pv
 sphere = pv.Sphere(radius=1.0)
 
 # Convert to surface mesh
-mesh = mmgpy.from_pyvista(sphere, mesh_type="surface")
+mesh = mmgpy.Mesh(sphere)
 
 # For volumetric meshes (needs tetrahedral cells)
 volume = pv.Box().triangulate().delaunay_3d()
-mesh_3d = mmgpy.from_pyvista(volume, mesh_type="3d")
+mesh_3d = mmgpy.Mesh(volume)
 
 # For 2D meshes
 plane = pv.Plane()
-mesh_2d = mmgpy.from_pyvista(plane, mesh_type="2d")
+mesh_2d = mmgpy.Mesh(plane)
 ```
 
 ### To PyVista
-
-<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy
@@ -87,8 +83,8 @@ mesh = mmgpy.read("input.mesh")
 # Convert to PyVista
 pv_mesh = mesh.to_pyvista()
 
-# Or using function
-pv_mesh = mmgpy.to_pyvista(mesh)
+# Or using method
+pv_mesh = mesh.to_pyvista()
 
 # Visualize
 pv_mesh.plot(show_edges=True)
@@ -127,8 +123,6 @@ mesh_s = mmgpy.Mesh("surface.stl")
 
 ## Complete Example
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import pyvista as pv
@@ -151,7 +145,7 @@ pv_mesh.save("output_pv.vtk")
 
 # Or create from PyVista
 torus = pv.ParametricTorus()
-torus_mesh = mmgpy.from_pyvista(torus, mesh_type="surface")
+torus_mesh = mmgpy.Mesh(torus)
 torus_mesh.remesh(hmax=0.1)
 torus_mesh.save("torus.mesh")
 ```

--- a/docs/api/lagrangian.md
+++ b/docs/api/lagrangian.md
@@ -35,6 +35,8 @@ elasticity, not shell/membrane elasticity needed for surfaces.
 For surface meshes, use `mmgpy.move_mesh()` instead, which directly moves vertices and
 remeshes to maintain quality:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import numpy as np
@@ -70,6 +72,8 @@ without ELAS, calls to `remesh_lagrangian()` will fail.
 
 Meshes have a `remesh_lagrangian()` method for direct use:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import numpy as np
@@ -88,6 +92,8 @@ result = mesh.remesh_lagrangian(displacement)
 ## Usage Examples
 
 ### Basic Lagrangian Remeshing
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy
@@ -116,6 +122,8 @@ print(f"Quality: {result.quality_mean_after:.3f}")
 
 Move only boundary vertices:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 from mmgpy import detect_boundary_vertices
 
@@ -136,6 +144,8 @@ result = mesh.remesh_lagrangian(displacement)
 ### Propagate Displacement to Interior
 
 Start with boundary displacement and propagate to interior:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import detect_boundary_vertices, propagate_displacement
@@ -159,6 +169,8 @@ result = mesh.remesh_lagrangian(full_disp)
 
 Apply displacement without topology changes:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 from mmgpy import move_mesh
 
@@ -179,6 +191,8 @@ new_vertices = mesh.get_vertices()
 ### Iterative Motion
 
 For large deformations, use multiple small steps:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy
@@ -203,6 +217,8 @@ mesh.save("final.mesh")
 
 Combine with remeshing parameters:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh_lagrangian(
     displacement,
@@ -216,6 +232,8 @@ result = mesh.remesh_lagrangian(
 ## Complete Example
 
 Deform a sphere into an ellipsoid:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/api/lagrangian.md
+++ b/docs/api/lagrangian.md
@@ -35,13 +35,14 @@ elasticity, not shell/membrane elasticity needed for surfaces.
 For surface meshes, use `mmgpy.move_mesh()` instead, which directly moves vertices and
 remeshes to maintain quality:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
+import pyvista as pv
 import numpy as np
 
-mesh = mmgpy.Mesh(vertices, triangles)  # Auto-detects surface mesh
+sphere = pv.Sphere(theta_resolution=10, phi_resolution=10)
+mesh = mmgpy.Mesh(sphere)  # Auto-detects surface mesh
+vertices = mesh.get_vertices()
 displacement = np.zeros((len(vertices), 3))
 displacement[:, 0] = 0.1  # Move in x direction
 
@@ -169,9 +170,9 @@ result = mesh.remesh_lagrangian(full_disp)
 
 Apply displacement without topology changes:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
+import numpy as np
 from mmgpy import move_mesh
 
 mesh = mmgpy.read("input.mesh")

--- a/docs/api/mesh-classes.md
+++ b/docs/api/mesh-classes.md
@@ -127,7 +127,7 @@ print(f"Quality: {result.quality_mean_before:.3f} -> {result.quality_mean_after:
 
 ### Local Sizing
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Set local refinement regions
@@ -161,7 +161,7 @@ mesh.validate(strict=True)
 
 ### PyVista Integration
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 import pyvista as pv

--- a/docs/api/mesh-classes.md
+++ b/docs/api/mesh-classes.md
@@ -58,12 +58,12 @@ mesh = mmgpy.Mesh(grid)
 
 ### Checking Mesh Type
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import MeshKind
 
-mesh = mmgpy.Mesh(vertices, elements)
+mesh = mmgpy.Mesh(vertices, tetrahedra)
 
 if mesh.kind == MeshKind.TETRAHEDRAL:
     print("3D volume mesh")
@@ -95,7 +95,8 @@ print(f"Vertices: {len(vertices)}")
 import numpy as np
 
 # Set a scalar field (metric for sizing)
-metric = np.ones(len(mesh.get_vertices()), dtype=np.float64) * 0.1
+n = len(mesh.get_vertices())
+metric = np.ones((n, 1), dtype=np.float64) * 0.1
 mesh["metric"] = metric
 
 # Get a field

--- a/docs/api/mesh-classes.md
+++ b/docs/api/mesh-classes.md
@@ -20,6 +20,8 @@ show_root_heading: true
 
 ### Creating Meshes
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import numpy as np
@@ -58,6 +60,8 @@ mesh = mmgpy.Mesh(grid)
 
 ### Checking Mesh Type
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 from mmgpy import MeshKind
 
@@ -73,6 +77,8 @@ elif mesh.kind == MeshKind.TRIANGULAR_SURFACE:
 
 ### Accessing Mesh Data
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 # Get vertices and elements
 vertices = mesh.get_vertices()      # Shape: (n_vertices, 2 or 3)
@@ -84,6 +90,8 @@ print(f"Vertices: {len(vertices)}")
 ```
 
 ### Working with Fields
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import numpy as np
@@ -97,6 +105,8 @@ m = mesh["metric"]
 ```
 
 ### Remeshing
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import Mmg3DOptions
@@ -119,6 +129,8 @@ print(f"Quality: {result.quality_mean_before:.3f} -> {result.quality_mean_after:
 
 ### Local Sizing
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 # Set local refinement regions
 mesh.set_size_sphere(center=[0.5, 0.5, 0.5], radius=0.2, size=0.01)
@@ -132,6 +144,8 @@ mesh.clear_local_sizing()
 ```
 
 ### Validation
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Simple validation
@@ -148,6 +162,8 @@ mesh.validate(strict=True)
 ```
 
 ### PyVista Integration
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import pyvista as pv

--- a/docs/api/mesh-classes.md
+++ b/docs/api/mesh-classes.md
@@ -20,8 +20,6 @@ show_root_heading: true
 
 ### Creating Meshes
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import numpy as np
@@ -77,7 +75,7 @@ elif mesh.kind == MeshKind.TRIANGULAR_SURFACE:
 
 ### Accessing Mesh Data
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Get vertices and elements
@@ -91,7 +89,7 @@ print(f"Vertices: {len(vertices)}")
 
 ### Working with Fields
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 import numpy as np
@@ -145,7 +143,7 @@ mesh.clear_local_sizing()
 
 ### Validation
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Simple validation

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -76,6 +76,8 @@ result = mesh.remesh()
 
 Size varying with position:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 import numpy as np
 
@@ -92,6 +94,8 @@ mesh.set_field("tensor", metric)
 ### Anisotropic Metric
 
 Different sizes in different directions:
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 import numpy as np
@@ -111,6 +115,8 @@ mesh.set_field("tensor", metric)
 ### Metric from Hessian
 
 Adapt mesh to solution curvature:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Solution field (e.g., temperature)
@@ -133,6 +139,8 @@ mesh.set_field("tensor", metric)
 
 Combine multiple metrics (minimum size wins):
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 # Two different metrics
 metric1 = metrics.create_isotropic_metric(sizes1)
@@ -144,6 +152,8 @@ mesh.set_field("tensor", combined)
 ```
 
 ### Extracting Metric Information
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Get current metric
@@ -161,6 +171,8 @@ print(f"Size range: {sizes.min():.4f} to {sizes.max():.4f}")
 ### Tensor Format Conversion
 
 MMG uses symmetric tensors in Voigt notation:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # 3D: 6 components per vertex
@@ -181,6 +193,8 @@ tensor_back = metrics.matrix_to_tensor(matrix)
 ### Validation
 
 Check metric tensor validity:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 metric = mesh["metric"]

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -139,10 +139,13 @@ mesh.set_field("tensor", metric)
 
 Combine multiple metrics (minimum size wins):
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
-# Two different metrics
+# Two different metrics with different sizes
+n_vertices = len(mesh.get_vertices())
+sizes1 = np.ones(n_vertices) * 0.05
+sizes2 = np.ones(n_vertices) * 0.08
 metric1 = metrics.create_isotropic_metric(sizes1)
 metric2 = metrics.create_isotropic_metric(sizes2)
 
@@ -153,7 +156,7 @@ mesh.set_field("tensor", combined)
 
 ### Extracting Metric Information
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Get current metric
@@ -172,7 +175,7 @@ print(f"Size range: {sizes.min():.4f} to {sizes.max():.4f}")
 
 MMG uses symmetric tensors in Voigt notation:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # 3D: 6 components per vertex
@@ -194,7 +197,7 @@ tensor_back = metrics.matrix_to_tensor(matrix)
 
 Check metric tensor validity:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 metric = mesh["metric"]

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -112,6 +112,8 @@ opt_opts = Mmg3DOptions.optimize_only()
 
 ### Converting to Dictionary
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 opts = Mmg3DOptions(hmax=0.1, hausd=0.001)
 
@@ -125,6 +127,8 @@ result = mesh.remesh(**opts.to_dict())
 
 ### Customizing Presets
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 # Start with fine preset values, then customize
 custom = Mmg3DOptions(hmax=0.05, hausd=0.01, hgrad=1.2, verbose=1)
@@ -133,6 +137,8 @@ custom = Mmg3DOptions(hmax=0.05, hausd=0.01, hgrad=1.2, verbose=1)
 ### Combining with Keyword Arguments
 
 Options objects and keyword arguments cannot be mixed:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Correct: use options object
@@ -149,6 +155,8 @@ result = mesh.remesh(opts, verbose=1)  # TypeError!
 
 ### For Quality Optimization
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 opts = Mmg3DOptions(
     optim=1,       # Enable optimization mode
@@ -159,6 +167,8 @@ opts = Mmg3DOptions(
 
 ### For Surface Preservation
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 opts = Mmg3DOptions(
     hmax=0.1,
@@ -168,6 +178,8 @@ opts = Mmg3DOptions(
 ```
 
 ### For CFD Meshes
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 opts = Mmg3DOptions(
@@ -180,6 +192,8 @@ opts = Mmg3DOptions(
 ```
 
 ### For FEM Meshes
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 opts = Mmg3DOptions(

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -187,7 +187,7 @@ opts = Mmg3DOptions(
     hmax=0.1,
     hgrad=1.2,     # Smooth size transition
     hausd=0.001,
-    angle=20.0,    # Detect more ridges
+    ar=20,       # Detect more ridges
 )
 ```
 

--- a/docs/api/results-validation.md
+++ b/docs/api/results-validation.md
@@ -75,6 +75,8 @@ show_root_heading: true
 
 ### Quick Validation
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 
@@ -88,6 +90,8 @@ else:
 ```
 
 ### Detailed Validation
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 report = mesh.validate(detailed=True)
@@ -110,6 +114,8 @@ for issue in report.issues:
 
 ### Strict Validation
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 from mmgpy import ValidationError
 
@@ -123,6 +129,8 @@ except ValidationError as e:
 ```
 
 ### Selective Validation
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Only check geometry
@@ -144,6 +152,8 @@ report = mesh.validate(
 ```
 
 ## Complete Example
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/api/results-validation.md
+++ b/docs/api/results-validation.md
@@ -75,8 +75,6 @@ show_root_heading: true
 
 ### Quick Validation
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 
@@ -97,10 +95,6 @@ else:
 report = mesh.validate(detailed=True)
 
 print(f"Valid: {report.is_valid}")
-print(f"Vertices: {report.n_vertices}")
-print(f"Elements: {report.n_elements}")
-print(f"Triangles: {report.n_triangles}")
-
 # Quality statistics
 print(f"Quality min: {report.quality.min:.3f}")
 print(f"Quality max: {report.quality.max:.3f}")
@@ -153,8 +147,6 @@ report = mesh.validate(
 
 ## Complete Example
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 from mmgpy import ValidationError
@@ -184,5 +176,4 @@ except ValidationError as e:
 # Final report
 final = mesh.validate(detailed=True)
 print(f"\nQuality improved: {initial.quality.mean:.3f} -> {final.quality.mean:.3f}")
-print(f"Elements: {initial.n_elements} -> {final.n_elements}")
 ```

--- a/docs/api/sizing.md
+++ b/docs/api/sizing.md
@@ -44,6 +44,8 @@ All mesh classes have convenience methods for adding sizing constraints:
 
 ### set_size_sphere
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 mesh.set_size_sphere(
     center=[0.5, 0.5, 0.5],  # Center of sphere
@@ -54,6 +56,8 @@ mesh.set_size_sphere(
 
 ### set_size_box
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 mesh.set_size_box(
     bounds=[[0, 0, 0], [0.3, 0.3, 0.3]],  # [[min], [max]]
@@ -62,6 +66,8 @@ mesh.set_size_box(
 ```
 
 ### set_size_cylinder
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # 3D meshes only
@@ -75,6 +81,8 @@ mesh.set_size_cylinder(
 
 ### set_size_from_point
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 mesh.set_size_from_point(
     point=[0.5, 0.5, 0.5],
@@ -86,6 +94,8 @@ mesh.set_size_from_point(
 
 ### clear_local_sizing
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 # Remove all sizing constraints
 mesh.clear_local_sizing()
@@ -93,12 +103,16 @@ mesh.clear_local_sizing()
 
 ### get_local_sizing_count
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 # Check number of active constraints
 n = mesh.get_local_sizing_count()
 ```
 
 ### apply_local_sizing
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Manually apply constraints to metric field
@@ -137,6 +151,8 @@ result = mesh.remesh(hmax=0.1)
 
 ### Multiple Regions
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 # Fine region
 mesh.set_size_sphere(center=[0.3, 0.5, 0.5], radius=0.1, size=0.005)
@@ -156,6 +172,8 @@ result = mesh.remesh(hmax=0.1)
 ```
 
 ### Direct Class Usage
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import SphereSize, BoxSize
@@ -212,6 +230,8 @@ mesh.clear_local_sizing()
 3. **Minimum Selection**: Where constraints overlap, minimum size wins
 4. **Metric Conversion**: Sizes are converted to isotropic metric tensors
 5. **Remeshing**: MMG uses the metric field to guide remeshing
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy.sizing import compute_sizes_from_constraints, sizes_to_metric

--- a/docs/api/sizing.md
+++ b/docs/api/sizing.md
@@ -42,9 +42,15 @@ show_root_heading: true
 
 All mesh classes have convenience methods for adding sizing constraints:
 
+```python
+import mmgpy
+
+mesh = mmgpy.read("input.mesh")
+```
+
 ### set_size_sphere
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh.set_size_sphere(
@@ -56,7 +62,7 @@ mesh.set_size_sphere(
 
 ### set_size_box
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh.set_size_box(
@@ -67,7 +73,7 @@ mesh.set_size_box(
 
 ### set_size_cylinder
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # 3D meshes only
@@ -81,7 +87,7 @@ mesh.set_size_cylinder(
 
 ### set_size_from_point
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh.set_size_from_point(
@@ -94,7 +100,7 @@ mesh.set_size_from_point(
 
 ### clear_local_sizing
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Remove all sizing constraints
@@ -103,7 +109,7 @@ mesh.clear_local_sizing()
 
 ### get_local_sizing_count
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Check number of active constraints
@@ -112,7 +118,7 @@ n = mesh.get_local_sizing_count()
 
 ### apply_local_sizing
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Manually apply constraints to metric field
@@ -173,9 +179,8 @@ result = mesh.remesh(hmax=0.1)
 
 ### Direct Class Usage
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
 from mmgpy import SphereSize, BoxSize
 from mmgpy.sizing import apply_sizing_constraints
 import numpy as np
@@ -231,21 +236,27 @@ mesh.clear_local_sizing()
 4. **Metric Conversion**: Sizes are converted to isotropic metric tensors
 5. **Remeshing**: MMG uses the metric field to guide remeshing
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
-from mmgpy.sizing import compute_sizes_from_constraints, sizes_to_metric
+import mmgpy
+from mmgpy import SphereSize, BoxSize
+from mmgpy.sizing import compute_sizes_from_constraints
+import mmgpy.metrics as metrics
 import numpy as np
+
+mesh = mmgpy.read("input.mesh")
 
 # Get vertex coordinates
 vertices = mesh.get_vertices()
 
 # Compute sizes from constraints
-constraints = [SphereSize(...), BoxSize(...)]
+constraints = [
+    SphereSize(center=np.array([0.5, 0.5, 0.5]), radius=0.2, size=0.01),
+    BoxSize(bounds=np.array([[0, 0, 0], [0.3, 0.3, 0.3]]), size=0.02),
+]
 sizes = compute_sizes_from_constraints(vertices, constraints)
 
-# Convert to metric field
-metric = sizes_to_metric(sizes)
+# Convert to metric tensor field
+metric = metrics.create_isotropic_metric(sizes)
 
 # Apply to mesh
 mesh.set_field("tensor", metric)

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -76,7 +76,7 @@ _VERTS_SURF, _CELLS_SURF = _make_surface_mesh()
 
 _SURFACE_EXTENSIONS = {".stl", ".obj", ".ply", ".off", ".vtp"}
 _SURFACE_KEYWORDS = {"surface", "mechanical", "part", "torus", "sphere", "bunny"}
-_2D_KEYWORDS = {"2d", "planar", "domain"}
+_2D_KEYWORDS = {"2d", "planar"}
 
 
 def _classify_filename(name: str) -> str:
@@ -171,3 +171,23 @@ def _make_surface_mesh_faces() -> np.ndarray:
 
 
 pv.read = _fake_pv_read  # type: ignore[assignment]
+
+# Patch pv.PolyData.save and pv.UnstructuredGrid.save to redirect to tmp_dir
+_real_pv_polydata_save = pv.PolyData.save
+_real_pv_unstructured_save = pv.UnstructuredGrid.save
+
+
+def _patched_pv_save(
+    self: pv.PolyData | pv.UnstructuredGrid,
+    filename: str,
+    **kwargs: object,
+) -> None:
+    dest = str(Path(_tmp_dir) / Path(filename).name)
+    if isinstance(self, pv.PolyData):
+        _real_pv_polydata_save(self, dest, **kwargs)
+    else:
+        _real_pv_unstructured_save(self, dest, **kwargs)
+
+
+pv.PolyData.save = _patched_pv_save  # type: ignore[assignment]
+pv.UnstructuredGrid.save = _patched_pv_save  # type: ignore[assignment]

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,133 @@
+"""Pytest-codeblocks fixtures for documentation code snippets.
+
+Monkeypatches mmgpy I/O so that code blocks referencing files like
+``mmgpy.read("input.mesh")`` work without real files on disk.
+
+Since pytest-codeblocks' TestBlock inherits from pytest.Item (not
+pytest.Function), autouse fixtures are not applied. Instead, we apply
+patches at module level when this conftest is loaded, and use
+pytest_runtest_setup/teardown hooks for per-test tmp_path management.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pyvista as pv
+from scipy.spatial import Delaunay
+
+if TYPE_CHECKING:
+    from mmgpy._mesh import Mesh as MeshType
+    from mmgpy._mesh import MeshKind
+
+os.environ["PYVISTA_OFF_SCREEN"] = "true"
+
+# ---------------------------------------------------------------------------
+# Module-level mesh factories (created once at import time)
+# ---------------------------------------------------------------------------
+
+
+def _make_3d_mesh() -> tuple[np.ndarray, np.ndarray]:
+    """Dense tetrahedral mesh of a unit cube via PyVista delaunay_3d."""
+    resolution = 5
+    x = np.linspace(0, 1, resolution)
+    y = np.linspace(0, 1, resolution)
+    z = np.linspace(0, 1, resolution)
+    xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
+    points = np.column_stack([xx.ravel(), yy.ravel(), zz.ravel()])
+    cloud = pv.PolyData(points)
+    tetra = cloud.delaunay_3d()
+    vertices = np.array(tetra.points, dtype=np.float64)
+    elements = tetra.cells_dict[pv.CellType.TETRA].astype(np.int32)
+    return vertices, elements
+
+
+def _make_2d_mesh() -> tuple[np.ndarray, np.ndarray]:
+    """Dense triangular mesh of a unit square via scipy Delaunay."""
+    resolution = 10
+    x = np.linspace(0, 1, resolution)
+    y = np.linspace(0, 1, resolution)
+    xx, yy = np.meshgrid(x, y)
+    points = np.column_stack([xx.ravel(), yy.ravel()])
+    tri = Delaunay(points)
+    return points.astype(np.float64), tri.simplices.astype(np.int32)
+
+
+def _make_surface_mesh() -> tuple[np.ndarray, np.ndarray]:
+    """Triangulated sphere surface via PyVista."""
+    sphere = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    sphere = sphere.triangulate()
+    vertices = np.array(sphere.points, dtype=np.float64)
+    faces = sphere.faces.reshape(-1, 4)[:, 1:].astype(np.int32)
+    return vertices, faces
+
+
+_VERTS_3D, _CELLS_3D = _make_3d_mesh()
+_VERTS_2D, _CELLS_2D = _make_2d_mesh()
+_VERTS_SURF, _CELLS_SURF = _make_surface_mesh()
+
+# ---------------------------------------------------------------------------
+# Routing helpers
+# ---------------------------------------------------------------------------
+
+_SURFACE_EXTENSIONS = {".stl", ".obj", ".ply", ".off", ".vtp"}
+_SURFACE_KEYWORDS = {"surface", "mechanical", "part", "torus", "sphere", "bunny"}
+_2D_KEYWORDS = {"2d", "planar", "domain"}
+
+
+def _classify_filename(name: str) -> str:
+    """Return '2d', 'surface', or '3d' based on filename heuristics."""
+    lower = name.lower()
+    ext = Path(name).suffix.lower()
+    if ext in _SURFACE_EXTENSIONS:
+        return "surface"
+    if any(kw in lower for kw in _2D_KEYWORDS):
+        return "2d"
+    if any(kw in lower for kw in _SURFACE_KEYWORDS):
+        return "surface"
+    return "3d"
+
+
+# ---------------------------------------------------------------------------
+# Module-level monkeypatches (applied once at import time)
+# ---------------------------------------------------------------------------
+
+import mmgpy  # noqa: E402
+import mmgpy._io as _io_mod  # noqa: E402
+from mmgpy import Mesh  # noqa: E402
+
+_real_read = _io_mod.read
+_real_save = Mesh.save
+
+# Temp dir for save redirects (cleaned up at process exit)
+_tmp_dir = tempfile.mkdtemp(prefix="mmgpy_docs_")
+
+
+def _fake_read(
+    source: str | Path | pv.UnstructuredGrid | pv.PolyData,
+    mesh_kind: MeshKind | None = None,
+) -> MeshType:
+    if isinstance(source, (pv.UnstructuredGrid, pv.PolyData)):
+        return _real_read(source, mesh_kind=mesh_kind)
+
+    name = str(source)
+    kind = _classify_filename(name)
+    if kind == "2d":
+        return Mesh(_VERTS_2D.copy(), _CELLS_2D.copy())
+    if kind == "surface":
+        return Mesh(_VERTS_SURF.copy(), _CELLS_SURF.copy())
+    return Mesh(_VERTS_3D.copy(), _CELLS_3D.copy())
+
+
+def _patched_save(self: MeshType, filename: str | Path) -> None:
+    dest = Path(_tmp_dir) / Path(filename).name
+    _real_save(self, str(dest))
+
+
+_io_mod.read = _fake_read
+mmgpy.read = _fake_read
+Mesh.save = _patched_save

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -11,7 +11,9 @@ pytest_runtest_setup/teardown hooks for per-test tmp_path management.
 
 from __future__ import annotations
 
+import atexit
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -80,7 +82,12 @@ _2D_KEYWORDS = {"2d", "planar"}
 
 
 def _classify_filename(name: str) -> str:
-    """Return '2d', 'surface', or '3d' based on filename heuristics."""
+    """Return '2d', 'surface', or '3d' based on filename heuristics.
+
+    NOTE: Routing is based on filename keywords/extensions. This works because
+    doc filenames are controlled, but e.g. "sphere_domain.mesh" would route to
+    surface even if used in a 3D context.
+    """
     lower = name.lower()
     ext = Path(name).suffix.lower()
     if ext in _SURFACE_EXTENSIONS:
@@ -105,6 +112,7 @@ _real_save = Mesh.save
 
 # Temp dir for save redirects (cleaned up at process exit)
 _tmp_dir = tempfile.mkdtemp(prefix="mmgpy_docs_")
+atexit.register(shutil.rmtree, _tmp_dir, ignore_errors=True)
 
 
 def _fake_read(
@@ -136,7 +144,10 @@ Mesh.save = _patched_save
 _real_pv_read = pv.read
 
 
-def _fake_pv_read(filename: str | Path, **_kwargs: object) -> pv.UnstructuredGrid:
+def _fake_pv_read(
+    filename: str | Path,
+    **_kwargs: object,
+) -> pv.UnstructuredGrid | pv.PolyData:
     kind = _classify_filename(str(filename))
     if kind == "2d":
         # Return a flat 2D-like UnstructuredGrid
@@ -191,3 +202,19 @@ def _patched_pv_save(
 
 pv.PolyData.save = _patched_pv_save  # type: ignore[assignment]
 pv.UnstructuredGrid.save = _patched_pv_save  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Restore originals on pytest teardown (avoids polluting other test suites
+# when running `pytest tests/ docs/` in a single invocation)
+# ---------------------------------------------------------------------------
+
+
+def pytest_unconfigure() -> None:
+    """Restore all monkeypatched functions."""
+    _io_mod.read = _real_read
+    mmgpy.read = _real_read
+    Mesh.save = _real_save
+    pv.read = _real_pv_read  # type: ignore[assignment]
+    pv.PolyData.save = _real_pv_polydata_save  # type: ignore[assignment]
+    pv.UnstructuredGrid.save = _real_pv_unstructured_save  # type: ignore[assignment]

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -131,3 +131,43 @@ def _patched_save(self: MeshType, filename: str | Path) -> None:
 _io_mod.read = _fake_read
 mmgpy.read = _fake_read
 Mesh.save = _patched_save
+
+# Also patch pv.read so docs like `pv.read("mesh.vtk")` work
+_real_pv_read = pv.read
+
+
+def _fake_pv_read(filename: str | Path, **_kwargs: object) -> pv.UnstructuredGrid:
+    kind = _classify_filename(str(filename))
+    if kind == "2d":
+        # Return a flat 2D-like UnstructuredGrid
+        cells = np.column_stack(
+            [np.full(len(_CELLS_2D), 3), _CELLS_2D],
+        ).ravel()
+        points_3d = np.column_stack(
+            [_VERTS_2D, np.zeros(len(_VERTS_2D))],
+        )
+        return pv.UnstructuredGrid(
+            cells,
+            np.full(len(_CELLS_2D), pv.CellType.TRIANGLE),
+            points_3d.copy(),
+        )
+    if kind == "surface":
+        return pv.PolyData(_VERTS_SURF.copy(), faces=_make_surface_mesh_faces())
+    # 3D tetrahedral
+    cells = np.column_stack(
+        [np.full(len(_CELLS_3D), 4), _CELLS_3D],
+    ).ravel()
+    return pv.UnstructuredGrid(
+        cells,
+        np.full(len(_CELLS_3D), pv.CellType.TETRA),
+        _VERTS_3D.copy(),
+    )
+
+
+def _make_surface_mesh_faces() -> np.ndarray:
+    """Return PyVista-style face array from surface mesh triangles."""
+    n = len(_CELLS_SURF)
+    return np.column_stack([np.full(n, 3), _CELLS_SURF]).ravel()
+
+
+pv.read = _fake_pv_read  # type: ignore[assignment]

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -49,6 +49,8 @@ result = mesh.remesh(
 
 Remesh while applying mesh displacement.
 
+!!! warning "Requires ELAS library"
+
 <!-- pytest-codeblocks:skip -->
 
 ```python

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -103,7 +103,7 @@ Apply regional mesh refinement.
 """Per-region mesh density control."""
 import mmgpy
 
-mesh = mmgpy.Mesh("domain.mesh")
+mesh = mmgpy.Mesh("domain_2d.mesh")
 
 # Fine mesh in center
 mesh.set_size_sphere(center=[0.5, 0.5], radius=0.2, size=0.01)
@@ -120,15 +120,13 @@ result = mesh.remesh(hmax=0.1)
 
 Adapt mesh to solution field.
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 """Mesh adaptation to solution gradients."""
 import mmgpy
 import mmgpy.metrics as metrics
 import numpy as np
 
-mesh = mmgpy.Mesh("domain.mesh")
+mesh = mmgpy.Mesh("domain_2d.mesh")
 vertices = mesh.get_vertices()
 
 # Solution field
@@ -137,7 +135,7 @@ solution = np.sin(vertices[:, 0] * 4 * np.pi) * np.cos(vertices[:, 1] * 4 * np.p
 # Create metric from solution gradients
 # (simplified - full implementation computes Hessian)
 sizes = 0.01 + 0.1 * np.abs(solution)
-metric = metrics.create_isotropic_metric(sizes)
+metric = metrics.create_isotropic_metric(sizes, dim=2)
 mesh.set_field("tensor", metric)
 
 result = mesh.remesh()
@@ -157,7 +155,7 @@ import mmgpy
 import mmgpy.metrics as metrics
 import numpy as np
 
-mesh = mmgpy.Mesh("domain.mesh")
+mesh = mmgpy.Mesh("domain_2d.mesh")
 n_vertices = len(mesh.get_vertices())
 
 # Create anisotropic metric (stretch in x direction)
@@ -182,11 +180,12 @@ Generate mesh from implicit function.
 import mmgpy
 import numpy as np
 
-mesh = mmgpy.Mesh("background.mesh")
+mesh = mmgpy.Mesh("background_2d.mesh")
 vertices = mesh.get_vertices()
 
 # Circle level-set
-levelset = (np.linalg.norm(vertices[:, :2] - [0.5, 0.5], axis=1) - 0.3).reshape(-1, 1)
+center = np.array([0.5, 0.5])
+levelset = (np.linalg.norm(vertices[:, :2] - center, axis=1) - 0.3).reshape(-1, 1)
 
 result = mesh.remesh_levelset(levelset)
 ```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -49,6 +49,8 @@ result = mesh.remesh(
 
 Remesh while applying mesh displacement.
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 """Lagrangian mesh motion remeshing."""
 import mmgpy
@@ -117,6 +119,8 @@ result = mesh.remesh(hmax=0.1)
 ### Solution-Based Adaptation
 
 Adapt mesh to solution field.
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 """Mesh adaptation to solution gradients."""
@@ -197,6 +201,8 @@ result = mesh.remesh_levelset(levelset)
 
 Industrial part surface remeshing.
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 """Mechanical part surface optimization."""
 import mmgpy
@@ -267,6 +273,8 @@ result = mesh.remesh_levelset(levelset)
 ## Running Examples
 
 Clone the repository and run examples:
+
+<!-- pytest-codeblocks:skip -->
 
 ```bash
 git clone https://github.com/kmarchais/mmgpy.git

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -211,7 +211,7 @@ mesh = mmgpy.Mesh("part.stl")
 result = mesh.remesh(
     hmax=0.05,
     hausd=0.001,
-    angle=30,  # Preserve sharp edges
+    ar=30,     # Preserve sharp edges
 )
 ```
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -201,8 +201,6 @@ result = mesh.remesh_levelset(levelset)
 
 Industrial part surface remeshing.
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 """Mechanical part surface optimization."""
 import mmgpy
@@ -212,7 +210,7 @@ mesh = mmgpy.Mesh("part.stl")
 result = mesh.remesh(
     hmax=0.05,
     hausd=0.001,
-    angle=30.0,  # Preserve sharp edges
+    angle=30,  # Preserve sharp edges
 )
 ```
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -177,7 +177,7 @@ Control edge lengths globally:
 
 Refine specific regions with sizing constraints:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Spherical refinement region
@@ -224,7 +224,7 @@ mmgpy uses normalized quality measures:
 
 The `RemeshResult` class provides quality statistics:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(hmax=0.1)
@@ -248,7 +248,7 @@ mmgpy supports 40+ file formats via meshio:
 
 Load any format with `mmgpy.Mesh()` or `mmgpy.read()`:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh = mmgpy.Mesh("model.stl")
@@ -266,7 +266,7 @@ Control output verbosity:
 | `1`   | Standard info      |
 | `2+`  | Debug output       |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(hmax=0.1, verbose=-1)  # Silent

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -152,6 +152,8 @@ result = mesh.remesh_levelset(levelset)
 
 Remesh while preserving a displacement field (useful for moving meshes):
 
+!!! warning "Requires ELAS library"
+
 <!-- pytest-codeblocks:skip -->
 
 ```python

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -103,17 +103,19 @@ This may:
 
 To improve quality without changing topology:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
+
+mesh = mmgpy.Mesh("input.mesh")
 result = mesh.remesh_optimize()
 ```
 
 Or equivalently:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
+
+mesh = mmgpy.Mesh("input.mesh")
 result = mesh.remesh(optim=1, noinsert=1)
 ```
 
@@ -121,9 +123,10 @@ result = mesh.remesh(optim=1, noinsert=1)
 
 To remesh with a single target size everywhere:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
+
+mesh = mmgpy.Mesh("input.mesh")
 result = mesh.remesh_uniform(size=0.05)
 ```
 
@@ -131,9 +134,8 @@ result = mesh.remesh_uniform(size=0.05)
 
 Extract and remesh an isosurface:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
 import numpy as np
 
 # Define a level-set function (distance to sphere)
@@ -202,10 +204,13 @@ mesh.set_size_from_point(
 
 For anisotropic remeshing, define a metric tensor at each vertex:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
 import mmgpy.metrics as metrics
+import numpy as np
+
+mesh = mmgpy.Mesh("input.mesh")
+n_vertices = len(mesh.get_vertices())
 
 # Create isotropic metric from sizes
 sizes = np.ones(n_vertices) * 0.1

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -83,6 +83,8 @@ mesh_2d = mmgpy.Mesh(vertices_2d, triangles)
 
 The default `remesh()` operation modifies the mesh topology to achieve target element sizes:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 result = mesh.remesh(
     hmin=0.01,   # Minimum edge length
@@ -101,11 +103,15 @@ This may:
 
 To improve quality without changing topology:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh_optimize()
 ```
 
 Or equivalently:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(optim=1, noinsert=1)
@@ -115,6 +121,8 @@ result = mesh.remesh(optim=1, noinsert=1)
 
 To remesh with a single target size everywhere:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh_uniform(size=0.05)
 ```
@@ -122,6 +130,8 @@ result = mesh.remesh_uniform(size=0.05)
 ### Level-Set Remeshing
 
 Extract and remesh an isosurface:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import numpy as np
@@ -139,6 +149,8 @@ result = mesh.remesh_levelset(levelset)
 ### Lagrangian Remeshing
 
 Remesh while preserving a displacement field (useful for moving meshes):
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Displacement field at each vertex
@@ -165,6 +177,8 @@ Control edge lengths globally:
 
 Refine specific regions with sizing constraints:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 # Spherical refinement region
 mesh.set_size_sphere(center=[0.5, 0.5, 0.5], radius=0.2, size=0.01)
@@ -188,6 +202,8 @@ mesh.set_size_from_point(
 
 For anisotropic remeshing, define a metric tensor at each vertex:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy.metrics as metrics
 
@@ -207,6 +223,8 @@ mmgpy uses normalized quality measures:
 - **Quality = 0.0** - Degenerate element (collapsed)
 
 The `RemeshResult` class provides quality statistics:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(hmax=0.1)
@@ -230,6 +248,8 @@ mmgpy supports 40+ file formats via meshio:
 
 Load any format with `mmgpy.Mesh()` or `mmgpy.read()`:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 mesh = mmgpy.Mesh("model.stl")
 mesh.save("output.vtk")
@@ -245,6 +265,8 @@ Control output verbosity:
 | `0`   | Errors only        |
 | `1`   | Standard info      |
 | `2+`  | Debug output       |
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(hmax=0.1, verbose=-1)  # Silent

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -124,8 +124,6 @@ result = mesh.remesh(hmax=0.1, verbose=-1)
 
 Visualize meshes with the built-in `plot()` method:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 
@@ -142,7 +140,7 @@ mesh.plot(color="lightblue", opacity=0.8)
 
 For custom plotters, use the `vtk` property:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 import pyvista as pv
@@ -153,8 +151,6 @@ plotter.show()
 ```
 
 Load from PyVista:
-
-<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -124,6 +124,8 @@ result = mesh.remesh(hmax=0.1, verbose=-1)
 
 Visualize meshes with the built-in `plot()` method:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 
@@ -140,6 +142,8 @@ mesh.plot(color="lightblue", opacity=0.8)
 
 For custom plotters, use the `vtk` property:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import pyvista as pv
 
@@ -149,6 +153,8 @@ plotter.show()
 ```
 
 Load from PyVista:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,11 +13,15 @@ Installing mmgpy gives you access to the MMG command-line executables:
 
 The executables are included with mmgpy:
 
+<!-- pytest-codeblocks:skip -->
+
 ```bash
 pip install mmgpy
 ```
 
 If you only need the CLI tools (no Python API):
+
+<!-- pytest-codeblocks:skip -->
 
 ```bash
 uv tool install mmgpy
@@ -26,6 +30,8 @@ uv tool install mmgpy
 ## Unified `mmg` Command
 
 The `mmg` command automatically detects the mesh type and delegates to the appropriate executable:
+
+<!-- pytest-codeblocks:skip -->
 
 ```bash
 mmg input.mesh -o output.mesh -hmax 0.1
@@ -39,6 +45,8 @@ This is equivalent to running `mmg3d`, `mmg2d`, or `mmgs` depending on the input
 
 ### Version Information
 
+<!-- pytest-codeblocks:skip -->
+
 ```bash
 mmg --version
 # mmgpy 0.4.0
@@ -48,6 +56,8 @@ mmg --help
 ```
 
 ## Quick Examples
+
+<!-- pytest-codeblocks:skip -->
 
 ```bash
 # Auto-detect mesh type

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -69,11 +69,17 @@ End
 
 ## Format Selection Guide
 
+```python
+import mmgpy
+
+mesh = mmgpy.read("input.mesh")
+```
+
 ### For MMG Processing
 
 Use `.mesh` format:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh.save("output.mesh")
@@ -87,7 +93,7 @@ mesh.save("output.mesh")
 
 Use VTK formats:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh.save("output.vtk")   # Legacy
@@ -126,12 +132,10 @@ MMG supports solution files (`.sol`) containing:
 
 ### Creating Solution Files
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 import numpy as np
-
-mesh = mmgpy.read("input.mesh")
 
 # Add scalar field
 temperature = np.random.rand(len(mesh.get_vertices()))
@@ -143,15 +147,13 @@ mesh.save("output.mesh")  # Also saves output.sol if fields exist
 
 ### Loading Solution Files
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
-# Solution file is loaded automatically if present
-mesh = mmgpy.read("input.mesh")
-
-# Access fields
-if "temperature" in mesh:
-    temp = mesh["temperature"]
+# Access user fields
+user_fields = mesh.get_user_fields()
+if "temperature" in user_fields:
+    temp = mesh.get_user_field("temperature")
 ```
 
 ## Binary vs ASCII
@@ -163,7 +165,7 @@ if "temperature" in mesh:
 | Human readable | Yes                 | No              |
 | Precision      | Text representation | Full precision  |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # ASCII
@@ -177,7 +179,7 @@ mesh.save("output.meshb")
 
 mmgpy automatically detects format from extension:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Auto-detected from extension
@@ -213,7 +215,7 @@ Some formats don't support all features:
 
 For large meshes:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Use binary format

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -73,6 +73,8 @@ End
 
 Use `.mesh` format:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 mesh.save("output.mesh")
 ```
@@ -85,6 +87,8 @@ mesh.save("output.mesh")
 
 Use VTK formats:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 mesh.save("output.vtk")   # Legacy
 mesh.save("output.vtu")   # XML (preferred)
@@ -93,6 +97,8 @@ mesh.save("output.vtu")   # XML (preferred)
 ### For CAD/3D Printing
 
 Use STL:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Surface meshes only
@@ -120,6 +126,8 @@ MMG supports solution files (`.sol`) containing:
 
 ### Creating Solution Files
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import numpy as np
 
@@ -134,6 +142,8 @@ mesh.save("output.mesh")  # Also saves output.sol if fields exist
 ```
 
 ### Loading Solution Files
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Solution file is loaded automatically if present
@@ -153,6 +163,8 @@ if "temperature" in mesh:
 | Human readable | Yes                 | No              |
 | Precision      | Text representation | Full precision  |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 # ASCII
 mesh.save("output.mesh")
@@ -164,6 +176,8 @@ mesh.save("output.meshb")
 ## Format Detection
 
 mmgpy automatically detects format from extension:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Auto-detected from extension
@@ -198,6 +212,8 @@ Some formats don't support all features:
 ### Large Files
 
 For large meshes:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Use binary format

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -104,11 +104,12 @@ mesh.save("output.vtu")   # XML (preferred)
 
 Use STL:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Surface meshes only
-mesh.save("output.stl")
+surface_mesh = mmgpy.read("model.stl")
+surface_mesh.save("output.stl")
 ```
 
 ### For Other Software

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -123,10 +123,10 @@ Ridge detection angle in degrees.
 | Default  | 45.0    |
 | Range    | 0 - 180 |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(angle=30.0)
+result = mesh.remesh(angle=30)
 ```
 
 - Edges with dihedral angle > `angle` are treated as ridges
@@ -314,12 +314,12 @@ result = mesh.remesh(
 
 ### Preserve Sharp Features
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
     hmax=0.1,
-    angle=20.0,  # Detect more ridges
+    angle=20,  # Detect more ridges
     hausd=0.001,
 )
 ```

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -1,7 +1,5 @@
 # MMG Parameters Reference
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 mesh = mmgpy.read("input.mesh")
@@ -41,7 +39,7 @@ Maximum edge length.
 | Default  | Auto-computed |
 | Range    | > hmin        |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(hmax=0.1)
@@ -81,7 +79,7 @@ Gradation parameter controlling size transition.
 | Default  | 1.3     |
 | Range    | >= 1.0  |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(hgrad=1.2)
@@ -105,7 +103,7 @@ Hausdorff distance - maximum distance between input and output geometry.
 | Default  | 0.01 \* bounding box diagonal |
 | Range    | > 0                           |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(hausd=0.001)
@@ -169,7 +167,7 @@ Disable vertex insertion.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(noinsert=1)
@@ -189,7 +187,7 @@ Disable edge/face swapping.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(noswap=1)
@@ -209,7 +207,7 @@ Disable vertex movement.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(nomove=1)
@@ -229,7 +227,7 @@ Preserve surface vertices.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(nosurf=1)
@@ -251,7 +249,7 @@ Verbosity level.
 | Default  | 1        |
 | Range    | -1 to 10 |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(verbose=-1)  # Silent
@@ -302,7 +300,7 @@ result = mesh.remesh_uniform(size=0.05)
 
 ### High-Quality Surface Approximation
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
@@ -330,7 +328,7 @@ result = mesh.remesh(
 
 ### Fast Coarse Remeshing
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
@@ -344,7 +342,7 @@ result = mesh.remesh(
 
 ### Volume Interior Only
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -129,10 +129,10 @@ Ridge detection angle in degrees.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(angle=30)
+result = mesh.remesh(ar=30)
 ```
 
-- Edges with dihedral angle > `angle` are treated as ridges
+- Edges with dihedral angle > `ar` are treated as ridges
 - Ridges are preserved during remeshing
 - `angle=180`: No ridge detection
 

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -23,8 +23,6 @@ Minimum edge length.
 
 ```python
 result = mesh.remesh(hmin=0.01)
-mesh = mmgpy.read("input.mesh")  # Reset mesh
-result = mesh.remesh(hmax=0.1)
 ```
 
 Edges shorter than `hmin` will be collapsed or lengthened.
@@ -64,10 +62,10 @@ Uniform target edge size.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
+# hsiz conflicts with prior metric, so reload the mesh
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(hsiz=0.05)
-mesh = mmgpy.read("input.mesh")  # Reset mesh
-result = mesh.remesh(hmax=0.1)
+mesh = mmgpy.read("input.mesh")
 ```
 
 When set, overrides `hmin` and `hmax` with uniform sizing.
@@ -155,10 +153,10 @@ Enable optimization mode.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
+# optim conflicts with prior metric, so reload the mesh
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(optim=1)
-mesh = mmgpy.read("input.mesh")  # Reset mesh
-result = mesh.remesh(hmax=0.1)
+mesh = mmgpy.read("input.mesh")
 ```
 
 When enabled, only moves vertices to improve quality (no topology changes).
@@ -275,7 +273,7 @@ result = mesh.remesh(verbose=5)   # Debug output
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(optim=1, noinsert=1)
 ```
 
@@ -284,7 +282,7 @@ Or use the convenience method:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh_optimize()
 ```
 
@@ -295,7 +293,7 @@ result = mesh.remesh_optimize()
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(hsiz=0.05)
 ```
 
@@ -304,9 +302,9 @@ Or use the convenience method:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh_uniform(size=0.05)
-mesh = mmgpy.read("input.mesh")  # Reset mesh
+mesh = mmgpy.read("input.mesh")
 ```
 
 ---
@@ -332,7 +330,7 @@ result = mesh.remesh(
 ```python
 result = mesh.remesh(
     hmax=0.1,
-    angle=20,  # Detect more ridges
+    ar=20,     # Detect more ridges
     hausd=0.001,
 )
 ```

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -19,10 +19,12 @@ Minimum edge length.
 | Default  | Auto-computed |
 | Range    | > 0           |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(hmin=0.01)
+mesh = mmgpy.read("input.mesh")  # Reset mesh
+result = mesh.remesh(hmax=0.1)
 ```
 
 Edges shorter than `hmin` will be collapsed or lengthened.
@@ -59,10 +61,13 @@ Uniform target edge size.
 | Default  | None    |
 | Range    | > 0     |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
+mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
 result = mesh.remesh(hsiz=0.05)
+mesh = mmgpy.read("input.mesh")  # Reset mesh
+result = mesh.remesh(hmax=0.1)
 ```
 
 When set, overrides `hmin` and `hmax` with uniform sizing.
@@ -147,10 +152,13 @@ Enable optimization mode.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
+mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
 result = mesh.remesh(optim=1)
+mesh = mmgpy.read("input.mesh")  # Reset mesh
+result = mesh.remesh(hmax=0.1)
 ```
 
 When enabled, only moves vertices to improve quality (no topology changes).
@@ -264,17 +272,19 @@ result = mesh.remesh(verbose=5)   # Debug output
 
 ### Quality Optimization Only
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
+mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
 result = mesh.remesh(optim=1, noinsert=1)
 ```
 
 Or use the convenience method:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
+mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
 result = mesh.remesh_optimize()
 ```
 
@@ -282,18 +292,21 @@ result = mesh.remesh_optimize()
 
 ### Uniform Remeshing
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
+mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
 result = mesh.remesh(hsiz=0.05)
 ```
 
 Or use the convenience method:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
+mesh = mmgpy.read("input.mesh")  # Fresh mesh needed
 result = mesh.remesh_uniform(size=0.05)
+mesh = mmgpy.read("input.mesh")  # Reset mesh
 ```
 
 ---

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -1,5 +1,12 @@
 # MMG Parameters Reference
 
+<!-- pytest-codeblocks:skip -->
+
+```python
+import mmgpy
+mesh = mmgpy.read("input.mesh")
+```
+
 Complete reference for all MMG remeshing parameters.
 
 ## Size Parameters
@@ -13,6 +20,8 @@ Minimum edge length.
 | Type     | `float`       |
 | Default  | Auto-computed |
 | Range    | > 0           |
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(hmin=0.01)
@@ -32,6 +41,8 @@ Maximum edge length.
 | Default  | Auto-computed |
 | Range    | > hmin        |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(hmax=0.1)
 ```
@@ -50,6 +61,8 @@ Uniform target edge size.
 | Default  | None    |
 | Range    | > 0     |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(hsiz=0.05)
 ```
@@ -67,6 +80,8 @@ Gradation parameter controlling size transition.
 | Type     | `float` |
 | Default  | 1.3     |
 | Range    | >= 1.0  |
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(hgrad=1.2)
@@ -90,6 +105,8 @@ Hausdorff distance - maximum distance between input and output geometry.
 | Default  | 0.01 \* bounding box diagonal |
 | Range    | > 0                           |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(hausd=0.001)
 ```
@@ -107,6 +124,8 @@ Ridge detection angle in degrees.
 | Type     | `float` |
 | Default  | 45.0    |
 | Range    | 0 - 180 |
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(angle=30.0)
@@ -130,6 +149,8 @@ Enable optimization mode.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(optim=1)
 ```
@@ -147,6 +168,8 @@ Disable vertex insertion.
 | Type     | `int`           |
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(noinsert=1)
@@ -166,6 +189,8 @@ Disable edge/face swapping.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(noswap=1)
 ```
@@ -184,6 +209,8 @@ Disable vertex movement.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(nomove=1)
 ```
@@ -201,6 +228,8 @@ Preserve surface vertices.
 | Type     | `int`           |
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(nosurf=1)
@@ -222,6 +251,8 @@ Verbosity level.
 | Default  | 1        |
 | Range    | -1 to 10 |
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(verbose=-1)  # Silent
 result = mesh.remesh(verbose=0)   # Errors only
@@ -235,11 +266,15 @@ result = mesh.remesh(verbose=5)   # Debug output
 
 ### Quality Optimization Only
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(optim=1, noinsert=1)
 ```
 
 Or use the convenience method:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh_optimize()
@@ -249,11 +284,15 @@ result = mesh.remesh_optimize()
 
 ### Uniform Remeshing
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(hsiz=0.05)
 ```
 
 Or use the convenience method:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh_uniform(size=0.05)
@@ -262,6 +301,8 @@ result = mesh.remesh_uniform(size=0.05)
 ---
 
 ### High-Quality Surface Approximation
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(
@@ -275,6 +316,8 @@ result = mesh.remesh(
 
 ### Preserve Sharp Features
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(
     hmax=0.1,
@@ -287,6 +330,8 @@ result = mesh.remesh(
 
 ### Fast Coarse Remeshing
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(
     hmax=0.5,
@@ -298,6 +343,8 @@ result = mesh.remesh(
 ---
 
 ### Volume Interior Only
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(

--- a/docs/tutorials/adaptive-sizing.md
+++ b/docs/tutorials/adaptive-sizing.md
@@ -186,8 +186,6 @@ result = mesh.remesh()
 
 Create refined mesh near a surface for CFD simulations:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import numpy as np
@@ -224,9 +222,8 @@ mesh.save("refined_domain.vtk")
 
 For programmatic use, you can use the sizing constraint classes directly:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
+import mmgpy
 from mmgpy import SphereSize, BoxSize, CylinderSize, PointSize
 from mmgpy.sizing import apply_sizing_constraints
 import numpy as np

--- a/docs/tutorials/adaptive-sizing.md
+++ b/docs/tutorials/adaptive-sizing.md
@@ -33,6 +33,8 @@ result = mesh.remesh(hmax=0.1, verbose=-1)
 
 Multiple spheres can be combined:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 # Fine region near origin
 mesh.set_size_sphere(center=[0, 0, 0], radius=0.1, size=0.005)
@@ -62,6 +64,8 @@ result = mesh.remesh(hmax=0.1)
 ```
 
 For 2D meshes:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 mesh.set_size_box(
@@ -143,6 +147,8 @@ result = mesh.remesh(hmax=0.1)
 
 Check and clear sizing constraints:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 # Check number of active constraints
 n_constraints = mesh.get_local_sizing_count()
@@ -158,6 +164,8 @@ assert mesh.get_local_sizing_count() == 0
 ## Manual Application
 
 Sizing constraints are automatically applied before remeshing. You can also apply them manually to inspect the resulting metric field:
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Add constraints
@@ -177,6 +185,8 @@ result = mesh.remesh()
 ## Complete Example: CFD Boundary Layer
 
 Create refined mesh near a surface for CFD simulations:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy
@@ -213,6 +223,8 @@ mesh.save("refined_domain.vtk")
 ## Using Sizing Constraint Classes Directly
 
 For programmatic use, you can use the sizing constraint classes directly:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import SphereSize, BoxSize, CylinderSize, PointSize

--- a/docs/tutorials/basic-remeshing.md
+++ b/docs/tutorials/basic-remeshing.md
@@ -71,7 +71,7 @@ for warning in result.warnings:
 
 Control the range of edge lengths in the output mesh:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
@@ -96,7 +96,7 @@ result = mesh.remesh_uniform(size=0.05)
 
 The `hausd` parameter controls how closely the output mesh approximates the input geometry:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
@@ -179,7 +179,7 @@ result = mesh.remesh(opt_opts)
 
 Save the remeshed output to any supported format:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 # Save to MMG native format

--- a/docs/tutorials/basic-remeshing.md
+++ b/docs/tutorials/basic-remeshing.md
@@ -82,14 +82,17 @@ result = mesh.remesh(
 
 For a uniform mesh with a single target size:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
-# Using hsiz parameter
+# Using hsiz parameter (needs a fresh mesh — hsiz conflicts with prior metric)
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(hsiz=0.05)
 
 # Or using the convenience method
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh_uniform(size=0.05)
+mesh = mmgpy.read("input.mesh")  # Reset for subsequent examples
 ```
 
 ## Geometric Approximation
@@ -141,14 +144,17 @@ result = mesh.remesh(**opts.to_dict())
 
 To improve quality without inserting/removing vertices:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
-# Using the convenience method
+# Using the convenience method (needs fresh mesh — optim conflicts with prior metric)
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh_optimize()
 
 # Equivalent to
+mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(optim=1, noinsert=1)
+mesh = mmgpy.read("input.mesh")  # Reset for subsequent examples
 ```
 
 This only moves existing vertices to improve element quality.
@@ -157,22 +163,26 @@ This only moves existing vertices to improve element quality.
 
 Options classes provide factory methods for common scenarios:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import Mmg3DOptions
 
 # Fine mesh preset
-fine_opts = Mmg3DOptions.fine(hmax=0.01)
+mesh = mmgpy.read("input.mesh")
+fine_opts = Mmg3DOptions.fine(hmax=0.05)
 result = mesh.remesh(fine_opts)
 
 # Coarse mesh preset
+mesh = mmgpy.read("input.mesh")
 coarse_opts = Mmg3DOptions.coarse(hmax=1.0)
 result = mesh.remesh(coarse_opts)
 
 # Optimization-only preset
+mesh = mmgpy.read("input.mesh")
 opt_opts = Mmg3DOptions.optimize_only()
 result = mesh.remesh(opt_opts)
+mesh = mmgpy.read("input.mesh")  # Reset for subsequent examples
 ```
 
 ## Saving Results
@@ -187,10 +197,6 @@ mesh.save("output.mesh")
 
 # Save to VTK for ParaView
 mesh.save("output.vtk")
-
-# Save to other formats
-mesh.save("output.stl")  # Surface only
-mesh.save("output.ply")
 ```
 
 ## Complete Example

--- a/docs/tutorials/basic-remeshing.md
+++ b/docs/tutorials/basic-remeshing.md
@@ -40,6 +40,8 @@ print(f"Elements: {result.elements_before} -> {result.elements_after}")
 
 Every remeshing operation returns a `RemeshResult` object with statistics:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 result = mesh.remesh(hmax=0.1)
 
@@ -69,6 +71,8 @@ for warning in result.warnings:
 
 Control the range of edge lengths in the output mesh:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(
     hmin=0.01,  # Minimum edge length (prevents over-refinement)
@@ -77,6 +81,8 @@ result = mesh.remesh(
 ```
 
 For a uniform mesh with a single target size:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Using hsiz parameter
@@ -90,6 +96,8 @@ result = mesh.remesh_uniform(size=0.05)
 
 The `hausd` parameter controls how closely the output mesh approximates the input geometry:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(
     hmax=0.1,
@@ -102,6 +110,8 @@ result = mesh.remesh(
 ## Using Options Objects
 
 For complex configurations, use typed options objects:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import Mmg3DOptions
@@ -121,6 +131,8 @@ result = mesh.remesh(opts)
 
 Options can be unpacked directly into `remesh()`:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(**opts.to_dict())
 ```
@@ -128,6 +140,8 @@ result = mesh.remesh(**opts.to_dict())
 ## Optimization Without Topology Changes
 
 To improve quality without inserting/removing vertices:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Using the convenience method
@@ -142,6 +156,8 @@ This only moves existing vertices to improve element quality.
 ## Factory Presets
 
 Options classes provide factory methods for common scenarios:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import Mmg3DOptions
@@ -162,6 +178,8 @@ result = mesh.remesh(opt_opts)
 ## Saving Results
 
 Save the remeshed output to any supported format:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Save to MMG native format

--- a/docs/tutorials/basic-remeshing.md
+++ b/docs/tutorials/basic-remeshing.md
@@ -111,7 +111,7 @@ result = mesh.remesh(
 
 For complex configurations, use typed options objects:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import Mmg3DOptions
@@ -122,7 +122,7 @@ opts = Mmg3DOptions(
     hmax=0.1,
     hausd=0.001,
     hgrad=1.3,      # Gradation: max ratio between adjacent edges
-    angle=45.0,     # Ridge detection angle (degrees)
+    ar=45,          # Ridge detection angle (degrees)
     verbose=1,
 )
 
@@ -131,7 +131,7 @@ result = mesh.remesh(opts)
 
 Options can be unpacked directly into `remesh()`:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(**opts.to_dict())

--- a/docs/tutorials/basic-remeshing.md
+++ b/docs/tutorials/basic-remeshing.md
@@ -85,14 +85,14 @@ For a uniform mesh with a single target size:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-# Using hsiz parameter (needs a fresh mesh — hsiz conflicts with prior metric)
+# Using hsiz parameter (reload: hsiz conflicts with prior metric)
 mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(hsiz=0.05)
 
 # Or using the convenience method
 mesh = mmgpy.read("input.mesh")
 result = mesh.remesh_uniform(size=0.05)
-mesh = mmgpy.read("input.mesh")  # Reset for subsequent examples
+mesh = mmgpy.read("input.mesh")
 ```
 
 ## Geometric Approximation
@@ -147,14 +147,14 @@ To improve quality without inserting/removing vertices:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-# Using the convenience method (needs fresh mesh — optim conflicts with prior metric)
+# Reload: optim conflicts with prior metric
 mesh = mmgpy.read("input.mesh")
 result = mesh.remesh_optimize()
 
 # Equivalent to
 mesh = mmgpy.read("input.mesh")
 result = mesh.remesh(optim=1, noinsert=1)
-mesh = mmgpy.read("input.mesh")  # Reset for subsequent examples
+mesh = mmgpy.read("input.mesh")
 ```
 
 This only moves existing vertices to improve element quality.
@@ -182,7 +182,7 @@ result = mesh.remesh(coarse_opts)
 mesh = mmgpy.read("input.mesh")
 opt_opts = Mmg3DOptions.optimize_only()
 result = mesh.remesh(opt_opts)
-mesh = mmgpy.read("input.mesh")  # Reset for subsequent examples
+mesh = mmgpy.read("input.mesh")
 ```
 
 ## Saving Results

--- a/docs/tutorials/levelset-extraction.md
+++ b/docs/tutorials/levelset-extraction.md
@@ -148,8 +148,6 @@ result = mesh.remesh_levelset(levelset)
 
 For surface meshes, level-set can extract curves:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import numpy as np
@@ -167,7 +165,7 @@ result = mesh.remesh_levelset(levelset)
 
 Combine level-set extraction with size parameters:
 
-<!-- pytest-codeblocks:cont -->
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh_levelset(

--- a/docs/tutorials/levelset-extraction.md
+++ b/docs/tutorials/levelset-extraction.md
@@ -179,8 +179,6 @@ result = mesh.remesh_levelset(
 
 ## Complete Example: Implicit Domain Meshing
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import numpy as np
@@ -219,7 +217,7 @@ mesh.save("double_sphere.vtk")
 
 ## Visualization
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 import pyvista as pv

--- a/docs/tutorials/levelset-extraction.md
+++ b/docs/tutorials/levelset-extraction.md
@@ -62,6 +62,8 @@ mesh = mmgpy.Mesh("unit_cube.mesh")
 
 ### Sphere
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 def sphere_levelset(coords, center=(0.5, 0.5, 0.5), radius=0.3):
     return (np.linalg.norm(coords - np.array(center), axis=1) - radius).reshape(-1, 1)
@@ -70,6 +72,8 @@ levelset = sphere_levelset(mesh.get_vertices())
 ```
 
 ### Torus
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 def torus_levelset(coords, R=0.5, r=0.15):
@@ -83,6 +87,8 @@ levelset = torus_levelset(mesh.get_vertices())
 ```
 
 ### Gyroid
+
+<!-- pytest-codeblocks:cont -->
 
 ```python
 def gyroid_levelset(coords, scale=2*np.pi):
@@ -98,6 +104,8 @@ levelset = gyroid_levelset(mesh.get_vertices())
 
 Combine shapes using min/max operations:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 # Union: min of level-sets
 def union(ls1, ls2):
@@ -112,10 +120,9 @@ def subtract(ls1, ls2):
     return np.maximum(ls1, -ls2)
 
 # Example: sphere with cylindrical hole
-sphere = sphere_levelset(vertices, center=(0.5, 0.5, 0.5), radius=0.4)
-cylinder = cylinder_levelset(vertices)  # Define appropriately
-
-result_ls = subtract(sphere, cylinder)
+# sphere = sphere_levelset(vertices, center=(0.5, 0.5, 0.5), radius=0.4)
+# cylinder = cylinder_levelset(vertices)  # Define appropriately
+# result_ls = subtract(sphere, cylinder)
 ```
 
 ## 2D Level-Set Remeshing
@@ -141,6 +148,8 @@ result = mesh.remesh_levelset(levelset)
 
 For surface meshes, level-set can extract curves:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import numpy as np
@@ -158,6 +167,8 @@ result = mesh.remesh_levelset(levelset)
 
 Combine level-set extraction with size parameters:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 result = mesh.remesh_levelset(
     levelset,
@@ -169,6 +180,8 @@ result = mesh.remesh_levelset(
 ```
 
 ## Complete Example: Implicit Domain Meshing
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy
@@ -208,6 +221,8 @@ mesh.save("double_sphere.vtk")
 
 ## Visualization
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import pyvista as pv
 
@@ -225,6 +240,8 @@ pv_mesh.plot(show_edges=True)
 3. **Narrow band**: If your level-set is only valid near the surface, ensure the background mesh is refined in that region
 
 4. **Validation**: After extraction, validate the mesh to ensure quality:
+
+   <!-- pytest-codeblocks:skip -->
 
    ```python
    assert mesh.validate(), "Extracted mesh has quality issues"

--- a/docs/tutorials/levelset-extraction.md
+++ b/docs/tutorials/levelset-extraction.md
@@ -104,7 +104,7 @@ levelset = gyroid_levelset(mesh.get_vertices())
 
 Combine shapes using min/max operations:
 
-<!-- pytest-codeblocks:cont -->
+<!-- pytest-codeblocks:skip -->
 
 ```python
 # Union: min of level-sets
@@ -120,9 +120,9 @@ def subtract(ls1, ls2):
     return np.maximum(ls1, -ls2)
 
 # Example: sphere with cylindrical hole
-# sphere = sphere_levelset(vertices, center=(0.5, 0.5, 0.5), radius=0.4)
-# cylinder = cylinder_levelset(vertices)  # Define appropriately
-# result_ls = subtract(sphere, cylinder)
+sphere = sphere_levelset(vertices, center=(0.5, 0.5, 0.5), radius=0.4)
+cylinder = cylinder_levelset(vertices)  # Define appropriately
+result_ls = subtract(sphere, cylinder)
 ```
 
 ## 2D Level-Set Remeshing

--- a/docs/tutorials/pyvista-integration.md
+++ b/docs/tutorials/pyvista-integration.md
@@ -240,6 +240,7 @@ mesh = mmgpy.Mesh(bunny)
 
 def remesh_callback(value):
     mesh.remesh(hmax=value, verbose=-1)
+    actor.mapper.SetInputData(mesh.to_pyvista())
     pl.update()
 
 pl = pv.Plotter()
@@ -279,8 +280,6 @@ pl.show()
 ## Complete Example
 
 Full workflow from PyVista primitive to remeshed output:
-
-<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/tutorials/pyvista-integration.md
+++ b/docs/tutorials/pyvista-integration.md
@@ -32,6 +32,8 @@ mesh.plot(color="lightblue", opacity=0.8, show_edges=False)
 
 For more complex visualizations, use the `vtk` property to access the PyVista mesh:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import pyvista as pv
@@ -177,6 +179,8 @@ pl.close()
 
 ### Transferring Scalar Fields
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import pyvista as pv
@@ -198,6 +202,8 @@ pv_mesh.plot(scalars="temperature", show_edges=True, cmap="coolwarm")
 
 ### From PyVista with Data
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import pyvista as pv
@@ -218,6 +224,8 @@ print(f"Elevation range: {elevation.min():.2f} to {elevation.max():.2f}")
 ## Interactive Workflows
 
 ### Interactive Refinement
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy
@@ -247,6 +255,8 @@ pl.show()
 
 ### Picking Points for Refinement
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import pyvista as pv
@@ -269,6 +279,8 @@ pl.show()
 ## Complete Example
 
 Full workflow from PyVista primitive to remeshed output:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/tutorials/pyvista-integration.md
+++ b/docs/tutorials/pyvista-integration.md
@@ -32,8 +32,6 @@ mesh.plot(color="lightblue", opacity=0.8, show_edges=False)
 
 For more complex visualizations, use the `vtk` property to access the PyVista mesh:
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import pyvista as pv
@@ -44,7 +42,6 @@ mesh.remesh(hmax=0.1)
 # Use mesh.vtk with any PyVista plotter
 plotter = pv.Plotter()
 plotter.add_mesh(mesh.vtk, show_edges=True, color="lightblue")
-plotter.add_mesh(other_mesh.vtk, color="red", opacity=0.5)
 plotter.show()
 ```
 
@@ -179,8 +176,6 @@ pl.close()
 
 ### Transferring Scalar Fields
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 import pyvista as pv
@@ -191,18 +186,17 @@ mesh = mmgpy.read("input.mesh")
 # Add a scalar field to the mesh
 vertices = mesh.get_vertices()
 scalar_field = np.sin(vertices[:, 0] * 2 * np.pi)
-mesh["temperature"] = scalar_field
+mesh.set_user_field("temperature", scalar_field)
 
-# Convert to PyVista - fields are preserved
+# Convert to PyVista and add user fields manually
 pv_mesh = mesh.to_pyvista()
+pv_mesh["temperature"] = mesh.get_user_field("temperature")
 
 # Plot with scalar field
 pv_mesh.plot(scalars="temperature", show_edges=True, cmap="coolwarm")
 ```
 
 ### From PyVista with Data
-
-<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy
@@ -213,11 +207,12 @@ import numpy as np
 sphere = pv.Sphere()
 sphere["elevation"] = sphere.points[:, 2]
 
-# Convert to mmgpy
+# Convert to mmgpy and store the field as a user field
 mesh = mmgpy.Mesh(sphere)
+mesh.set_user_field("elevation", sphere["elevation"])
 
 # Access the field
-elevation = mesh["elevation"]
+elevation = mesh.get_user_field("elevation")
 print(f"Elevation range: {elevation.min():.2f} to {elevation.max():.2f}")
 ```
 

--- a/docs/tutorials/pyvista-integration.md
+++ b/docs/tutorials/pyvista-integration.md
@@ -236,7 +236,7 @@ mesh = mmgpy.Mesh(bunny)
 def remesh_callback(value):
     mesh.remesh(hmax=value, verbose=-1)
     actor.mapper.SetInputData(mesh.to_pyvista())
-    pl.update()
+    pl.render()
 
 pl = pv.Plotter()
 actor = pl.add_mesh(mesh.to_pyvista(), show_edges=True)
@@ -245,6 +245,7 @@ pl.add_slider_widget(
     rng=[0.01, 0.1],
     value=0.05,
     title="hmax",
+    interaction_event="always",
 )
 pl.show()
 ```
@@ -264,7 +265,7 @@ def add_refinement(point):
     mesh.set_size_sphere(center=point, radius=0.1, size=0.01)
     mesh.remesh(hmax=0.1, verbose=-1)
     actor.mapper.SetInputData(mesh.to_pyvista())
-    pl.update()
+    pl.render()
 
 pl = pv.Plotter()
 actor = pl.add_mesh(pv_mesh, show_edges=True, pickable=True)

--- a/docs/tutorials/surface-remeshing.md
+++ b/docs/tutorials/surface-remeshing.md
@@ -70,7 +70,7 @@ result = mesh.remesh(
 
 ## Preserving Boundaries
 
-To keep vertices fixed during remeshing:
+To keep boundary edges fixed during remeshing:
 
 <!-- pytest-codeblocks:cont -->
 

--- a/docs/tutorials/surface-remeshing.md
+++ b/docs/tutorials/surface-remeshing.md
@@ -64,13 +64,13 @@ MMG can detect and preserve sharp edges based on the angle between adjacent face
 result = mesh.remesh(
     hmax=0.1,
     hausd=0.001,
-    angle=45,  # Edges sharper than 45° are preserved as ridges
+    ar=45,  # Edges sharper than 45° are preserved as ridges
 )
 ```
 
 ## Preserving Boundaries
 
-To keep boundary edges fixed during remeshing:
+To prevent vertex movement during remeshing (vertices stay in place, but edges may still be swapped or split):
 
 <!-- pytest-codeblocks:cont -->
 

--- a/docs/tutorials/surface-remeshing.md
+++ b/docs/tutorials/surface-remeshing.md
@@ -72,7 +72,7 @@ result = mesh.remesh(
 
 To keep boundary edges fixed during remeshing:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
@@ -143,8 +143,6 @@ mesh.to_pyvista().plot(show_edges=True)
 ## Visualization
 
 Visualize before and after:
-
-<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/docs/tutorials/surface-remeshing.md
+++ b/docs/tutorials/surface-remeshing.md
@@ -58,13 +58,13 @@ Setting `hausd` too large can cause loss of geometric features. Start with small
 
 MMG can detect and preserve sharp edges based on the angle between adjacent faces:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
     hmax=0.1,
     hausd=0.001,
-    angle=45.0,  # Edges sharper than 45° are preserved as ridges
+    angle=45,  # Edges sharper than 45° are preserved as ridges
 )
 ```
 
@@ -72,7 +72,7 @@ result = mesh.remesh(
 
 To keep boundary edges fixed during remeshing:
 
-<!-- pytest-codeblocks:cont -->
+<!-- pytest-codeblocks:skip -->
 
 ```python
 result = mesh.remesh(
@@ -85,7 +85,7 @@ result = mesh.remesh(
 
 For smooth surfaces without sharp features:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import MmgSOptions
@@ -94,7 +94,7 @@ opts = MmgSOptions(
     hmax=0.1,
     hausd=0.0001,  # Tight approximation
     hgrad=1.1,     # Gentle size gradation
-    angle=180.0,   # No ridge detection
+    ar=180,      # No ridge detection
 )
 
 result = mesh.remesh(opts)
@@ -104,7 +104,7 @@ result = mesh.remesh(opts)
 
 For industrial/CAD parts with sharp edges:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import MmgSOptions
@@ -113,7 +113,7 @@ opts = MmgSOptions(
     hmax=0.1,
     hausd=0.001,
     hgrad=1.3,
-    angle=30.0,    # Detect sharp edges
+    ar=30,       # Detect sharp edges
 )
 
 result = mesh.remesh(opts)
@@ -173,8 +173,6 @@ pl.show()
 
 ## Complete Example
 
-<!-- pytest-codeblocks:skip -->
-
 ```python
 import mmgpy
 from mmgpy import MmgSOptions
@@ -184,7 +182,7 @@ mesh = mmgpy.read("mechanical_part.stl")
 
 # Check initial state
 report = mesh.validate(detailed=True)
-print(f"Initial: {report.n_triangles} triangles, quality={report.quality.mean:.3f}")
+print(f"Initial quality: {report.quality.mean:.3f}")
 
 # Configure remeshing
 opts = MmgSOptions(
@@ -192,7 +190,7 @@ opts = MmgSOptions(
     hmax=0.05,
     hausd=0.0005,
     hgrad=1.2,
-    angle=30.0,
+    ar=30,
     verbose=1,
 )
 

--- a/docs/tutorials/surface-remeshing.md
+++ b/docs/tutorials/surface-remeshing.md
@@ -70,14 +70,14 @@ result = mesh.remesh(
 
 ## Preserving Boundaries
 
-To keep boundary edges fixed during remeshing:
+To keep vertices fixed during remeshing:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest-codeblocks:cont -->
 
 ```python
 result = mesh.remesh(
     hmax=0.1,
-    nosurf=1,  # Preserve surface points
+    nomove=1,  # Don't move existing vertices
 )
 ```
 

--- a/docs/tutorials/surface-remeshing.md
+++ b/docs/tutorials/surface-remeshing.md
@@ -41,6 +41,8 @@ print(f"Triangles: {result.triangles_before} -> {result.triangles_after}")
 
 The `hausd` parameter is crucial for surface meshes - it controls how closely the remeshed surface approximates the original:
 
+<!-- pytest-codeblocks:cont -->
+
 ```python
 # Tight approximation (more triangles, better geometry)
 result = mesh.remesh(hmax=0.1, hausd=0.0001)
@@ -56,6 +58,8 @@ Setting `hausd` too large can cause loss of geometric features. Start with small
 
 MMG can detect and preserve sharp edges based on the angle between adjacent faces:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(
     hmax=0.1,
@@ -68,6 +72,8 @@ result = mesh.remesh(
 
 To keep boundary edges fixed during remeshing:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 result = mesh.remesh(
     hmax=0.1,
@@ -78,6 +84,8 @@ result = mesh.remesh(
 ## Smooth Surface Remeshing
 
 For smooth surfaces without sharp features:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import MmgSOptions
@@ -95,6 +103,8 @@ result = mesh.remesh(opts)
 ## Mechanical Part Remeshing
 
 For industrial/CAD parts with sharp edges:
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 from mmgpy import MmgSOptions
@@ -134,6 +144,8 @@ mesh.to_pyvista().plot(show_edges=True)
 
 Visualize before and after:
 
+<!-- pytest-codeblocks:skip -->
+
 ```python
 import mmgpy
 import pyvista as pv
@@ -162,6 +174,8 @@ pl.show()
 ```
 
 ## Complete Example
+
+<!-- pytest-codeblocks:skip -->
 
 ```python
 import mmgpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ ignore = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "docs/conftest.py" = [
-    "INP001",  # conftest.py is not a package
+    "INP001",  # docs/ is not a package, conftest.py doesn't need __init__.py
 ]
 "tests/**/*.py" = [
     "S101",    # asserts allowed in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ dev = [
     "pytest-benchmark>=5.0.0",
     "pytest-cov>=4.1.0",
     "ruff>=0.14.10",
+    "pytest-codeblocks>=0.17.0",
 ]
 docs = [
     "mkdocs-material>=9.5.0",
@@ -138,6 +139,9 @@ ignore = [
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]
+"docs/conftest.py" = [
+    "INP001",  # conftest.py is not a package
+]
 "tests/**/*.py" = [
     "S101",    # asserts allowed in tests
     "T201",    # print statements allowed in tests for debugging
@@ -253,7 +257,7 @@ ignore = [
 # Progress module uses union types that cause complex type inference issues
 # Interactive module uses PyVista types that have incomplete stubs
 # UI module uses trame which has no type stubs
-exclude = ["tests/**", "scripts/**", "examples/**", "src/mmgpy/_progress.py", "src/mmgpy/interactive/**", "src/mmgpy/ui/**"]
+exclude = ["tests/**", "scripts/**", "examples/**", "docs/**", "src/mmgpy/_progress.py", "src/mmgpy/interactive/**", "src/mmgpy/ui/**"]
 
 [tool.ty.rules]
 # Ignore unresolved imports for C++ extension module that isn't available at type-check time

--- a/uv.lock
+++ b/uv.lock
@@ -1498,6 +1498,7 @@ dev = [
     { name = "pybind11" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
+    { name = "pytest-codeblocks" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "scikit-build-core" },
@@ -1542,6 +1543,7 @@ dev = [
     { name = "pybind11", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
+    { name = "pytest-codeblocks", specifier = ">=0.17.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "scikit-build-core", specifier = ">=0.11.5" },
@@ -2484,6 +2486,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
+]
+
+[[package]]
+name = "pytest-codeblocks"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/99/1ee3017a525dcb36566f0523938fbc20fb33ef8bf957205fafe6659f3a60/pytest_codeblocks-0.17.0.tar.gz", hash = "sha256:446e1babd182f54b4f113d567737a22f5405cade144c08a0085b2985247943d5", size = 11176, upload-time = "2023-09-17T19:17:31.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/2c/503f797c7ac1e35d81944f8fbcf3ea7a1965e435676570a833035d8d0937/pytest_codeblocks-0.17.0-py3-none-any.whl", hash = "sha256:b2aed8e66c3ce65435630783b391e7c7ae46f80b8220d3fa1bb7c689b36e78ad", size = 7716, upload-time = "2023-09-17T19:17:29.506Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Create `docs/conftest.py` that monkeypatches mmgpy I/O to intercept file reads (routing to pre-built 3D/2D/surface mesh factories), redirects saves to a temp directory, and patches `pv.read`/`pv.save` for PyVista code blocks
- Annotate all 22 docs markdown files with `pytest-codeblocks` directives (`cont` for chained blocks, `skip` for justified cases only)
- Add CI step in `build-and-test.yml` running `uv run pytest --codeblocks docs/ -v` on ubuntu+3.13
- Fix documentation bugs caught by the tests (wrong parameter names, nonexistent attributes, incorrect API usage, missing imports, undefined variables, metric conflicts, invalid options)
- Add visible "Requires ELAS library" admonitions before Lagrangian code blocks in general docs pages

Results: **94 passed, 25 skipped, 0 failures** across 119 test items in 22 docs files.

### Documentation bugs fixed

| Bug | Fix |
|-----|-----|
| `angle=45.0` in Options classes | `ar=45` (`ar` is the actual parameter name) |
| `mmgpy.from_pyvista(obj, mesh_type="surface")` | `mmgpy.Mesh(obj)` (auto-detect) |
| `mmgpy.to_pyvista(mesh)` | `mesh.to_pyvista()` (function doesn't accept Mesh wrapper) |
| `report.n_vertices` / `n_elements` / `n_triangles` | Removed (ValidationReport doesn't have these) |
| Slider callback missing mesh update | Added `actor.mapper.SetInputData(mesh.to_pyvista())` |
| `mesh["temperature"]` for user fields | `mesh.set_user_field()`/`mesh.get_user_field()` |
| `"temperature" in mesh` | `mesh.get_user_fields()` check |
| `mesh = mmgpy.Mesh(vertices, elements)` | `mesh = mmgpy.Mesh(vertices, tetrahedra)` |
| `sizes_to_metric()` for tensor field | `metrics.create_isotropic_metric()` (returns Nx6, not Nx1) |
| `metric = np.ones(N) * 0.1` for scalar metric | `metric = np.ones((N, 1)) * 0.1` (needs Nx1 shape) |
| `SphereSize(...)` with literal ellipsis | Replaced with actual values |
| 2D examples using `domain.mesh` (routed to 3D) | Changed to `domain_2d.mesh` |
| 2D metric missing `dim=2` | Added `metrics.create_isotropic_metric(sizes, dim=2)` |
| Standalone blocks missing `import mmgpy` | Added imports to make blocks self-contained |
| `other_mesh.vtk` (undefined variable) | Removed from example |
| `nosurf=1` on surface mesh | Changed to `nomove=1` (nosurf invalid for MMGS) |
| `mesh.save("output.stl")` on 3D tet mesh | Split into volume/surface examples |
| `hsiz`/`optim`/`remesh_optimize`/`remesh_uniform` after prior remesh | Reload fresh mesh before incompatible operations |
| `Mmg3DOptions.fine(hmax=0.01)` hangs | Changed to `hmax=0.05` |

### conftest improvements

- Removed `"domain"` from `_2D_KEYWORDS` so `domain.mesh` routes to 3D (correct for levelset/CFD examples)
- Added `pv.PolyData.save`/`pv.UnstructuredGrid.save` patching to redirect to tmp_dir

### Remaining 25 skips (all justified)

| Category | Count | Files |
|----------|-------|-------|
| ELAS dependency | 9 | `lagrangian.md` (7), `examples/index.md` (1), `concepts.md` (1) |
| Bash blocks | 6 | `cli.md` (5), `examples/index.md` (1) |
| Interactive widgets | 2 | `pyvista-integration.md` — `add_slider_widget`, `enable_point_picking` |
| Undefined pseudocode function | 2 | `metrics.md` (`compute_hessian`), `levelset-extraction.md` (`cylinder_levelset`) |
| Cross-chain dependency | 3 | `mesh-classes.md` (1), `options.md` (1), `adaptive-sizing.md` (1) |
| Intentional TypeError demo | 1 | `options.md` — `mesh.remesh(opts, verbose=1)` |
| Levelset size mismatch | 1 | `levelset-extraction.md` — vertex count changes after `remesh_levelset` |
| `mesh.validate()` after skipped block | 1 | `levelset-extraction.md` — `cont` from a skipped block |

Closes #190

## Test plan

- [x] `PYVISTA_OFF_SCREEN=true uv run pytest --codeblocks docs/ -v` — 94 passed, 25 skipped, 0 failures
- [x] `uv run pytest tests/ -x -q` — all 783 existing tests pass
- [x] Pre-commit hooks pass (ruff, codespell, prettier, etc.)