### PR TITLE
ci: add skip-existing to PyPI publish step

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -10,6 +10,11 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      publish_to_pypi:
+        description: "Publish to PyPI"
+        required: false
+        default: false
+        type: boolean
       publish_to_testpypi:
         description: "Publish to TestPyPI and run verification tests"
         required: false
@@ -245,7 +250,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     name: Publish to PyPI
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.publish_to_pypi)
 
     environment:
       name: pypi


### PR DESCRIPTION
## Summary

The v0.8.0 release is missing the `cp314-cp314-win_amd64.whl` on PyPI. The original upload failed with `400 Bad Request` on the last wheel, and manual upload via twine also fails because PyPI enforces trusted publishing (Sigstore attestations).

**Fix**: Add `skip-existing: true` to the PyPI publish action so the release workflow can be rerun — it will skip all already-uploaded wheels and only push the missing one through the trusted publisher.

## Test plan

- [ ] Merge this PR
- [ ] Rerun the failed v0.8.0 release workflow
- [ ] Verify `cp314-cp314-win_amd64.whl` appears on PyPI