### PR TITLE
ci: add daily docs test against latest PyPI release

### DIFF
--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -7,6 +7,13 @@ on:
 
 jobs:
   test-released-docs:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.14"
+
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +30,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install mmgpy from PyPI with test dependencies
         run: |


### PR DESCRIPTION
## Summary

- Adds a scheduled workflow that runs daily at 6 AM UTC
- Installs the latest released mmgpy from PyPI (not from source)
- Checks out the docs/examples at the corresponding version tag
- Runs `pytest --codeblocks docs/` and all examples

This catches breakage from upstream dependency updates (PyVista, VTK, NumPy, SciPy, etc.) without needing a code change to trigger CI.

## Test plan

- [ ] Trigger manually via `workflow_dispatch` to verify it works
- [ ] Confirm it picks up the correct PyPI version and matching tag