### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.8.0] - 2026-03-18
 
 ### Added
@@ -186,6 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimized wheel sizes (under 100MB) for PyPI upload
 - Linux manylinux wheels with proper platform tags
 
+[Unreleased]: https://github.com/kmarchais/mmgpy/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/kmarchais/mmgpy/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/kmarchais/mmgpy/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/kmarchais/mmgpy/compare/v0.6.0...v0.7.0

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.8.0"
+  version: "0.9.0.dev0"
 
 package:
   name: mmgpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.8.0"
+version = "0.9.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.8.0"
+    assert mmgpy.__version__ == "0.9.0.dev0"
 
 
 def test_mmg_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1517,7 +1517,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.8.0"
+version = "0.9.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "meshio" },


### PR DESCRIPTION
## Release v0.8.0

### Added

- Python 3.14 support.
- Free-threaded Python 3.14 (`cp314t`) wheel builds for Linux.

### Changed

- Upgrade build-time VTK from 9.5.2 to 9.6.0.
- Build Linux x86_64 wheels with `manylinux_2_28` and remove the `scipy<1.17` cap so newer SciPy releases can be installed.
- Widen VTK constraint from `>=9.5,<9.6` to `>=9.5,<9.7` to allow VTK 9.6 (required for Python 3.14 wheels).
- Bump `pyvista` lower bound from `>=0.46.4` to `>=0.47` (first version compatible with VTK 9.6).
- Add upper bounds to all runtime and optional dependencies.
- Parameterize VTK version in cibuildwheel config to avoid hardcoded paths.
- Bump cibuildwheel from v3.0 to v3.4.