### PR TITLE
Add Python 3.14 support, build x86_64 wheels with manylinux_2_28

### DIFF
--- a/.github/scripts/download_vtk.sh
+++ b/.github/scripts/download_vtk.sh
@@ -8,7 +8,7 @@ set -e
 PLATFORM="${1:-linux}"
 ARCH="${2:-x86_64}"
 OUTPUT_DIR="${3:-./vtk-cache}"
-VTK_VERSION="${VTK_VERSION:-9.5.2}"
+VTK_VERSION="${VTK_VERSION:-9.6.0}"
 VTK_MAJOR_MINOR="${VTK_VERSION%.*}"
 
 echo "=== Downloading VTK ${VTK_VERSION} for ${PLATFORM}-${ARCH} ==="
@@ -70,28 +70,31 @@ elif [ "${PLATFORM}" = "macos" ] || [ "${PLATFORM}" = "darwin" ]; then
     mv lib*.dylib "${LIB_DIR}/" 2>/dev/null || true
 fi
 
-# Fix versioned symlinks (9.5.9.5 -> 9.5.2 -> 9.5)
+# Fix versioned symlinks (e.g. 9.6.9.6 -> 9.6.0 -> 9.6)
+# vtk-builds names libraries as lib*-MAJOR.MINOR.MAJOR.MINOR.{so,dylib},
+# but CMake and linkers look for lib*-MAJOR.MINOR.{so,dylib}.
 echo "Fixing VTK library symlinks..."
 cd "${LIB_DIR}"
 
+FULL_SUFFIX="${VTK_MAJOR_MINOR}.${VTK_MAJOR_MINOR}"
 if [ "${PLATFORM}" = "linux" ]; then
     for lib in *.so; do
         [ -e "$lib" ] || continue  # Skip if no match
-        if [[ "$lib" == *"-9.5.9.5.so" ]]; then
-            base=$(echo "$lib" | sed "s/-9.5.9.5.so//g")
-            rm -f "${base}-9.5.2.so" "${base}-9.5.so" 2>/dev/null || true
-            ln -sf "${base}-9.5.9.5.so" "${base}-9.5.2.so"
-            ln -sf "${base}-9.5.9.5.so" "${base}-9.5.so"
+        if [[ "$lib" == *"-${FULL_SUFFIX}.so" ]]; then
+            base=$(echo "$lib" | sed "s/-${FULL_SUFFIX}.so//g")
+            rm -f "${base}-${VTK_VERSION}.so" "${base}-${VTK_MAJOR_MINOR}.so" 2>/dev/null || true
+            ln -sf "${base}-${FULL_SUFFIX}.so" "${base}-${VTK_VERSION}.so"
+            ln -sf "${base}-${FULL_SUFFIX}.so" "${base}-${VTK_MAJOR_MINOR}.so"
         fi
     done
 elif [ "${PLATFORM}" = "macos" ] || [ "${PLATFORM}" = "darwin" ]; then
     for lib in *.dylib; do
         [ -e "$lib" ] || continue  # Skip if no match
-        if [[ "$lib" == *"-9.5.9.5.dylib" ]]; then
-            base=$(echo "$lib" | sed "s/-9.5.9.5.dylib//g")
-            rm -f "${base}-9.5.2.dylib" "${base}-9.5.dylib" 2>/dev/null || true
-            ln -sf "${base}-9.5.9.5.dylib" "${base}-9.5.2.dylib"
-            ln -sf "${base}-9.5.9.5.dylib" "${base}-9.5.dylib"
+        if [[ "$lib" == *"-${FULL_SUFFIX}.dylib" ]]; then
+            base=$(echo "$lib" | sed "s/-${FULL_SUFFIX}.dylib//g")
+            rm -f "${base}-${VTK_VERSION}.dylib" "${base}-${VTK_MAJOR_MINOR}.dylib" 2>/dev/null || true
+            ln -sf "${base}-${FULL_SUFFIX}.dylib" "${base}-${VTK_VERSION}.dylib"
+            ln -sf "${base}-${FULL_SUFFIX}.dylib" "${base}-${VTK_MAJOR_MINOR}.dylib"
         fi
     done
 fi

--- a/.github/scripts/download_vtk.sh
+++ b/.github/scripts/download_vtk.sh
@@ -17,6 +17,8 @@ RELEASE_TAG="VTK-${VTK_VERSION}-shared"
 
 case "${PLATFORM}" in
     linux)
+        # vtk-builds publishes manylinux2014 archives; these remain forward-compatible
+        # with the manylinux_2_28 wheel image used in build-wheels.yml.
         VTK_FILE="vtk-manylinux2014_${ARCH}.tar.gz"
         LIB_EXT="so"
         LIB_DIR="lib64"

--- a/.github/scripts/download_vtk.sh
+++ b/.github/scripts/download_vtk.sh
@@ -116,7 +116,7 @@ fi
 
 # Create bin directory with stub executables (needed by CMake)
 mkdir -p bin
-for exe in vtkWrapHierarchy vtkWrapPython vtkWrapPythonInit vtkParseJava vtkWrapJava vtkWrapSerDes vtkProbeOpenGLVersion; do
+for exe in vtkWrapHierarchy vtkWrapPython vtkWrapPythonInit vtkParseJava vtkWrapJava vtkWrapJavaScript vtkWrapSerDes vtkProbeOpenGLVersion; do
     touch "bin/${exe}-${VTK_MAJOR_MINOR}"
     chmod +x "bin/${exe}-${VTK_MAJOR_MINOR}"
 done

--- a/.github/scripts/vtk_modules.py
+++ b/.github/scripts/vtk_modules.py
@@ -74,6 +74,7 @@ ESSENTIAL_VTK_MODULES: set[str] = {
     "metaio",
     "png",
     "pugixml",
+    "scn",
     "sys",
     "tiff",
     "token",

--- a/.github/scripts/vtk_modules.py
+++ b/.github/scripts/vtk_modules.py
@@ -10,15 +10,15 @@ import re
 def get_vtk_major_minor() -> str:
     """Get VTK major.minor version from environment or auto-detect.
 
-    Uses VTK_VERSION environment variable (e.g., "9.4.1" -> "9.4").
-    Falls back to "9.4" if not set.
+    Uses VTK_VERSION environment variable (e.g., "9.6.0" -> "9.6").
+    Falls back to "9.6" if not set.
     """
     vtk_version = os.environ.get("VTK_VERSION", "")
     if vtk_version:
         match = re.match(r"(\d+\.\d+)", vtk_version)
         if match:
             return match.group(1)
-    return "9.4"
+    return "9.6"
 
 
 VTK_MAJOR_MINOR: str = get_vtk_major_minor()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-latest
         python-version:
           - "3.10"
-          - "3.13"
+          - "3.14"
 
     runs-on: ${{ matrix.os }}
 
@@ -100,14 +100,14 @@ jobs:
         run: uv run pytest --cov=src/mmgpy --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Test documentation code blocks
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         env:
           PYVISTA_OFF_SCREEN: "true"
           MPLBACKEND: Agg
         run: uv run pytest --codeblocks docs/ -v
 
       - name: Run examples
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         env:
           MPLBACKEND: Agg
           PYVISTA_OFF_SCREEN: "true"
@@ -127,7 +127,7 @@ jobs:
         shell: bash
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,7 +45,7 @@ jobs:
           # but those older glibc binaries remain compatible in a manylinux_2_28 wheel.
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -95,7 +95,7 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -183,7 +183,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,7 +45,7 @@ jobs:
           # but those older glibc binaries remain compatible in a manylinux_2_28 wheel.
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.0
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -95,7 +95,7 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.0
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.0
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -183,7 +183,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.0
+        uses: pypa/cibuildwheel@v3.4
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./.github/scripts/download_vtk.sh linux x86_64 ./vtk-cache
       - name: Build manylinux_2_28 x86_64 wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp313-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           CIBW_ARCHS_LINUX: x86_64
           # vtk-builds currently publishes manylinux2014 x86_64 archives only,
           # but those older glibc binaries remain compatible in a manylinux_2_28 wheel.
@@ -91,7 +91,7 @@ jobs:
         run: ./.github/scripts/download_vtk.sh linux aarch64 ./vtk-cache
       - name: Build manylinux_2_28 aarch64 wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp313-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
@@ -133,7 +133,7 @@ jobs:
           echo "VTK_VERSION=$VTK_VERSION" >> $GITHUB_ENV
       - name: Build wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp313-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
         uses: pypa/cibuildwheel@v3.0
       - name: Upload wheels as artifacts
@@ -181,7 +181,7 @@ jobs:
         run: ./.github/scripts/download_vtk.sh macos arm64 ./vtk-cache
       - name: Build wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp313-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
         uses: pypa/cibuildwheel@v3.0
       - name: Upload wheels as artifacts

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -28,6 +28,7 @@ jobs:
           VTK_VERSION=$(grep 'vtk_version' pyproject.toml | sed 's/.*"\([0-9.]*\)".*/\1/')
           echo "version=$VTK_VERSION" >> $GITHUB_OUTPUT
           echo "VTK_VERSION=$VTK_VERSION" >> $GITHUB_ENV
+          echo "VTK_MAJOR_MINOR=${VTK_VERSION%.*}" >> $GITHUB_ENV
       - name: Cache VTK
         id: cache-vtk
         uses: actions/cache@v4
@@ -80,6 +81,7 @@ jobs:
           VTK_VERSION=$(grep 'vtk_version' pyproject.toml | sed 's/.*"\([0-9.]*\)".*/\1/')
           echo "version=$VTK_VERSION" >> $GITHUB_OUTPUT
           echo "VTK_VERSION=$VTK_VERSION" >> $GITHUB_ENV
+          echo "VTK_MAJOR_MINOR=${VTK_VERSION%.*}" >> $GITHUB_ENV
       - name: Cache VTK
         id: cache-vtk
         uses: actions/cache@v4
@@ -131,6 +133,7 @@ jobs:
           VTK_VERSION=$(grep 'vtk_version' pyproject.toml | sed 's/.*"\([0-9.]*\)".*/\1/')
           echo "version=$VTK_VERSION" >> $GITHUB_OUTPUT
           echo "VTK_VERSION=$VTK_VERSION" >> $GITHUB_ENV
+          echo "VTK_MAJOR_MINOR=${VTK_VERSION%.*}" >> $GITHUB_ENV
       - name: Build wheels
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
@@ -170,6 +173,7 @@ jobs:
           VTK_VERSION=$(grep 'vtk_version' pyproject.toml | sed 's/.*"\([0-9.]*\)".*/\1/')
           echo "version=$VTK_VERSION" >> $GITHUB_OUTPUT
           echo "VTK_VERSION=$VTK_VERSION" >> $GITHUB_ENV
+          echo "VTK_MAJOR_MINOR=${VTK_VERSION%.*}" >> $GITHUB_ENV
       - name: Cache VTK
         id: cache-vtk
         uses: actions/cache@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,11 +37,13 @@ jobs:
       - name: Download and prepare VTK
         if: steps.cache-vtk.outputs.cache-hit != 'true'
         run: ./.github/scripts/download_vtk.sh linux x86_64 ./vtk-cache
-      - name: Build manylinux2014 x86_64 wheels
+      - name: Build manylinux_2_28 x86_64 wheels
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp313-*' || '' }}
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          # vtk-builds currently publishes manylinux2014 x86_64 archives only,
+          # but those older glibc binaries remain compatible in a manylinux_2_28 wheel.
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
         uses: pypa/cibuildwheel@v3.0
       - name: Upload wheels as artifacts

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,7 +45,7 @@ jobs:
           # but those older glibc binaries remain compatible in a manylinux_2_28 wheel.
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -95,7 +95,7 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -183,7 +183,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           VTK_VERSION: ${{ steps.vtk.outputs.version }}
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -17,7 +17,7 @@ jobs:
           - macos-latest
         python-version:
           - "3.10"
-          - "3.13"
+          - "3.14"
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Build Linux x86_64 wheels with `manylinux_2_28` and remove the `scipy<1.17` cap so Python 3.11+ can install newer SciPy releases.
+
 ## [0.6.0] - 2026-03-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Python 3.14 support.
+- Free-threaded Python 3.14 (`cp314t`) wheel builds for Linux.
 
 ### Changed
 
+- Upgrade build-time VTK from 9.5.2 to 9.6.0.
 - Build Linux x86_64 wheels with `manylinux_2_28` and remove the `scipy<1.17` cap so newer SciPy releases can be installed.
 - Widen VTK constraint from `>=9.5,<9.6` to `>=9.5,<9.7` to allow VTK 9.6 (required for Python 3.14 wheels).
+- Bump `pyvista` lower bound from `>=0.46.4` to `>=0.47` (first version compatible with VTK 9.6).
 - Add upper bounds to all runtime and optional dependencies.
+- Parameterize VTK version in cibuildwheel config to avoid hardcoded paths.
+- Bump cibuildwheel from v3.0 to v3.4.
+
+## [0.7.1] - 2026-03-16
+
+### Fixed
+
+- Update examples to use `Mesh` class instead of deprecated `MmgMesh2D`/`MmgMesh3D`/`MmgMeshS` ([#186](https://github.com/kmarchais/mmgpy/pull/186))
+
+## [0.7.0] - 2026-03-15
+
+### Added
+
+- Support for system-installed MMG via `mmgsuite` for conda builds ([#183](https://github.com/kmarchais/mmgpy/pull/183))
 
 ## [0.6.0] - 2026-03-08
 
@@ -169,7 +186,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimized wheel sizes (under 100MB) for PyPI upload
 - Linux manylinux wheels with proper platform tags
 
-[Unreleased]: https://github.com/kmarchais/mmgpy/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/kmarchais/mmgpy/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/kmarchais/mmgpy/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/kmarchais/mmgpy/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/kmarchais/mmgpy/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/kmarchais/mmgpy/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/kmarchais/mmgpy/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Python 3.14 support.
+
 ### Changed
 
-- Build Linux x86_64 wheels with `manylinux_2_28` and remove the `scipy<1.17` cap so Python 3.11+ can install newer SciPy releases.
+- Build Linux x86_64 wheels with `manylinux_2_28` and remove the `scipy<1.17` cap so newer SciPy releases can be installed.
+- Widen VTK constraint from `>=9.5,<9.6` to `>=9.5,<9.7` to allow VTK 9.6 (required for Python 3.14 wheels).
+- Add upper bounds to all runtime and optional dependencies.
 
 ## [0.6.0] - 2026-03-08
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ project(mmgpy VERSION ${MMGPY_NUMERIC_VERSION})
 
 option(MMGPY_CONDA_BUILD "Building for conda-forge (use system MMG, skip wheel-specific bundling/RPATH)" OFF)
 
+# Prevent Windows.h from defining min/max macros (conflicts with VTK 9.6 headers)
+if(MSVC)
+    add_definitions(-DNOMINMAX)
+endif()
+
 include(GNUInstallDirs)
 
 # Find Python - let scikit-build-core handle it in wheel builds

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -38,7 +38,7 @@ requirements:
     - meshio >=5.3.5
     - pyvista >=0.47.0
     - rich >=13.0.0
-    - scipy >=1.11.0,<1.17
+    - scipy >=1.11.0,<2
     - mmgsuite * vtk*
     - vtk >=9.6,<9.7
     - if: python < '3.11'

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -40,6 +40,8 @@ requirements:
     - rich >=13.0.0
     - scipy >=1.11.0,<2
     - mmgsuite * vtk*
+    # conda-forge ships VTK 9.6 for all Python versions, so no marker split
+    # needed here (unlike pyproject.toml which allows 9.5.x for Python <3.14).
     - vtk >=9.6,<9.7
     - if: python < '3.11'
       then: typing-extensions >=4.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,6 +269,8 @@ unresolved-import = "ignore"
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
+# cp314 is not in cibuildwheel's default set yet
+enable = ["cpython-prerelease"]
 # Skip 32-bit builds and musllinux (VTK doesn't provide musllinux wheels)
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 test-command = 'python -c "import mmgpy"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "rich>=13.0.0,<15",
     "scipy>=1.11.0,<2",
     "typing-extensions>=4.0.0,<5; python_version < '3.11'",
-    "vtk>=9.5,<9.7",
+    "vtk>=9.5,<9.7; python_version < '3.14'",
+    "vtk>=9.6,<9.7; python_version >= '3.14'",
 ]
 authors = [{ name = "Kevin Marchais", email = "kevinmarchais@gmail.com" }]
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,13 @@ description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "meshio>=5.3.5",
-    "numpy>=2.0.2",
-    "patchelf>=0.17.2.4; sys_platform == 'linux'",
-    "pyvista>=0.46.4",
-    "rich>=13.0.0",
-    "scipy>=1.11.0",
-    "typing-extensions>=4.0.0; python_version < '3.11'",
+    "meshio>=5.3.5,<6",
+    "numpy>=2.0.2,<3",
+    "patchelf>=0.17.2.4,<1; sys_platform == 'linux'",
+    "pyvista>=0.46.4,<1",
+    "rich>=13.0.0,<15",
+    "scipy>=1.11.0,<2",
+    "typing-extensions>=4.0.0,<5; python_version < '3.11'",
     "vtk>=9.5,<9.6",
 ]
 authors = [{ name = "Kevin Marchais", email = "kevinmarchais@gmail.com" }]
@@ -42,11 +42,11 @@ classifiers = [
 # Note: dependency-groups below are for local dev with uv sync --group <name>
 [project.optional-dependencies]
 ui = [
-    "pywebview>=6.1",
-    "trame>=3.12.0",
-    "trame-vtk>=2.10.2",
-    "trame-vtklocal>=0.16.0",
-    "trame-vuetify>=3.2.0",
+    "pywebview>=6.1,<7",
+    "trame>=3.12.0,<4",
+    "trame-vtk>=2.10.2,<3",
+    "trame-vtklocal>=0.16.0,<1",
+    "trame-vuetify>=3.2.0,<4",
 ]
 
 [tool.mmgpy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "patchelf>=0.17.2.4; sys_platform == 'linux'",
     "pyvista>=0.46.4",
     "rich>=13.0.0",
-    "scipy>=1.11.0,<1.17",
+    "scipy>=1.11.0",
     "typing-extensions>=4.0.0; python_version < '3.11'",
     "vtk>=9.5,<9.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,8 +269,6 @@ unresolved-import = "ignore"
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
-# cp314 is not in cibuildwheel's default set yet
-enable = ["cpython-prerelease"]
 # Skip 32-bit builds and musllinux (VTK doesn't provide musllinux wheels)
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 test-command = 'python -c "import mmgpy"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ ui = [
 
 [tool.mmgpy]
 mmg_version = "5.8.0"
-vtk_version = "9.5.2"
+vtk_version = "9.6.0"
 
 [tool.uv]
 # Allow editable installs without --no-build-isolation flag
@@ -285,7 +285,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx*"
 inherit.environment = "append"
-environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.5", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include" }
+environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.6", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include" }
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
@@ -300,7 +300,7 @@ before-all = [
     'ln -sf /tmp/vtk/include /tmp/include || true',
     'echo "VTK ready: $(ls /tmp/vtk/lib64/libvtk*.so 2>/dev/null | wc -l) libraries"',
 ]
-environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.5", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/usr/lib:/usr/local/lib:/opt" }
+environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.6", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/usr/lib:/usr/local/lib:/opt" }
 environment-pass = ["VTK_VERSION"]
 # Run auditwheel with full VTK (needs all deps), then optimize_wheels.py filters after
 repair-wheel-command = "LD_LIBRARY_PATH=/tmp/vtk/lib64:$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} --exclude libmmg2d.so.5 --exclude libmmg3d.so.5 --exclude libmmgs.so.5 {wheel} && python3 /project/.github/scripts/optimize_wheels.py {dest_dir}/*.whl && for whl in {dest_dir}/*.whl; do size=$(stat -c%s \"$whl\"); if [ \"$size\" -gt 104857600 ]; then echo \"ERROR: Wheel exceeds 100MB PyPI limit: $whl ($size bytes)\"; exit 1; fi; done"
@@ -316,7 +316,7 @@ before-all = [
     'ln -sf /tmp/vtk/include /tmp/include || true',
     'echo "VTK ready: $(ls /tmp/vtk/lib/libvtk*.dylib 2>/dev/null | wc -l) libraries"',
 ]
-environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.5", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include", "MACOSX_DEPLOYMENT_TARGET" = "10.15" }
+environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.6", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include", "MACOSX_DEPLOYMENT_TARGET" = "10.15" }
 # Skip delocate due to VTK install_name issues; optimize wheel and copy
 repair-wheel-command = "python3 $PWD/.github/scripts/optimize_wheels.py {wheel} && cp {wheel} {dest_dir}/"
 
@@ -324,9 +324,9 @@ repair-wheel-command = "python3 $PWD/.github/scripts/optimize_wheels.py {wheel} 
 archs = ["AMD64"]
 before-all = [
     "powershell -Command \"$VTK_VERSION = $env:VTK_VERSION; $RELEASE_TAG = 'VTK-' + $VTK_VERSION + '-shared'; $VTK_FILE = 'vtk-Windows-x86_64.tar.gz'; $VTK_URL = 'https://github.com/sanguinariojoe/vtk-builds/releases/download/' + $RELEASE_TAG + '/' + $VTK_FILE; Invoke-WebRequest -Uri $VTK_URL -OutFile vtk.tar.gz; New-Item -Path 'C:/vtk' -ItemType Directory -Force; tar -xzf vtk.tar.gz -C C:/vtk --strip-components=1\"",
-    "powershell -Command \"New-Item -Path 'C:/lib' -ItemType Directory -Force; New-Item -Path 'C:/bin' -ItemType Directory -Force; New-Item -Path 'C:/include' -ItemType Directory -Force; Move-Item 'C:/vtk/*.lib' 'C:/lib/' -Force; Move-Item 'C:/vtk/*.dll' 'C:/bin/' -Force; Move-Item 'C:/vtk/*.exe' 'C:/bin/' -Force; Move-Item 'C:/vtk/vtk-9.5' 'C:/include/vtk-9.5' -Force\"",
+    "powershell -Command \"New-Item -Path 'C:/lib' -ItemType Directory -Force; New-Item -Path 'C:/bin' -ItemType Directory -Force; New-Item -Path 'C:/include' -ItemType Directory -Force; Move-Item 'C:/vtk/*.lib' 'C:/lib/' -Force; Move-Item 'C:/vtk/*.dll' 'C:/bin/' -Force; Move-Item 'C:/vtk/*.exe' 'C:/bin/' -Force; Move-Item 'C:/vtk/vtk-9.6' 'C:/include/vtk-9.6' -Force\"",
 ]
-environment = { VTK_DIR = "C:/vtk/cmake/vtk-9.5" }
+environment = { VTK_DIR = "C:/vtk/cmake/vtk-9.6" }
 repair-wheel-command = "uvx delvewheel repair -w {dest_dir} {wheel} --add-path C:/bin --ignore-in-wheel && powershell -Command \"Get-ChildItem '{dest_dir}/*.whl' | ForEach-Object { if ($_.Length -gt 104857600) { throw ('Wheel exceeds 100MB PyPI limit: ' + $_.Name + ' (' + $_.Length + ' bytes)') } }\""
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx*"
 inherit.environment = "append"
-environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.6", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include" }
+environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-$VTK_MAJOR_MINOR", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include" }
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
@@ -301,8 +301,8 @@ before-all = [
     'ln -sf /tmp/vtk/include /tmp/include || true',
     'echo "VTK ready: $(ls /tmp/vtk/lib64/libvtk*.so 2>/dev/null | wc -l) libraries"',
 ]
-environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.6", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/usr/lib:/usr/local/lib:/opt" }
-environment-pass = ["VTK_VERSION"]
+environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-$VTK_MAJOR_MINOR", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/usr/lib:/usr/local/lib:/opt" }
+environment-pass = ["VTK_VERSION", "VTK_MAJOR_MINOR"]
 # Run auditwheel with full VTK (needs all deps), then optimize_wheels.py filters after
 repair-wheel-command = "LD_LIBRARY_PATH=/tmp/vtk/lib64:$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} --exclude libmmg2d.so.5 --exclude libmmg3d.so.5 --exclude libmmgs.so.5 {wheel} && python3 /project/.github/scripts/optimize_wheels.py {dest_dir}/*.whl && for whl in {dest_dir}/*.whl; do size=$(stat -c%s \"$whl\"); if [ \"$size\" -gt 104857600 ]; then echo \"ERROR: Wheel exceeds 100MB PyPI limit: $whl ($size bytes)\"; exit 1; fi; done"
 
@@ -317,7 +317,7 @@ before-all = [
     'ln -sf /tmp/vtk/include /tmp/include || true',
     'echo "VTK ready: $(ls /tmp/vtk/lib/libvtk*.dylib 2>/dev/null | wc -l) libraries"',
 ]
-environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-9.6", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include", "MACOSX_DEPLOYMENT_TARGET" = "10.15" }
+environment = { "VTK_DIR" = "/tmp/vtk/cmake/vtk-$VTK_MAJOR_MINOR", "CMAKE_PREFIX_PATH" = "/tmp/vtk:/tmp", "CMAKE_IGNORE_PATH" = "/opt/homebrew:/opt/homebrew/lib:/opt/homebrew/include:/usr/local:/usr/local/lib:/usr/local/include", "MACOSX_DEPLOYMENT_TARGET" = "10.15" }
 # Skip delocate due to VTK install_name issues; optimize wheel and copy
 repair-wheel-command = "python3 $PWD/.github/scripts/optimize_wheels.py {wheel} && cp {wheel} {dest_dir}/"
 
@@ -325,9 +325,9 @@ repair-wheel-command = "python3 $PWD/.github/scripts/optimize_wheels.py {wheel} 
 archs = ["AMD64"]
 before-all = [
     "powershell -Command \"$VTK_VERSION = $env:VTK_VERSION; $RELEASE_TAG = 'VTK-' + $VTK_VERSION + '-shared'; $VTK_FILE = 'vtk-Windows-x86_64.tar.gz'; $VTK_URL = 'https://github.com/sanguinariojoe/vtk-builds/releases/download/' + $RELEASE_TAG + '/' + $VTK_FILE; Invoke-WebRequest -Uri $VTK_URL -OutFile vtk.tar.gz; New-Item -Path 'C:/vtk' -ItemType Directory -Force; tar -xzf vtk.tar.gz -C C:/vtk --strip-components=1\"",
-    "powershell -Command \"New-Item -Path 'C:/lib' -ItemType Directory -Force; New-Item -Path 'C:/bin' -ItemType Directory -Force; New-Item -Path 'C:/include' -ItemType Directory -Force; Move-Item 'C:/vtk/*.lib' 'C:/lib/' -Force; Move-Item 'C:/vtk/*.dll' 'C:/bin/' -Force; Move-Item 'C:/vtk/*.exe' 'C:/bin/' -Force; Move-Item 'C:/vtk/vtk-9.6' 'C:/include/vtk-9.6' -Force\"",
+    "powershell -Command \"$VTK_MM = $env:VTK_VERSION.Substring(0, $env:VTK_VERSION.LastIndexOf('.')); New-Item -Path 'C:/lib' -ItemType Directory -Force; New-Item -Path 'C:/bin' -ItemType Directory -Force; New-Item -Path 'C:/include' -ItemType Directory -Force; Move-Item 'C:/vtk/*.lib' 'C:/lib/' -Force; Move-Item 'C:/vtk/*.dll' 'C:/bin/' -Force; Move-Item 'C:/vtk/*.exe' 'C:/bin/' -Force; Move-Item \\\"C:/vtk/vtk-$VTK_MM\\\" \\\"C:/include/vtk-$VTK_MM\\\" -Force\"",
 ]
-environment = { VTK_DIR = "C:/vtk/cmake/vtk-9.6" }
+environment = { VTK_DIR = "C:/vtk/cmake/vtk-$VTK_MAJOR_MINOR" }
 repair-wheel-command = "uvx delvewheel repair -w {dest_dir} {wheel} --add-path C:/bin --ignore-in-wheel && powershell -Command \"Get-ChildItem '{dest_dir}/*.whl' | ForEach-Object { if ($_.Length -gt 104857600) { throw ('Wheel exceeds 100MB PyPI limit: ' + $_.Name + ' (' + $_.Length + ' bytes)') } }\""
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "rich>=13.0.0,<15",
     "scipy>=1.11.0,<2",
     "typing-extensions>=4.0.0,<5; python_version < '3.11'",
-    "vtk>=9.5,<9.6",
+    "vtk>=9.5,<9.7",
 ]
 authors = [{ name = "Kevin Marchais", email = "kevinmarchais@gmail.com" }]
 license = { text = "MIT" }
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 # Optional dependencies for pip/uvx users (e.g., pip install mmgpy[ui])
@@ -266,7 +267,7 @@ unresolved-import = "ignore"
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-build = "cp310-* cp311-* cp312-* cp313-*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 # Skip 32-bit builds and musllinux (VTK doesn't provide musllinux wheels)
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 test-command = 'python -c "import mmgpy"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "meshio>=5.3.5,<6",
     "numpy>=2.0.2,<3",
     "patchelf>=0.17.2.4,<1; sys_platform == 'linux'",
-    "pyvista>=0.46.4,<1",
+    "pyvista>=0.47,<1",
     "rich>=13.0.0,<15",
     "scipy>=1.11.0,<2",
     "typing-extensions>=4.0.0,<5; python_version < '3.11'",
@@ -268,9 +268,10 @@ unresolved-import = "ignore"
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
-# Skip 32-bit builds and musllinux (VTK doesn't provide musllinux wheels)
-skip = "*-win32 *-manylinux_i686 *-musllinux*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
+# Skip 32-bit builds, musllinux (VTK doesn't provide musllinux wheels),
+# and free-threaded on macOS/Windows (VTK only has cp314t wheels for Linux).
+skip = "*-win32 *-manylinux_i686 *-musllinux* cp314t-macosx* cp314t-win*"
 test-command = 'python -c "import mmgpy"'
 build-verbosity = 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -1541,7 +1541,7 @@ requires-dist = [
     { name = "pyvista", specifier = ">=0.46.4" },
     { name = "pywebview", marker = "extra == 'ui'", specifier = ">=6.1" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "scipy", specifier = ">=1.11.0,<1.17" },
+    { name = "scipy", specifier = ">=1.11.0" },
     { name = "trame", marker = "extra == 'ui'", specifier = ">=3.12.0" },
     { name = "trame-vtk", marker = "extra == 'ui'", specifier = ">=2.10.2" },
     { name = "trame-vtklocal", marker = "extra == 'ui'", specifier = ">=0.16.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1535,18 +1535,18 @@ ui = [
 
 [package.metadata]
 requires-dist = [
-    { name = "meshio", specifier = ">=5.3.5" },
-    { name = "numpy", specifier = ">=2.0.2" },
-    { name = "patchelf", marker = "sys_platform == 'linux'", specifier = ">=0.17.2.4" },
-    { name = "pyvista", specifier = ">=0.46.4" },
-    { name = "pywebview", marker = "extra == 'ui'", specifier = ">=6.1" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "scipy", specifier = ">=1.11.0" },
-    { name = "trame", marker = "extra == 'ui'", specifier = ">=3.12.0" },
-    { name = "trame-vtk", marker = "extra == 'ui'", specifier = ">=2.10.2" },
-    { name = "trame-vtklocal", marker = "extra == 'ui'", specifier = ">=0.16.0" },
-    { name = "trame-vuetify", marker = "extra == 'ui'", specifier = ">=3.2.0" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
+    { name = "meshio", specifier = ">=5.3.5,<6" },
+    { name = "numpy", specifier = ">=2.0.2,<3" },
+    { name = "patchelf", marker = "sys_platform == 'linux'", specifier = ">=0.17.2.4,<1" },
+    { name = "pyvista", specifier = ">=0.46.4,<1" },
+    { name = "pywebview", marker = "extra == 'ui'", specifier = ">=6.1,<7" },
+    { name = "rich", specifier = ">=13.0.0,<15" },
+    { name = "scipy", specifier = ">=1.11.0,<2" },
+    { name = "trame", marker = "extra == 'ui'", specifier = ">=3.12.0,<4" },
+    { name = "trame-vtk", marker = "extra == 'ui'", specifier = ">=2.10.2,<3" },
+    { name = "trame-vtklocal", marker = "extra == 'ui'", specifier = ">=0.16.0,<1" },
+    { name = "trame-vuetify", marker = "extra == 'ui'", specifier = ">=3.2.0,<4" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5" },
     { name = "vtk", specifier = ">=9.5,<9.6" },
 ]
 provides-extras = ["ui"]

--- a/uv.lock
+++ b/uv.lock
@@ -1547,7 +1547,7 @@ requires-dist = [
     { name = "trame-vtklocal", marker = "extra == 'ui'", specifier = ">=0.16.0,<1" },
     { name = "trame-vuetify", marker = "extra == 'ui'", specifier = ">=3.2.0,<4" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5" },
-    { name = "vtk", specifier = ">=9.5,<9.6" },
+    { name = "vtk", specifier = ">=9.5,<9.7" },
 ]
 provides-extras = ["ui"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -657,10 +657,12 @@ name = "cyclopts"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version >= '3.14'" },
-    { name = "docstring-parser", marker = "python_full_version >= '3.14'" },
-    { name = "rich", marker = "python_full_version >= '3.14'" },
-    { name = "rich-rst", marker = "python_full_version >= '3.14'" },
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/e7/3e26855c046ac527cf94d890f6698e703980337f22ea7097e02b35b910f9/cyclopts-4.10.0.tar.gz", hash = "sha256:0ae04a53274e200ef3477c8b54de63b019bc6cd0162d75c718bf40c9c3fb5268", size = 166394, upload-time = "2026-03-14T14:09:31.043Z" }
 wheels = [
@@ -1522,8 +1524,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "patchelf", marker = "sys_platform == 'linux'" },
-    { name = "pyvista", version = "0.46.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pyvista", version = "0.47.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pyvista" },
     { name = "rich" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1575,7 +1576,7 @@ requires-dist = [
     { name = "meshio", specifier = ">=5.3.5,<6" },
     { name = "numpy", specifier = ">=2.0.2,<3" },
     { name = "patchelf", marker = "sys_platform == 'linux'", specifier = ">=0.17.2.4,<1" },
-    { name = "pyvista", specifier = ">=0.46.4,<1" },
+    { name = "pyvista", specifier = ">=0.47,<1" },
     { name = "pywebview", marker = "extra == 'ui'", specifier = ">=6.1,<7" },
     { name = "rich", specifier = ">=13.0.0,<15" },
     { name = "scipy", specifier = ">=1.11.0,<2" },
@@ -2598,42 +2599,18 @@ wheels = [
 
 [[package]]
 name = "pyvista"
-version = "0.46.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11' and python_full_version < '3.14'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "matplotlib", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pillow", marker = "python_full_version < '3.14'" },
-    { name = "pooch", marker = "python_full_version < '3.14'" },
-    { name = "scooby", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "vtk", version = "9.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/bd/a4e4131b2d4b908a060b43f8346ce863d76a6fecf8a1c2c845602e96c610/pyvista-0.46.5.tar.gz", hash = "sha256:b637bfa32136b95e5e5a6d972871606a68e3c625fc652ff5d9f00390294e99c0", size = 2397682, upload-time = "2026-01-15T00:29:12.727Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/df/39a108f198dd2240f2c9dad06c7c81d44809aeb83f3eb2c9d5a1ae9e4311/pyvista-0.46.5-py3-none-any.whl", hash = "sha256:d254e1e32e1df0dc04b409f989bd56b24d9e94086d868597af6c501151ec17fa", size = 2448206, upload-time = "2026-01-15T00:29:10.035Z" },
-]
-
-[[package]]
-name = "pyvista"
 version = "0.47.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
-    { name = "cyclopts", marker = "python_full_version >= '3.14'" },
-    { name = "matplotlib", marker = "python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pillow", marker = "python_full_version >= '3.14'" },
-    { name = "pooch", marker = "python_full_version >= '3.14'" },
-    { name = "scooby", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "cyclopts" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "pooch" },
+    { name = "scooby" },
+    { name = "typing-extensions" },
+    { name = "vtk", version = "9.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "vtk", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/ab/4813c71ac41b6691f16f658a9432ffe6d536a1f55d79c193c5c073eb370e/pyvista-0.47.1.tar.gz", hash = "sha256:2d517aeb0e76ea29d7a21ad95237c03ea0b45257d87d0bd88987b49965d1f1a3", size = 2463080, upload-time = "2026-02-23T07:07:11.324Z" }
@@ -2784,8 +2761,8 @@ name = "rich-rst"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.14'" },
-    { name = "rich", marker = "python_full_version >= '3.14'" },
+    { name = "docutils" },
+    { name = "rich" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.11' and python_full_version < '3.14'",
     "python_full_version < '3.11'",
 ]
 
@@ -457,7 +458,8 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.11' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -651,12 +653,45 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs", marker = "python_full_version >= '3.14'" },
+    { name = "docstring-parser", marker = "python_full_version >= '3.14'" },
+    { name = "rich", marker = "python_full_version >= '3.14'" },
+    { name = "rich-rst", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/e7/3e26855c046ac527cf94d890f6698e703980337f22ea7097e02b35b910f9/cyclopts-4.10.0.tar.gz", hash = "sha256:0ae04a53274e200ef3477c8b54de63b019bc6cd0162d75c718bf40c9c3fb5268", size = 166394, upload-time = "2026-03-14T14:09:31.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/06/d68a5d5d292c2ad2bc6a02e5ca2cb1bb9c15e941ab02f004a06a342d7f0f/cyclopts-4.10.0-py3-none-any.whl", hash = "sha256:50f333382a60df8d40ec14aa2e627316b361c4f478598ada1f4169d959bf9ea7", size = 204097, upload-time = "2026-03-14T14:09:32.504Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -1487,12 +1522,14 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "patchelf", marker = "sys_platform == 'linux'" },
-    { name = "pyvista" },
+    { name = "pyvista", version = "0.46.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pyvista", version = "0.47.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "rich" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "vtk" },
+    { name = "vtk", version = "9.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "vtk", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 
 [package.optional-dependencies]
@@ -1547,7 +1584,8 @@ requires-dist = [
     { name = "trame-vtklocal", marker = "extra == 'ui'", specifier = ">=0.16.0,<1" },
     { name = "trame-vuetify", marker = "extra == 'ui'", specifier = ">=3.2.0,<4" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5" },
-    { name = "vtk", specifier = ">=9.5,<9.7" },
+    { name = "vtk", marker = "python_full_version < '3.14'", specifier = ">=9.5,<9.7" },
+    { name = "vtk", marker = "python_full_version >= '3.14'", specifier = ">=9.6,<9.7" },
 ]
 provides-extras = ["ui"]
 
@@ -1921,7 +1959,8 @@ name = "numpy"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.11' and python_full_version < '3.14'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/62/ae72ff66c0f1fd959925b4c11f8c2dea61f47f6acaea75a08512cdfe3fed/numpy-2.4.1.tar.gz", hash = "sha256:a1ceafc5042451a858231588a104093474c6a5c57dcc724841f5c888d237d690", size = 20721320, upload-time = "2026-01-10T06:44:59.619Z" }
 wheels = [
@@ -2561,19 +2600,45 @@ wheels = [
 name = "pyvista"
 version = "0.46.5"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11' and python_full_version < '3.14'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "matplotlib" },
+    { name = "matplotlib", marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pillow" },
-    { name = "pooch" },
-    { name = "scooby" },
-    { name = "typing-extensions" },
-    { name = "vtk" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pillow", marker = "python_full_version < '3.14'" },
+    { name = "pooch", marker = "python_full_version < '3.14'" },
+    { name = "scooby", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "vtk", version = "9.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/bd/a4e4131b2d4b908a060b43f8346ce863d76a6fecf8a1c2c845602e96c610/pyvista-0.46.5.tar.gz", hash = "sha256:b637bfa32136b95e5e5a6d972871606a68e3c625fc652ff5d9f00390294e99c0", size = 2397682, upload-time = "2026-01-15T00:29:12.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/df/39a108f198dd2240f2c9dad06c7c81d44809aeb83f3eb2c9d5a1ae9e4311/pyvista-0.46.5-py3-none-any.whl", hash = "sha256:d254e1e32e1df0dc04b409f989bd56b24d9e94086d868597af6c501151ec17fa", size = 2448206, upload-time = "2026-01-15T00:29:10.035Z" },
+]
+
+[[package]]
+name = "pyvista"
+version = "0.47.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "cyclopts", marker = "python_full_version >= '3.14'" },
+    { name = "matplotlib", marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pillow", marker = "python_full_version >= '3.14'" },
+    { name = "pooch", marker = "python_full_version >= '3.14'" },
+    { name = "scooby", marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "vtk", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/ab/4813c71ac41b6691f16f658a9432ffe6d536a1f55d79c193c5c073eb370e/pyvista-0.47.1.tar.gz", hash = "sha256:2d517aeb0e76ea29d7a21ad95237c03ea0b45257d87d0bd88987b49965d1f1a3", size = 2463080, upload-time = "2026-02-23T07:07:11.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/52/a98dea948d9782b80e8e60804097fee7f7bd8fed92c9d4f0c657e4c3a6f8/pyvista-0.47.1-py3-none-any.whl", hash = "sha256:eb8cee6b6246c41f1a9d2d07e662ec7d0192ea5cf585d64ebf1266774258df59", size = 2508384, upload-time = "2026-02-23T07:07:09.069Z" },
 ]
 
 [[package]]
@@ -2715,6 +2780,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils", marker = "python_full_version >= '3.14'" },
+    { name = "rich", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.13"
 source = { registry = "https://pypi.org/simple" }
@@ -2819,7 +2897,8 @@ name = "scipy"
 version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.11' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3093,8 +3172,12 @@ wheels = [
 name = "vtk"
 version = "9.5.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11' and python_full_version < '3.14'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "matplotlib" },
+    { name = "matplotlib", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/71/0cc26142f4f5276944c17a8c839b3e06894617627750686e12dab708ade0/vtk-9.5.2-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:9ca87122352cf3c8748fee73c48930efa46fe1a868149a1f760bc17e8fae27ba", size = 86865294, upload-time = "2025-09-18T00:56:08.013Z" },
@@ -3117,6 +3200,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/d1/c8c4c9b4ff2044fadf4f0d0230a933cc1962e7ba8bca6013737e5773c5c2/vtk-9.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11cf870c05539e9f82f4a5adf450384e0be4ee6cc80274f9502715a4139e2777", size = 112292475, upload-time = "2025-09-18T00:57:46.196Z" },
     { url = "https://files.pythonhosted.org/packages/87/6d/b0d404822329d3b7eeccd66cf61480cbb66bf1bf6bd2ef8eabedcec8428f/vtk-9.5.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3c4b658d61815cb87177f4e94281396c9be5a28798464a2c6fa0897b1bba282f", size = 103798352, upload-time = "2025-09-18T00:57:52.993Z" },
     { url = "https://files.pythonhosted.org/packages/07/8f/400d4e4270bd5da3a19ce465aa288c03435e1f38b0344ac2540615ec5b0b/vtk-9.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:974783b8865e2ddc2818d3090705b6bc6bf8ae40346d67f9a43485fabcfb3a99", size = 64000682, upload-time = "2025-09-18T00:57:57.926Z" },
+]
+
+[[package]]
+name = "vtk"
+version = "9.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "matplotlib", marker = "python_full_version >= '3.14'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/03/26331321bd6e11b90e8658e764712ddde8f0477495d8475faa6581dc8201/vtk-9.6.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:16075dab279cf079e7d1a52d27219eee0a89f0d7f13a5c1130fa2c0acba100fc", size = 114284029, upload-time = "2026-02-11T04:16:37.11Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/f6/7cf0a8991584cc89701fc63d1cce6a3cf414b6d30cb9388927f842e0718e/vtk-9.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1598a524f2b8355be2e369f43343adecbea8ade826f5ba63c29421570b7a8cd3", size = 106508468, upload-time = "2026-02-11T04:16:47.729Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/b0f4d56774898677c4ec7f5a853b98850507d373dd5b718340f591cf426f/vtk-9.6.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:93bd59d309e9ec7a9b6c64142a3e227bc487c065be1bdc45c7c725099c9234e3", size = 145601885, upload-time = "2026-02-11T04:16:57.203Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/7c/6725349e0cc97c435de95383552ad8992d2fbeeb2c23359bdd76ee416ed0/vtk-9.6.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:04a37b251d8a2baba85848f43ae15a40140a7fd25de5e0034e17b15a6e179b66", size = 135395383, upload-time = "2026-02-11T04:17:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6f/2ada468aae22c16b35001e89dc25fc07c55d379f346b9090c354339bc030/vtk-9.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:3cdc37959e9195c02452cbd6ddee8cb463931fe3a6fcd698ec5cd25c1f15aaba", size = 81132802, upload-time = "2026-02-11T04:17:24.824Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/0e0789d2c65bd59034d78d1508dd06b3552c8eefc3f62a7192645769e177/vtk-9.6.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8df76d131c284e99aac2e76055e5f0a8c94d54197089f8bd2f67213f51de6333", size = 114283990, upload-time = "2026-02-11T04:17:35.917Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5d/b7e600401a107043a5960e39089bc69ce024ef9f6385abae233d5e904f33/vtk-9.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3368371403d57108471431811851a82ad73524f31b684491eee2c9aef122632", size = 106508258, upload-time = "2026-02-11T04:17:45.653Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e4/6ee05d08689ae7a3061119ee1b6241428b9b5e16d5850f7d855999c73af1/vtk-9.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e404d66c11476cfac2781025c29e9518ffbfa9a760ced419e5b34640d437f4dc", size = 145601858, upload-time = "2026-02-11T04:17:57.616Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f2/322bce9de7830836d6a8136f1dff86912a5771e70fc765ea3e45d571aeae/vtk-9.6.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ebea2a1d6ec6e04822e805acfd3119437ce9728b6807fa707c3ba0dc0de6c90a", size = 135395425, upload-time = "2026-02-11T04:18:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d0/865bd4ea5ded69fda7b045f911db35e4f90462b10bed60bdbe3c3b90785e/vtk-9.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:a82d59c4119aadd2885e4174432ff87f94320ba38aaeb7e2282ba0e6e3d09e0e", size = 81133528, upload-time = "2026-02-11T04:18:23.784Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e2/9fd5392dcb81a824722a58f2361ce476fc6c274c09ea25975f1b5c1c7578/vtk-9.6.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:fcbfa103fb817a7c7564d32b0572c11d301542e860a9bf0592f5f9dd25cdff55", size = 114461792, upload-time = "2026-02-11T04:18:38.887Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c3/c822d52fcc1992d3d7133d87cf09a22504b7c7ef6e89c12a72c1d9de7bf6/vtk-9.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:09ceedfb4e49db477aa40ae83d7578c1007387205463504e63b560e7c56219f3", size = 106561402, upload-time = "2026-02-11T04:18:48.542Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ec/f607398ac9859f1f75f2bc352eebb567e3bb25ba830656056428a4440b88/vtk-9.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e59c5badb1c3b86f784db761a86ddc0bcb4a15640a17b64ec5fd0710ed5edf3", size = 145648107, upload-time = "2026-02-11T04:19:01.913Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/44/0c491f8b3bd8f72606cde4df0f516553c089e09192ee929e0d434455d77d/vtk-9.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1b1f0537c7886d671bd3cb3c09409e2a6565444ccee96dc5a12d19252a1755bf", size = 135453768, upload-time = "2026-02-11T04:19:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/83/724e0b3abb7e6e0e6fc0fb8ca2a91e2834d1ab6a64da8e0823ce6974aeb2/vtk-9.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:351f023eadcd095838e4e3a7bc12b1b80abe3d7a77b9473ddeeefe065ec42cbe", size = 81148714, upload-time = "2026-02-11T04:19:23.441Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bc/5ffde34e0ac31180f5d74d4ce6e0f29bcb57b699afdc0fe758954c63a322/vtk-9.6.0-cp313-cp313-macosx_10_10_x86_64.whl", hash = "sha256:ca02262e60d2891d83f64e979a66e303809b182b47fc1c21ca6bbc4041b12419", size = 114479468, upload-time = "2026-02-11T04:19:29.486Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/1b3c814bd8ab6fbd762f28cdf8603dad270d4a653d01d409588a5a93f67a/vtk-9.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:14ef4d2bb32ee4322145d07d76ac587d6030cff03765fb15c0209b7aabdef7ff", size = 106563537, upload-time = "2026-02-11T04:19:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/f89017433124aa03c68895c0bcc248dc618c407b1e9c855f749eddc0cf57/vtk-9.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1af7f194e5b5c665343a41280834aab5d6ba803594032d837ab0710e974339bf", size = 145648560, upload-time = "2026-02-11T04:19:43.405Z" },
+    { url = "https://files.pythonhosted.org/packages/53/04/faa899f4d03d3c272ce470e5835f7abef52e031fd442ea563b5ea72809f8/vtk-9.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:82936685bc64ba4b206e60d67355c75ff6eb80f9e0154a931b4f4a2989bc103f", size = 135456009, upload-time = "2026-02-11T04:19:50.378Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e2/d9b1e45c2d9a013853c19ada13a9bac4464cc9f8db83649719922cfb0244/vtk-9.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:b0b5a3480769439ed9ea393bf7cb474a974550565a39ce9e9586438a24b46b1d", size = 81150601, upload-time = "2026-02-11T04:19:56.995Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/36/f04c4be0bab19b8e251d7dabbbebdece70b98745afe783711feddb4e4a83/vtk-9.6.0-cp314-cp314-macosx_10_10_x86_64.whl", hash = "sha256:4ea035a360ab3ff3fcc6e9e34e2b7c5d8440d442b4d2f2ec68834dd241d1e45b", size = 114114985, upload-time = "2026-02-11T04:20:03.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/12435ba3722e1a728f6b67cdd3a3ccb3b275d9acf19715081dd3e2cac90e/vtk-9.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:951837676f5ce294651f1e051a0581db2d6b0e519d0ce0ebc77ff2f446028a64", size = 106573090, upload-time = "2026-02-11T04:20:09.931Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ff/d693b5829f845f7bfbb104f651e871875a191e7da68a5fde210f9b4d0061/vtk-9.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeb84471ef22fffb9120284af2cb0bda6af0b4ca421b9b8cb0741f1ca52930a2", size = 145664165, upload-time = "2026-02-11T04:20:18.178Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c4/32cd861bf88b539fe17ca5dab55bc54190eb9f532fd9e3852d574f0c5ad7/vtk-9.6.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1a67c3b1cf1d89e83e6d4cd6e6b070ea5e979477bbc881daf19729b8a8e2cfd7", size = 135480217, upload-time = "2026-02-11T04:20:25.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/75/88c5a42110fd84745b0a62088f2b461dc0bd70714c8c2940aa8d3e4de2ce/vtk-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:8613b91c9e7d3de3905a9801be646863c93df797facd22b5070c95de6a1d77a4", size = 83078781, upload-time = "2026-02-11T04:20:30.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/dd/28cd6cdb05887ed27a6195e41572b4174612a7f871b68ebb011c42629153/vtk-9.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d06fe9b5a9786165a59f494f801f35ad37018e45cfa91060ff025719a2f1e387", size = 145286019, upload-time = "2026-02-11T04:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/e6b6da544a406ec8ca0082cddc0d8c5927546bc3fa8aa63a7396932c4771/vtk-9.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:5b1262a67e358b59c5ae82f136a6515980fbb1a3cf8329dd36b07dcb31c81227", size = 135294404, upload-time = "2026-02-11T04:20:46.313Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #140.

Adds Python 3.14 support, switches Linux x86_64 wheels to `manylinux_2_28`, removes the `scipy<1.17` cap, and adds upper bounds to all dependencies.

## Changes

### Python 3.14 support
- Widen VTK constraint from `>=9.5,<9.6` to `>=9.5,<9.7` (Python <3.14) / `>=9.6,<9.7` (Python >=3.14), since VTK 9.6.0 is the first version with cp314 wheels
- Add `cp314-*` to the cibuildwheel build list
- Add `Programming Language :: Python :: 3.14` classifier
- Update CI test matrices to cover 3.10 + 3.14 (oldest + newest)

### manylinux_2_28 migration
- Switch the Linux x86_64 cibuildwheel image from `manylinux2014` to `manylinux_2_28`
- Remove the `scipy<1.17` upper bound (scipy 1.17+ dropped manylinux2014)
- Add a comment in `download_vtk.sh` explaining why the manylinux2014 VTK archives remain usable in the newer wheel image

### Dependency bounds
- Add upper bounds to all runtime and optional dependencies (next major version)

### CI updates
- Bump cibuildwheel from v3.0 to v3.4 (native cp314 support)
- Update `uv.lock` with forked VTK resolution (9.5.2 for <3.14, 9.6.0 for >=3.14)

## Test Plan

- [x] Existing tests pass (793 passed locally)
- [x] `uv lock` and `uv sync` succeed
- [ ] CI wheel builds pass for all platforms
- [ ] `import mmgpy` works on cp314 wheels

## Checklist

- [x] Code follows project style
- [x] Documentation updated (CHANGELOG.md)
- [x] No new warnings