### PR TITLE
docs: add conda-forge badge and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mmgpy
 
 [![PyPI](https://img.shields.io/pypi/v/mmgpy)](https://pypi.org/project/mmgpy/)
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/mmgpy)](https://anaconda.org/conda-forge/mmgpy)
 [![Python](https://img.shields.io/pypi/pyversions/mmgpy)](https://pypi.org/project/mmgpy/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://kmarchais.github.io/mmgpy)
@@ -32,22 +33,45 @@ uvx --from "mmgpy[ui]" mmgpy-ui
 
 ## Installation
 
-```bash
-pip install mmgpy
+The recommended way to install mmgpy:
 
-# With UI support
-pip install "mmgpy[ui]"
+```bash
+uv pip install mmgpy
 ```
 
-Using [uv](https://docs.astral.sh/uv/)?
+This uses pre-built wheels from PyPI that bundle all native libraries (MMG, VTK) — no compiler needed.
+
+### Other install methods
+
+```bash
+# pip
+pip install mmgpy
+
+# conda-forge
+conda install -c conda-forge mmgpy
+
+# With UI support
+uv pip install "mmgpy[ui]"
+```
+
+### Using uv for project management
 
 ```bash
 uv add mmgpy                 # add to project dependencies
-uv pip install mmgpy         # install in current environment
-uv pip install "mmgpy[ui]"   # install with UI support
 uv tool install mmgpy        # install CLI tools globally
 uv tool install "mmgpy[ui]"  # install CLI tools + UI globally
 ```
+
+### PyPI vs conda-forge
+
+|                   | PyPI (pip/uv)                 | conda-forge                         |
+| ----------------- | ----------------------------- | ----------------------------------- |
+| **Install speed** | Fast (pre-built wheels)       | Slower (solver + download)          |
+| **Dependencies**  | Bundled (self-contained)      | Shared across packages              |
+| **Disk usage**    | Larger (duplicate VTK/libs)   | Smaller in conda environments       |
+| **Best for**      | Quick setup, isolated use, CI | Scientific stacks sharing VTK/NumPy |
+
+Use **PyPI** (`uv pip install`) for the fastest setup. Use **conda-forge** when you already have a conda environment with VTK, PyVista, or other scientific packages to avoid duplicating shared libraries.
 
 ## Features
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,18 +7,18 @@
 
 ## Installing from PyPI
 
-The easiest way to install mmgpy is from PyPI:
+The fastest way to install mmgpy:
+
+=== "uv (recommended)"
+
+    ```bash
+    uv pip install mmgpy
+    ```
 
 === "pip"
 
     ```bash
     pip install mmgpy
-    ```
-
-=== "uv"
-
-    ```bash
-    uv pip install mmgpy
     ```
 
 === "pipx (CLI only)"
@@ -34,6 +34,33 @@ Pre-built wheels are available for:
 | Windows  | x86_64          |
 | macOS    | arm64, x86_64   |
 | Linux    | x86_64, aarch64 |
+
+PyPI wheels bundle all native libraries (MMG, VTK), so no compiler or system packages are needed.
+
+## Installing from conda-forge
+
+If you use conda or mamba for scientific computing:
+
+```bash
+conda install -c conda-forge mmgpy
+```
+
+or with [pixi](https://pixi.sh/):
+
+```bash
+pixi add mmgpy
+```
+
+### PyPI vs conda-forge
+
+|                   | PyPI (pip/uv)                 | conda-forge                         |
+| ----------------- | ----------------------------- | ----------------------------------- |
+| **Install speed** | Fast (pre-built wheels)       | Slower (solver + download)          |
+| **Dependencies**  | Bundled (self-contained)      | Shared across packages              |
+| **Disk usage**    | Larger (duplicate VTK/libs)   | Smaller in conda environments       |
+| **Best for**      | Quick setup, isolated use, CI | Scientific stacks sharing VTK/NumPy |
+
+Use **PyPI** for the fastest, most portable setup. Use **conda-forge** when you already have a conda environment with VTK, PyVista, or other scientific packages to avoid duplicating shared libraries.
 
 ## Installing from Source
 


### PR DESCRIPTION
## Summary

- Add conda-forge version badge to README
- Add conda-forge and pixi install instructions to README and docs
- Add PyPI vs conda-forge comparison table explaining trade-offs
- Recommend `uv pip install` as the default install method

## Changes

- **README.md**: conda-forge badge, restructured install section with comparison table
- **docs/getting-started/installation.md**: conda-forge section with pixi, comparison table

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify docs build with `mkdocs build`
- [ ] Check table renders properly in both GitHub and mkdocs