### PR TITLE
ci: add skip-existing to PyPI publish step

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -264,6 +264,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   # TestPyPI publishing (manual trigger only)
   # Prerequisites:


### PR DESCRIPTION
## Summary

The v0.8.0 release Build Wheels workflow is marked as failed, but all wheels are available on PyPI.

**Root cause**: The last wheel (`cp314-cp314-win_amd64.whl`) got a `400 Bad Request` from PyPI because it was already uploaded (likely a duplicate trigger). All other wheels uploaded successfully.

**Fix**: Add `skip-existing: true` to the PyPI publish action so duplicate uploads are silently skipped instead of failing the workflow.