### PR TITLE
refactor: rewrite unified mmg CLI to use Python API directly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,73 +1,189 @@
+---
+icon: lucide/history
+---
+
 # Changelog
 
 All notable changes to mmgpy are documented here.
+This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
+### Removed
 
-- Comprehensive API documentation site with MkDocs
-- Tutorials for common workflows
-- Examples gallery
+- `mmg2d`, `mmg3d`, `mmgs` CLI commands — use the unified `mmg` command instead
 
-## [0.4.0] - In Development
+## [0.9.0] - 2026-04-01
 
 ### Added
 
-- `mesh.validate()` method with comprehensive quality checks (#88)
-- `RemeshResult` dataclass with detailed statistics from remeshing operations (#87)
-- Unified `Mesh` class with auto-detection and `mmgpy.read()` function (#85)
+- `set_required_triangles` API and tests ([#206](https://github.com/kmarchais/mmgpy/pull/206))
+- Complete constraint marker coverage and unset variants ([#208](https://github.com/kmarchais/mmgpy/pull/208))
+- Set/get normal vectors at vertices for 3D and surface meshes ([#209](https://github.com/kmarchais/mmgpy/pull/209))
+- `set_local_parameters` for region-specific mesh sizing ([#210](https://github.com/kmarchais/mmgpy/pull/210))
+- Advanced topology queries ([#211](https://github.com/kmarchais/mmgpy/pull/211))
+- Multi-material and level-set base reference support ([#212](https://github.com/kmarchais/mmgpy/pull/212))
 
 ### Changed
 
-- Remeshing methods now return `RemeshResult` instead of `bool`
+- Removed VTK bundling from build pipeline ([#204](https://github.com/kmarchais/mmgpy/pull/204))
 
-## [0.3.0] - 2024
+## [0.8.0] - 2026-03-18
 
 ### Added
 
-- Local sizing parameters API for per-region mesh control (#81)
-  - `set_size_sphere()`, `set_size_box()`, `set_size_cylinder()`, `set_size_from_point()`
-- Typed options dataclasses: `Mmg3DOptions`, `Mmg2DOptions`, `MmgSOptions` (#70)
-  - Factory methods: `.fine()`, `.coarse()`, `.optimize_only()`
-- PyVista integration for mesh conversion (#69)
-  - `mesh.to_pyvista()` and `mmgpy.from_pyvista()`
-- Level-set discretization API (#68)
-  - `mesh.remesh_levelset(levelset_field)`
-- Topology query methods (#67)
-  - `get_adjacent_elements()`, `get_vertex_neighbors()`
-- Element attributes API (#66)
-  - `set_corners()`, `set_required_vertices()`, `set_ridge_edges()`
-- Logging module with Rich integration (#65)
-  - `enable_debug()`, `set_log_level()`, `rich_progress()`
-- Lagrangian motion remeshing (#64)
-  - `mesh.remesh_lagrangian(displacement)`
-- Field storage via `__getitem__`/`__setitem__` (#63)
-  - `mesh["temperature"] = values`
-- Convenience remeshing methods (#62)
-  - `remesh_optimize()`, `remesh_uniform(size)`
-- Bulk data operations for all mesh types (#61)
+- Python 3.14 support
+- Free-threaded Python 3.14 (`cp314t`) wheel builds for Linux
 
 ### Changed
 
-- Updated VTK to 9.5.2 (#82)
-- Improved wheel size optimization
+- Upgrade build-time VTK from 9.5.2 to 9.6.0
+- Build Linux x86_64 wheels with `manylinux_2_28`
+- Widen VTK constraint from `>=9.5,<9.6` to `>=9.5,<9.7`
+- Bump `pyvista` lower bound to `>=0.47`
+- Add upper bounds to all runtime and optional dependencies
+- Bump cibuildwheel from v3.0 to v3.4
 
-## [0.2.0] - 2024
-
-### Added
-
-- Initial PyPI release
-- Pre-built wheels for Windows, macOS, and Linux
-- Support for Python 3.10 - 3.13
-- `MmgMesh3D`, `MmgMesh2D`, `MmgMeshS` classes
-- File-based remeshing: `mmg3d.remesh()`, `mmg2d.remesh()`, `mmgs.remesh()`
-- Bundled MMG executables
+## [0.7.1] - 2026-03-16
 
 ### Fixed
 
-- RPATH handling on macOS and Linux
-- DLL loading on Windows
+- Update examples to use `Mesh` class instead of deprecated `MmgMesh2D`/`3D`/`S` ([#186](https://github.com/kmarchais/mmgpy/pull/186))
+
+## [0.7.0] - 2026-03-15
+
+### Added
+
+- Support for system-installed MMG via mmgsuite ([#183](https://github.com/kmarchais/mmgpy/pull/183))
+- conda-forge package support ([#179](https://github.com/kmarchais/mmgpy/pull/179))
+
+### Fixed
+
+- Release GIL during remeshing, detect mesh corruption, fix stderr capture ([#177](https://github.com/kmarchais/mmgpy/pull/177))
+- Set execute permissions on bundled executables for `uvx` installs ([#174](https://github.com/kmarchais/mmgpy/pull/174))
+
+## [0.6.0] - 2026-03-08
+
+### Added
+
+- Editable install with automatic C++ rebuild ([#170](https://github.com/kmarchais/mmgpy/pull/170))
+
+### Fixed
+
+- Use stdlib logging in CLI error paths to fix Windows subprocess hang ([#172](https://github.com/kmarchais/mmgpy/pull/172))
+
+### Changed
+
+- Update dependencies to fix security alerts ([#167](https://github.com/kmarchais/mmgpy/pull/167))
+
+## [0.5.2] - 2026-01-21
+
+### Fixed
+
+- Fix `PermissionError` when running `uvx mmgpy` commands on Linux/macOS ([#174](https://github.com/kmarchais/mmgpy/pull/174))
+
+## [0.5.1] - 2026-01-20
+
+### Added
+
+- Enable editable install with automatic C++ rebuild
+
+### Fixed
+
+- Use stdlib logging in CLI error paths to fix Windows subprocess hang ([#172](https://github.com/kmarchais/mmgpy/pull/172))
+
+### Changed
+
+- Update dependencies to fix security alerts ([#167](https://github.com/kmarchais/mmgpy/pull/167))
+
+## [0.5.0] - 2026-01-19
+
+### Added
+
+- Web-based mesh viewer and remeshing interface with trame ([#158](https://github.com/kmarchais/mmgpy/pull/158))
+- Enhanced UI with dark mode, new options, and CLI entry point ([#161](https://github.com/kmarchais/mmgpy/pull/161))
+- Unified `Mesh` class and `mmgpy.read()` function ([#85](https://github.com/kmarchais/mmgpy/pull/85))
+- `RemeshResult` dataclass with statistics ([#87](https://github.com/kmarchais/mmgpy/pull/87))
+- `mesh.validate()` method with comprehensive quality checks ([#88](https://github.com/kmarchais/mmgpy/pull/88))
+- `mesh.plot()`, `mesh.vtk`, and unified `mmg` command ([#90](https://github.com/kmarchais/mmgpy/pull/90))
+- Context manager support for mesh operations ([#93](https://github.com/kmarchais/mmgpy/pull/93))
+- Solution field transfer during remeshing ([#156](https://github.com/kmarchais/mmgpy/pull/156))
+- Progress callbacks with cancellation support ([#149](https://github.com/kmarchais/mmgpy/pull/149))
+- File logging support and external logger integration ([#148](https://github.com/kmarchais/mmgpy/pull/148))
+- Capture MMG warnings from stderr during remeshing ([#151](https://github.com/kmarchais/mmgpy/pull/151))
+- Auto-triangulate non-triangular meshes (quads, polygons) ([#155](https://github.com/kmarchais/mmgpy/pull/155))
+- Native MMG loading for Medit (.mesh) files ([#159](https://github.com/kmarchais/mmgpy/pull/159))
+- Mesh repair utilities module ([#144](https://github.com/kmarchais/mmgpy/pull/144))
+- Geometry convenience methods ([#139](https://github.com/kmarchais/mmgpy/pull/139))
+- Interactive sizing editor for visual constraint definition ([#132](https://github.com/kmarchais/mmgpy/pull/132))
+- Duplicate vertex detection with KD-tree ([#137](https://github.com/kmarchais/mmgpy/pull/137))
+- Test coverage reporting with pytest-cov ([#131](https://github.com/kmarchais/mmgpy/pull/131))
+- Performance benchmarks with pytest-benchmark ([#92](https://github.com/kmarchais/mmgpy/pull/92))
+- MkDocs documentation site with API reference and tutorials ([#89](https://github.com/kmarchais/mmgpy/pull/89))
+- CONTRIBUTING.md guide ([#94](https://github.com/kmarchais/mmgpy/pull/94))
+
+### Fixed
+
+- Save displacement and levelset fields during checkpoint ([#154](https://github.com/kmarchais/mmgpy/pull/154))
+- `NotImplementedError` for unsupported Lagrangian motion in MMGS ([#153](https://github.com/kmarchais/mmgpy/pull/153))
+- Standardize array initialization types to `py::ssize_t` in bindings ([#141](https://github.com/kmarchais/mmgpy/pull/141))
+- Type validation for option casting in C++ bindings ([#138](https://github.com/kmarchais/mmgpy/pull/138))
+
+### Changed
+
+- Replace monkey-patching with Mesh wrapper class ([#142](https://github.com/kmarchais/mmgpy/pull/142))
+- Simplify RPATH handling by removing Python runtime fixes ([#147](https://github.com/kmarchais/mmgpy/pull/147))
+
+## [0.4.0] - 2026-01-18
+
+Same content as [0.5.0] — released as a pre-release before the final 0.5.0.
+
+## [0.3.0] - 2026-01-05
+
+### Changed
+
+- Updated VTK from 9.3.1/9.4.1 to 9.5.2
+- Simplified Linux wheel builds to manylinux only (dropped musllinux)
+- Aligned manylinux versions with PyPI VTK wheel availability
+- Removed redundant CI workflow files
+
+## [0.2.0] - 2026-01-01
+
+### Added
+
+- In-memory remeshing API for all mesh classes ([#63](https://github.com/kmarchais/mmgpy/pull/63))
+- Lagrangian motion remeshing API ([#64](https://github.com/kmarchais/mmgpy/pull/64))
+- Logging module and progress callbacks with Rich integration ([#65](https://github.com/kmarchais/mmgpy/pull/65))
+- Element attributes API (`set_corners`, `set_required_vertices`, `set_ridge_edges`) ([#66](https://github.com/kmarchais/mmgpy/pull/66))
+- Topology query methods (`get_adjacent_elements`, `get_vertex_neighbors`) ([#67](https://github.com/kmarchais/mmgpy/pull/67))
+- Level-set discretization API ([#68](https://github.com/kmarchais/mmgpy/pull/68))
+- PyVista integration (`mesh.to_pyvista()`, `mmgpy.from_pyvista()`) ([#69](https://github.com/kmarchais/mmgpy/pull/69))
+- Typed options dataclasses with factory methods (`.fine()`, `.coarse()`, `.optimize_only()`) ([#70](https://github.com/kmarchais/mmgpy/pull/70))
+- Local sizing parameters API (`set_size_sphere`, `set_size_box`, `set_size_cylinder`, `set_size_from_point`) ([#81](https://github.com/kmarchais/mmgpy/pull/81))
+
+## [0.1.5] - 2025-12-31
+
+### Added
+
+- First PyPI release with `pip install mmgpy`
+- Pre-built wheels for Windows, macOS, and Linux
+
+### Changed
+
+- Updated bundled VTK to 9.4.1
+- Optimized wheel sizes (all under 100MB)
+
+## [0.1.4] - 2025-08-29
+
+Maintenance release with version bump.
+
+## [0.1.1] - 2024-12-21
+
+### Added
+
+- MMG compiled with VTK support
+- Python 3.9 support
+- pre-commit configuration
 
 ## [0.1.0] - 2024
 
@@ -79,15 +195,22 @@ All notable changes to mmgpy are documented here.
 
 ---
 
-## Version Numbering
-
-mmgpy follows [Semantic Versioning](https://semver.org/):
-
-- **MAJOR**: Breaking API changes
-- **MINOR**: New features, backward compatible
-- **PATCH**: Bug fixes, backward compatible
-
 ## Links
 
 - [GitHub Releases](https://github.com/kmarchais/mmgpy/releases)
 - [PyPI](https://pypi.org/project/mmgpy/)
+
+[0.9.0]: https://github.com/kmarchais/mmgpy/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/kmarchais/mmgpy/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/kmarchais/mmgpy/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/kmarchais/mmgpy/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/kmarchais/mmgpy/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/kmarchais/mmgpy/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/kmarchais/mmgpy/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/kmarchais/mmgpy/compare/v0.3.0...v0.5.0
+[0.4.0]: https://github.com/kmarchais/mmgpy/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/kmarchais/mmgpy/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/kmarchais/mmgpy/compare/v0.1.5...v0.2.0
+[0.1.5]: https://github.com/kmarchais/mmgpy/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/kmarchais/mmgpy/compare/v0.1.1...v0.1.4
+[0.1.1]: https://github.com/kmarchais/mmgpy/compare/v0.0.1...v0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,16 +76,11 @@ wheel.packages = ["src/mmgpy"]
 sdist.include = ["CMakeLists.txt", "src/*", "extern/*", "scripts/*"]
 sdist.exclude = ["vtk*/**", "vtk*.tar.gz", "*.mesh", "*.sol", "*.vtk"]
 
-# Scripts entry points - wrappers that find and run native MMG executables.
-# Native executables (mmg3d_O3, mmg2d_O3, mmgs_O3) are installed to mmgpy/bin/
-# and symlinked to venv/bin/ by CMake. These wrapper entry points provide
-# shorter command names (mmg3d, mmg2d, mmgs) and the unified 'mmg' command.
+# Scripts entry points - the unified 'mmg' command auto-detects mesh type
+# and remeshes via the Python API (no subprocess, single file read).
 [project.scripts]
 mmgpy = "mmgpy._cli:_run_mmg"
 mmg = "mmgpy._cli:_run_mmg"
-mmg2d = "mmgpy._cli:_run_mmg2d"
-mmg3d = "mmgpy._cli:_run_mmg3d"
-mmgs = "mmgpy._cli:_run_mmgs"
 
 [project.entry-points."mmgpy.ui"]
 ui = "mmgpy.ui:run_ui"
@@ -214,10 +209,10 @@ ignore = [
     "PLR0915", # wrapper functions that patch multiple mesh classes have many statements
 ]
 "src/mmgpy/_cli.py" = [
-    "S603",    # subprocess calls with absolute paths to system tools are safe
-    "C901",    # executable finder has many fallback paths
+    "C901",    # _run_mmg and _find_mmg_executable have many branches
     "T201",    # print statements for CLI output
-    "PLR0912", # many branches in executable search fallback paths
+    "PLR0912", # many branches in executable search and arg parsing
+    "PLR0915", # many statements in _run_mmg entry point
 ]
 "src/mmgpy/_logging.py" = [
     "PLC0415", # imports inside functions for optional Rich dependency

--- a/src/mmgpy/_cli.py
+++ b/src/mmgpy/_cli.py
@@ -1,9 +1,11 @@
-"""Lightweight CLI entry points for MMG executables.
+"""Lightweight CLI entry point for the unified ``mmg`` command.
 
-This module is intentionally kept free of heavy imports (VTK, pyvista, numpy,
-etc.) so that the simple alias commands (mmg2d, mmg3d, mmgs) start instantly.
-Only the unified ``mmg`` command lazy-imports heavier dependencies for mesh
-type detection.
+The ``mmg`` command auto-detects the mesh type (2D, 3D, surface) from the
+input file and remeshes it using the Python API — no subprocess is spawned,
+and the file is read only once.
+
+All standard MMG flags (``-hmax``, ``-hausd``, ``-hgrad``, etc.) are supported
+and mapped directly to the underlying C++ library calls.
 """
 
 from __future__ import annotations
@@ -11,9 +13,10 @@ from __future__ import annotations
 import logging
 import site
 import stat
-import subprocess
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 
 def _get_cli_logger() -> logging.Logger:  # pragma: no cover
@@ -111,61 +114,179 @@ def _find_mmg_executable(base_name: str) -> str | None:  # pragma: no cover
     return None
 
 
-def _run_mmg2d() -> None:  # pragma: no cover
-    """Run the mmg2d_O3 executable."""
-    exe_path = _find_mmg_executable("mmg2d_O3")
-    if exe_path:
-        subprocess.run([exe_path, *sys.argv[1:]], check=False)
-    else:
-        _get_cli_logger().error("mmg2d_O3 executable not found")
-        sys.exit(1)
+# -- Argument parsing --------------------------------------------------------
+
+# MMG flags that take a numeric or path argument.
+_FLAGS_WITH_VALUE = {
+    "-in",
+    "-o",
+    "-out",
+    "-sol",
+    "-met",
+    "-ls",
+    "-lag",
+    "-ar",
+    "-nr",
+    "-hmin",
+    "-hmax",
+    "-hsiz",
+    "-hausd",
+    "-hgrad",
+    "-hgradreq",
+    "-m",
+    "-v",
+    "-xreg",
+    "-nreg",
+    "-nsd",
+}
+
+# Flags that map directly to remesh **kwargs (flag name minus leading dash).
+_NUMERIC_OPTION_FLAGS = {
+    "-hmin",
+    "-hmax",
+    "-hsiz",
+    "-hausd",
+    "-hgrad",
+    "-hgradreq",
+    "-ar",
+    "-xreg",
+    "-nreg",
+    "-nsd",
+}
+
+# Boolean flags (no value) that map to remesh **kwargs = 1.
+_BOOLEAN_OPTION_FLAGS = {
+    "-noinsert",
+    "-noswap",
+    "-nomove",
+    "-nosurf",
+    "-optim",
+}
 
 
-def _run_mmg3d() -> None:  # pragma: no cover
-    """Run the mmg3d_O3 executable."""
-    exe_path = _find_mmg_executable("mmg3d_O3")
-    if exe_path:
-        subprocess.run([exe_path, *sys.argv[1:]], check=False)
-    else:
-        _get_cli_logger().error("mmg3d_O3 executable not found")
-        sys.exit(1)
+@dataclass
+class _ParsedArgs:
+    """Structured representation of parsed CLI arguments."""
+
+    input_mesh: str | None = None
+    output_mesh: str | None = None
+    sol_file: str | None = None
+    met_file: str | None = None
+    ls_value: float | None = None
+    lag_value: int | None = None
+    remesh_options: dict[str, Any] = field(default_factory=dict)
 
 
-def _run_mmgs() -> None:  # pragma: no cover
-    """Run the mmgs_O3 executable."""
-    exe_path = _find_mmg_executable("mmgs_O3")
-    if exe_path:
-        subprocess.run([exe_path, *sys.argv[1:]], check=False)
-    else:
-        _get_cli_logger().error("mmgs_O3 executable not found")
-        sys.exit(1)
+def _parse_args(args: list[str]) -> _ParsedArgs:
+    """Parse MMG-style CLI arguments into structured form.
+
+    Handles ``-flag value`` pairs, boolean flags, and positional input file
+    detection.  Unknown flags are silently ignored so that the CLI remains
+    forward-compatible with new MMG options.
+    """
+    parsed = _ParsedArgs()
+    i = 0
+    while i < len(args):
+        arg = args[i]
+
+        # -- flags with a value argument -------------------------------------
+        if arg in _FLAGS_WITH_VALUE and i + 1 < len(args):
+            value = args[i + 1]
+            if arg in ("-in",):
+                parsed.input_mesh = value
+            elif arg in ("-o", "-out"):
+                parsed.output_mesh = value
+            elif arg == "-sol":
+                parsed.sol_file = value
+            elif arg == "-met":
+                parsed.met_file = value
+            elif arg == "-ls":
+                parsed.ls_value = float(value)
+            elif arg == "-lag":
+                parsed.lag_value = int(value)
+            elif arg == "-v":
+                parsed.remesh_options["verbose"] = int(value)
+            elif arg == "-m":
+                parsed.remesh_options["mem"] = int(value)
+            elif arg in _NUMERIC_OPTION_FLAGS:
+                key = arg.lstrip("-")
+                parsed.remesh_options[key] = float(value)
+            # -nr and other unknown value-flags are skipped
+            i += 2
+            continue
+
+        # -- boolean flags (no value) ----------------------------------------
+        if arg in _BOOLEAN_OPTION_FLAGS:
+            key = arg.lstrip("-")
+            parsed.remesh_options[key] = 1
+            i += 1
+            continue
+
+        # -- positional: first non-flag existing file is input ---------------
+        if not arg.startswith("-") and parsed.input_mesh is None and Path(arg).exists():
+            parsed.input_mesh = arg
+
+        i += 1
+
+    return parsed
+
+
+def _default_output_path(input_path: str) -> str:
+    """Derive the default output path following MMG convention.
+
+    ``input.mesh`` → ``input.o.mesh``
+    """
+    p = Path(input_path)
+    return str(p.with_name(f"{p.stem}.o{p.suffix}"))
+
+
+# -- Main entry point -------------------------------------------------------
 
 
 def _run_mmg() -> None:  # pragma: no cover
-    """Run the appropriate mmg executable based on auto-detected mesh type.
+    """Run the unified ``mmg`` command.
 
-    This unified command automatically detects the mesh type from the input file
-    and delegates to the appropriate mmg2d_O3, mmg3d_O3, or mmgs_O3 executable.
+    Auto-detects mesh type from the input file, then remeshes via the
+    Python API (single read, no subprocess).
     """
-    from ._io import read as _read  # noqa: PLC0415
-    from ._mesh import MeshKind  # noqa: PLC0415
-
     args = sys.argv[1:]
+
+    # -- help ----------------------------------------------------------------
     if not args or args[0] in ("-h", "--help"):
         print(
             "mmg - Unified mesh remeshing tool with auto-detection\n\n"
-            "Usage: mmg <input_mesh> [options]\n\n"
-            "This command automatically detects the mesh type and delegates to:\n"
-            "  - mmg2d (or mmg2d_O3) for 2D planar meshes (triangles with z~=0)\n"
-            "  - mmg3d (or mmg3d_O3) for 3D volumetric meshes (tetrahedra)\n"
-            "  - mmgs (or mmgs_O3) for 3D surface meshes (triangles in 3D space)\n\n"
-            "All standard mmg options are passed through to the executable.\n"
-            "Run 'mmg3d -h', 'mmg2d -h', or 'mmgs -h' for specific options.",
+            "Usage: mmg [options] <input_mesh>\n"
+            "       mmg <input_mesh> [options]\n\n"
+            "This command automatically detects the mesh type and remeshes\n"
+            "using the appropriate MMG library (mmg2d, mmg3d, or mmgs).\n\n"
+            "Options:\n"
+            "  -in <file>      Input mesh file (or pass as positional arg)\n"
+            "  -o <file>       Output mesh file (default: <input>.o.<ext>)\n"
+            "  -sol <file>     Input solution file (.sol/.solb)\n"
+            "  -met <file>     Input metric file (.sol/.solb)\n"
+            "  -hmin <val>     Minimum edge size\n"
+            "  -hmax <val>     Maximum edge size\n"
+            "  -hsiz <val>     Constant edge size\n"
+            "  -hausd <val>    Hausdorff distance for geometry approximation\n"
+            "  -hgrad <val>    Gradation parameter (>= 1.0)\n"
+            "  -hgradreq <val> Gradation on required entities\n"
+            "  -ar <val>       Angle detection threshold (degrees)\n"
+            "  -ls <val>       Level-set mode with isovalue\n"
+            "  -lag <val>      Lagrangian mode (0, 1, or 2)\n"
+            "  -v <val>        Verbosity (-1=silent, 0=errors, 1=info)\n"
+            "  -m <val>        Maximum memory (MB)\n"
+            "  -noinsert       Disable point insertion\n"
+            "  -noswap         Disable edge/face swapping\n"
+            "  -nomove         Disable point relocation\n"
+            "  -nosurf         Disable surface modifications\n"
+            "  -optim          Optimization mode (no topology changes)\n"
+            "  -h, --help      Show this help message\n"
+            "  -V, --version   Show version information",
         )
         sys.exit(0)
 
-    if args[0] in ("-v", "--version"):
-        # Lazy-import version info only when needed
+    # -- version -------------------------------------------------------------
+    if args[0] in ("-V", "--version"):
         try:
             from . import _version  # type: ignore[attr-defined]  # noqa: PLC0415
 
@@ -178,72 +299,86 @@ def _run_mmg() -> None:  # pragma: no cover
         print(f"MMG   {MMG_VERSION}")
         sys.exit(0)
 
-    # MMG flags that take an argument (skip the next arg when detecting input file)
-    flags_with_args = {
-        "-o",
-        "-out",
-        "-sol",
-        "-met",
-        "-ls",
-        "-lag",
-        "-ar",
-        "-nr",
-        "-hmin",
-        "-hmax",
-        "-hsiz",
-        "-hausd",
-        "-hgrad",
-        "-hgradreq",
-        "-m",
-        "-v",
-        "-xreg",
-        "-nreg",
-        "-nsd",
-    }
+    # -- parse arguments -----------------------------------------------------
+    parsed = _parse_args(args)
 
-    # Find the input mesh file (first positional argument that's a file)
-    input_mesh = None
-    skip_next = False
-    for arg in args:
-        if skip_next:
-            skip_next = False
-            continue
-        if arg in flags_with_args:
-            skip_next = True
-            continue
-        if not arg.startswith("-") and Path(arg).exists():
-            input_mesh = arg
-            break
-
-    if input_mesh is None:
+    if parsed.input_mesh is None:
         _get_cli_logger().error("No input mesh file found in arguments")
         sys.exit(1)
 
-    # Detect mesh type (input_mesh is str after the None check above)
+    input_path = Path(str(parsed.input_mesh))
+    if not input_path.exists():
+        _get_cli_logger().error("Input file does not exist: %s", input_path)
+        sys.exit(1)
+
+    # -- read mesh (single read, auto-detects type) --------------------------
+    from ._io import read as _read  # noqa: PLC0415
+    from ._logging import get_logger  # noqa: PLC0415
+
     try:
-        mesh = _read(str(input_mesh))
-        mesh_kind = mesh.kind
+        mesh = _read(str(input_path))
     except Exception:  # noqa: BLE001
         _get_cli_logger().exception(
-            "Failed to detect mesh type from '%s'. "
-            "Try using a specific command instead: mmg3d, mmg2d, or mmgs",
-            input_mesh,
+            "Failed to read mesh from '%s'",
+            input_path,
         )
         sys.exit(1)
 
-    # Map mesh kind to executable
-    exe_map = {
-        MeshKind.TETRAHEDRAL: ("mmg3d_O3", _run_mmg3d),
-        MeshKind.TRIANGULAR_2D: ("mmg2d_O3", _run_mmg2d),
-        MeshKind.TRIANGULAR_SURFACE: ("mmgs_O3", _run_mmgs),
-    }
+    get_logger().info("Detected %s mesh", mesh.kind.value)
 
-    exe_name, run_func = exe_map[mesh_kind]
+    # -- load solution / metric files ----------------------------------------
+    if parsed.sol_file is not None:
+        mesh._impl.load_sol(str(parsed.sol_file))  # noqa: SLF001
 
-    # Lazy-import logger from main package only for info message
-    from ._logging import get_logger  # noqa: PLC0415
+    if parsed.met_file is not None:
+        mesh._impl.load_sol(str(parsed.met_file))  # noqa: SLF001
 
-    get_logger().info("Detected %s mesh, using %s", mesh_kind.value, exe_name)
+    # -- remesh --------------------------------------------------------------
+    try:
+        if parsed.ls_value is not None:
+            result = mesh.remesh_levelset(
+                mesh["levelset"],
+                ls=parsed.ls_value,
+                progress=False,
+                **parsed.remesh_options,
+            )
+        elif parsed.lag_value is not None:
+            result = mesh.remesh_lagrangian(
+                mesh["displacement"],
+                progress=False,
+                **parsed.remesh_options,
+            )
+        else:
+            result = mesh.remesh(
+                progress=False,
+                **parsed.remesh_options,
+            )
+    except Exception:  # noqa: BLE001
+        _get_cli_logger().exception("Remeshing failed")
+        sys.exit(1)
 
-    # Delegate to the appropriate executable
-    run_func()
+    # -- save output ---------------------------------------------------------
+    output_path = parsed.output_mesh or _default_output_path(str(input_path))
+
+    try:
+        mesh.save(output_path)
+    except Exception:  # noqa: BLE001
+        _get_cli_logger().exception("Failed to save output to '%s'", output_path)
+        sys.exit(1)
+
+    # Save solution alongside output if one was loaded
+    if parsed.sol_file is not None or parsed.met_file is not None:
+        output_sol_path = Path(output_path).with_suffix(".sol")
+        try:
+            mesh._impl.save_sol(str(output_sol_path))  # noqa: SLF001
+        except Exception:  # noqa: BLE001
+            _get_cli_logger().warning(
+                "Failed to save solution to '%s'",
+                output_sol_path,
+            )
+
+    if not result.success:
+        _get_cli_logger().error("Remeshing completed with errors")
+        sys.exit(1)
+
+    sys.exit(0)

--- a/src/mmgpy/_cli.py
+++ b/src/mmgpy/_cli.py
@@ -34,7 +34,11 @@ def _get_cli_logger() -> logging.Logger:  # pragma: no cover
 
 
 def _ensure_executable(path: Path) -> None:  # pragma: no cover
-    """Ensure a file has execute permissions (Unix only)."""
+    """Ensure a file has execute permissions (Unix only).
+
+    .. note:: Kept for the public API re-export in ``__init__.py``
+       (used by tests and downstream code).
+    """
     if sys.platform == "win32":
         return
 
@@ -53,6 +57,10 @@ def _ensure_executable(path: Path) -> None:  # pragma: no cover
 
 def _find_mmg_executable(base_name: str) -> str | None:  # pragma: no cover
     """Find an MMG executable in mmgpy/bin, venv bin, or system PATH.
+
+    .. note:: No longer used by the CLI entry point (the unified ``mmg``
+       command calls the Python API directly).  Kept for the public
+       re-export in ``__init__.py`` and for test usage.
 
     Args:
         base_name: Base name of executable (e.g., "mmg3d_O3")
@@ -126,7 +134,7 @@ _FLAGS_WITH_VALUE = {
     "-ls",
     "-lag",
     "-ar",
-    "-nr",
+    "-nr",  # consumed but intentionally unhandled (MMG no-ridge flag)
     "-hmin",
     "-hmax",
     "-hsiz",
@@ -192,7 +200,7 @@ def _parse_args(args: list[str]) -> _ParsedArgs:
         # -- flags with a value argument -------------------------------------
         if arg in _FLAGS_WITH_VALUE and i + 1 < len(args):
             value = args[i + 1]
-            if arg in ("-in",):
+            if arg == "-in":
                 parsed.input_mesh = value
             elif arg in ("-o", "-out"):
                 parsed.output_mesh = value
@@ -327,6 +335,13 @@ def _run_mmg() -> None:  # pragma: no cover
     get_logger().info("Detected %s mesh", mesh.kind.value)
 
     # -- load solution / metric files ----------------------------------------
+    if parsed.sol_file is not None and parsed.met_file is not None:
+        _get_cli_logger().error(
+            "-sol and -met cannot both be specified "
+            "(the second would overwrite the first)",
+        )
+        sys.exit(1)
+
     if parsed.sol_file is not None:
         mesh._impl.load_sol(str(parsed.sol_file))  # noqa: SLF001
 
@@ -336,6 +351,12 @@ def _run_mmg() -> None:  # pragma: no cover
     # -- remesh --------------------------------------------------------------
     try:
         if parsed.ls_value is not None:
+            if "levelset" not in mesh:
+                _get_cli_logger().error(
+                    "-ls requires a 'levelset' field in the mesh; "
+                    "load one with -sol or set it via the Python API",
+                )
+                sys.exit(1)
             result = mesh.remesh_levelset(
                 mesh["levelset"],
                 ls=parsed.ls_value,
@@ -343,6 +364,12 @@ def _run_mmg() -> None:  # pragma: no cover
                 **parsed.remesh_options,
             )
         elif parsed.lag_value is not None:
+            if "displacement" not in mesh:
+                _get_cli_logger().error(
+                    "-lag requires a 'displacement' field in the mesh; "
+                    "load one with -sol or set it via the Python API",
+                )
+                sys.exit(1)
             result = mesh.remesh_lagrangian(
                 mesh["displacement"],
                 progress=False,

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
+
+from mmgpy._cli import _default_output_path, _parse_args
 
 
 @pytest.fixture
@@ -74,18 +75,195 @@ End
     return mesh_file
 
 
+class TestParseArgs:
+    """Test _parse_args() argument parsing."""
+
+    def test_positional_input(self, test_mesh_3d: Path) -> None:
+        """Positional argument is detected as input file."""
+        result = _parse_args([str(test_mesh_3d)])
+        assert result.input_mesh == str(test_mesh_3d)
+
+    def test_explicit_input_flag(self, test_mesh_3d: Path) -> None:
+        """The -in flag sets the input file."""
+        result = _parse_args(["-in", str(test_mesh_3d)])
+        assert result.input_mesh == str(test_mesh_3d)
+
+    def test_output_flag_short(
+        self,
+        test_mesh_3d: Path,
+        tmp_path: Path,
+    ) -> None:
+        """The -o flag sets the output file."""
+        out = str(tmp_path / "out.mesh")
+        result = _parse_args([str(test_mesh_3d), "-o", out])
+        assert result.output_mesh == out
+
+    def test_output_flag_long(
+        self,
+        test_mesh_3d: Path,
+        tmp_path: Path,
+    ) -> None:
+        """The -out flag sets the output file."""
+        out = str(tmp_path / "out.mesh")
+        result = _parse_args([str(test_mesh_3d), "-out", out])
+        assert result.output_mesh == out
+
+    def test_numeric_options(self, test_mesh_3d: Path) -> None:
+        """Numeric flags are parsed into remesh_options."""
+        result = _parse_args(
+            [
+                str(test_mesh_3d),
+                "-hmax",
+                "0.5",
+                "-hmin",
+                "0.01",
+                "-hausd",
+                "0.001",
+                "-hgrad",
+                "1.3",
+            ],
+        )
+        assert result.remesh_options["hmax"] == 0.5
+        assert result.remesh_options["hmin"] == 0.01
+        assert result.remesh_options["hausd"] == 0.001
+        assert result.remesh_options["hgrad"] == 1.3
+
+    def test_verbose_flag(self, test_mesh_3d: Path) -> None:
+        """The -v flag maps to verbose."""
+        result = _parse_args([str(test_mesh_3d), "-v", "1"])
+        assert result.remesh_options["verbose"] == 1
+
+    def test_memory_flag(self, test_mesh_3d: Path) -> None:
+        """The -m flag maps to mem."""
+        result = _parse_args([str(test_mesh_3d), "-m", "512"])
+        assert result.remesh_options["mem"] == 512
+
+    def test_boolean_flags(self, test_mesh_3d: Path) -> None:
+        """Boolean flags (no value) are parsed as 1."""
+        result = _parse_args(
+            [
+                str(test_mesh_3d),
+                "-noinsert",
+                "-noswap",
+                "-nomove",
+            ],
+        )
+        assert result.remesh_options["noinsert"] == 1
+        assert result.remesh_options["noswap"] == 1
+        assert result.remesh_options["nomove"] == 1
+
+    def test_levelset_flag(self, test_mesh_3d: Path) -> None:
+        """The -ls flag triggers level-set mode."""
+        result = _parse_args([str(test_mesh_3d), "-ls", "0.5"])
+        assert result.ls_value == 0.5
+
+    def test_lagrangian_flag(self, test_mesh_3d: Path) -> None:
+        """The -lag flag triggers Lagrangian mode."""
+        result = _parse_args([str(test_mesh_3d), "-lag", "1"])
+        assert result.lag_value == 1
+
+    def test_sol_and_met_flags(self, test_mesh_3d: Path) -> None:
+        """The -sol and -met flags are parsed."""
+        result = _parse_args(
+            [
+                str(test_mesh_3d),
+                "-sol",
+                "input.sol",
+                "-met",
+                "metric.sol",
+            ],
+        )
+        assert result.sol_file == "input.sol"
+        assert result.met_file == "metric.sol"
+
+    def test_output_before_input(
+        self,
+        test_mesh_3d: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Input is detected even when -o comes before the positional arg."""
+        out = str(tmp_path / "out.mesh")
+        result = _parse_args(["-o", out, str(test_mesh_3d)])
+        assert result.input_mesh == str(test_mesh_3d)
+        assert result.output_mesh == out
+
+    def test_mixed_flags_order(
+        self,
+        test_mesh_3d: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Flags in any order are parsed correctly."""
+        out = str(tmp_path / "out.mesh")
+        result = _parse_args(
+            [
+                "-hmax",
+                "0.5",
+                str(test_mesh_3d),
+                "-o",
+                out,
+                "-noinsert",
+                "-v",
+                "-1",
+            ],
+        )
+        assert result.input_mesh == str(test_mesh_3d)
+        assert result.output_mesh == out
+        assert result.remesh_options["hmax"] == 0.5
+        assert result.remesh_options["noinsert"] == 1
+        assert result.remesh_options["verbose"] == -1
+
+    def test_no_input_returns_none(self) -> None:
+        """No input file results in input_mesh=None."""
+        result = _parse_args(["-hmax", "0.5"])
+        assert result.input_mesh is None
+
+    def test_nonexistent_positional_ignored(self) -> None:
+        """A positional arg that doesn't exist as a file is ignored."""
+        result = _parse_args(["nonexistent_file.mesh"])
+        assert result.input_mesh is None
+
+    def test_angle_detection(self, test_mesh_3d: Path) -> None:
+        """The -ar flag is parsed as a numeric option."""
+        result = _parse_args([str(test_mesh_3d), "-ar", "30"])
+        assert result.remesh_options["ar"] == 30.0
+
+    def test_optim_flag(self, test_mesh_3d: Path) -> None:
+        """The -optim flag is parsed as boolean."""
+        result = _parse_args([str(test_mesh_3d), "-optim"])
+        assert result.remesh_options["optim"] == 1
+
+    def test_hsiz_flag(self, test_mesh_3d: Path) -> None:
+        """The -hsiz flag is parsed as a numeric option."""
+        result = _parse_args([str(test_mesh_3d), "-hsiz", "0.1"])
+        assert result.remesh_options["hsiz"] == 0.1
+
+
+class TestDefaultOutputPath:
+    """Test _default_output_path() convention."""
+
+    def test_mesh_extension(self) -> None:
+        """Standard .mesh extension."""
+        assert _default_output_path("input.mesh") == "input.o.mesh"
+
+    def test_meshb_extension(self) -> None:
+        """Binary .meshb extension."""
+        assert _default_output_path("input.meshb") == "input.o.meshb"
+
+    def test_vtk_extension(self) -> None:
+        """VTK extension."""
+        assert _default_output_path("model.vtk") == "model.o.vtk"
+
+    def test_path_with_directory(self) -> None:
+        """Full path is preserved."""
+        expected = "/data/meshes/cube.o.mesh"
+        assert _default_output_path("/data/meshes/cube.mesh") == expected
+
+
 class TestMmgCLI:
     """Test mmg CLI command."""
 
     def test_mmg_help(self) -> None:
         """Test mmg --help shows help message."""
-        result = subprocess.run(
-            [sys.executable, "-m", "mmgpy", "--help"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        # mmgpy module doesn't have --help, use the entry point directly
         result = subprocess.run(
             ["mmg", "--help"],
             capture_output=True,
@@ -93,7 +271,7 @@ class TestMmgCLI:
             check=False,
         )
         assert result.returncode == 0
-        assert "mmg" in result.stdout.lower() or "usage" in result.stdout.lower()
+        assert "usage" in result.stdout.lower() or "mmg" in result.stdout.lower()
 
     def test_mmg_version(self) -> None:
         """Test mmg --version shows version info."""
@@ -127,7 +305,6 @@ class TestMmgCLI:
             check=False,
         )
         assert result.returncode != 0
-        # Error may be in stdout (rich logger) or stderr
         combined_output = result.stdout + result.stderr
         assert "No input mesh file found" in combined_output
 
@@ -140,7 +317,7 @@ class TestMmgInputDetection:
         test_mesh_3d: Path,
         tmp_path: Path,
     ) -> None:
-        """Test that input is detected when -o flag comes before it."""
+        """Input is detected when -o flag comes before it."""
         output_file = tmp_path / "output.mesh"
         result = subprocess.run(
             ["mmg", "-o", str(output_file), str(test_mesh_3d)],
@@ -149,21 +326,15 @@ class TestMmgInputDetection:
             check=False,
             timeout=30,
         )
-        # Should detect mesh and delegate to mmg3d
-        # Or show "not found" if executables not available (editable installs)
         combined = result.stdout + result.stderr
-        assert (
-            "Detected" in combined
-            or result.returncode == 0
-            or "not found" in combined.lower()
-        )
+        assert result.returncode == 0 or "Detected" in combined
 
     def test_detects_input_with_hmax_flag(
         self,
         test_mesh_3d: Path,
         tmp_path: Path,
     ) -> None:
-        """Test that input is detected when -hmax flag is present."""
+        """Input is detected when -hmax flag is present."""
         output_file = tmp_path / "output.mesh"
         result = subprocess.run(
             ["mmg", "-hmax", "0.5", str(test_mesh_3d), "-o", str(output_file)],
@@ -172,14 +343,8 @@ class TestMmgInputDetection:
             check=False,
             timeout=30,
         )
-        # Should detect mesh and delegate to mmg3d
-        # Or show "not found" if executables not available (editable installs)
         combined = result.stdout + result.stderr
-        assert (
-            "Detected" in combined
-            or result.returncode == 0
-            or "not found" in combined.lower()
-        )
+        assert result.returncode == 0 or "Detected" in combined
 
 
 class TestMmgMeshTypeDetection:
@@ -190,7 +355,7 @@ class TestMmgMeshTypeDetection:
         test_mesh_3d: Path,
         tmp_path: Path,
     ) -> None:
-        """Test detection of 3D tetrahedral mesh."""
+        """3D tetrahedral mesh is detected and remeshed."""
         output_file = tmp_path / "output.mesh"
         result = subprocess.run(
             ["mmg", str(test_mesh_3d), "-o", str(output_file)],
@@ -199,21 +364,15 @@ class TestMmgMeshTypeDetection:
             check=False,
             timeout=30,
         )
-        # Should detect tetrahedral mesh and use mmg3d
-        # Or show "not found" if executables not available (editable installs)
         combined = (result.stdout + result.stderr).lower()
-        assert (
-            "tetrahedral" in combined
-            or result.returncode == 0
-            or "not found" in combined
-        )
+        assert "tetrahedral" in combined or result.returncode == 0
 
     def test_detects_surface_mesh(
         self,
         test_mesh_surface: Path,
         tmp_path: Path,
     ) -> None:
-        """Test detection of surface mesh."""
+        """Surface mesh is detected and remeshed."""
         output_file = tmp_path / "output.mesh"
         result = subprocess.run(
             ["mmg", str(test_mesh_surface), "-o", str(output_file)],
@@ -222,15 +381,11 @@ class TestMmgMeshTypeDetection:
             check=False,
             timeout=30,
         )
-        # Should detect surface mesh and use mmgs
-        # Or show "not found" if executables not available (editable installs)
         combined = (result.stdout + result.stderr).lower()
-        assert (
-            "surface" in combined or result.returncode == 0 or "not found" in combined
-        )
+        assert "surface" in combined or result.returncode == 0
 
     def test_detects_2d_mesh(self, test_mesh_2d: Path, tmp_path: Path) -> None:
-        """Test detection of 2D mesh."""
+        """2D mesh is detected and remeshed."""
         output_file = tmp_path / "output.mesh"
         result = subprocess.run(
             ["mmg", str(test_mesh_2d), "-o", str(output_file)],
@@ -239,64 +394,81 @@ class TestMmgMeshTypeDetection:
             check=False,
             timeout=30,
         )
-        # Should detect 2D mesh and use mmg2d
-        # Or show "not found" if executables not available (editable installs)
         combined = (result.stdout + result.stderr).lower()
-        assert "2d" in combined or result.returncode == 0 or "not found" in combined
+        assert "2d" in combined or result.returncode == 0
 
 
-class TestMmgAliases:
-    """Test command aliases (mmg2d, mmg3d, mmgs)."""
+class TestMmgRemeshing:
+    """Test that the mmg CLI actually produces output files."""
 
-    def test_mmg3d_alias_runs(self) -> None:
-        """Test that mmg3d alias works."""
+    def test_remesh_produces_output(
+        self,
+        test_mesh_3d: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Remeshing creates an output file."""
+        output_file = tmp_path / "output.mesh"
         result = subprocess.run(
-            ["mmg3d", "-h"],
+            ["mmg", str(test_mesh_3d), "-o", str(output_file), "-v", "-1"],
             capture_output=True,
             text=True,
             check=False,
             timeout=30,
         )
-        # Should show help, run successfully, or show "not found" for editable installs
-        combined = (result.stdout + result.stderr).lower()
-        assert result.returncode == 0 or "usage" in combined or "not found" in combined
+        assert result.returncode == 0
+        assert output_file.exists()
 
-    def test_mmg2d_alias_runs(self) -> None:
-        """Test that mmg2d alias works."""
+    def test_default_output_naming(
+        self,
+        test_mesh_3d: Path,
+    ) -> None:
+        """Without -o, output follows the {stem}.o{ext} convention."""
         result = subprocess.run(
-            ["mmg2d", "-h"],
+            ["mmg", str(test_mesh_3d), "-v", "-1"],
             capture_output=True,
             text=True,
             check=False,
             timeout=30,
         )
-        # Should show help, run successfully, or show "not found" for editable installs
-        combined = (result.stdout + result.stderr).lower()
-        assert result.returncode == 0 or "usage" in combined or "not found" in combined
+        assert result.returncode == 0
+        expected_output = test_mesh_3d.with_name("test.o.mesh")
+        assert expected_output.exists()
 
-    def test_mmgs_alias_runs(self) -> None:
-        """Test that mmgs alias works."""
+    def test_remesh_with_options(
+        self,
+        test_mesh_3d: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Remeshing with -hmax option works."""
+        output_file = tmp_path / "output.mesh"
         result = subprocess.run(
-            ["mmgs", "-h"],
+            [
+                "mmg",
+                str(test_mesh_3d),
+                "-o",
+                str(output_file),
+                "-hmax",
+                "0.5",
+                "-v",
+                "-1",
+            ],
             capture_output=True,
             text=True,
             check=False,
             timeout=30,
         )
-        # Should show help, run successfully, or show "not found" for editable installs
-        combined = (result.stdout + result.stderr).lower()
-        assert result.returncode == 0 or "usage" in combined or "not found" in combined
+        assert result.returncode == 0
+        assert output_file.exists()
 
 
 class TestMmgErrorHandling:
     """Test error handling and helpful messages."""
 
-    def test_unsupported_format_suggests_specific_command(
+    def test_unsupported_format_shows_error(
         self,
         tmp_path: Path,
     ) -> None:
-        """Test that unsupported format gives helpful suggestion."""
-        # Create a file with completely unrecognizable format
+        """Unrecognizable file format gives a clear error."""
         bad_file = tmp_path / "bad.xyz123"
         bad_file.write_text("invalid mesh content that cannot be parsed")
 
@@ -308,11 +480,5 @@ class TestMmgErrorHandling:
             timeout=30,
         )
         assert result.returncode != 0
-        # Should suggest using specific commands (error may be in stdout or stderr)
         combined_output = result.stdout + result.stderr
-        assert (
-            "mmg3d" in combined_output
-            or "mmg2d" in combined_output
-            or "mmgs" in combined_output
-            or "Failed to detect" in combined_output
-        )
+        assert "Failed to read" in combined_output or "Error" in combined_output

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -255,8 +255,8 @@ class TestDefaultOutputPath:
 
     def test_path_with_directory(self) -> None:
         """Full path is preserved."""
-        expected = "/data/meshes/cube.o.mesh"
-        assert _default_output_path("/data/meshes/cube.mesh") == expected
+        result = Path(_default_output_path("/data/meshes/cube.mesh"))
+        assert result == Path("/data/meshes/cube.o.mesh")
 
 
 class TestMmgCLI:

--- a/tests/wheel_executable_test.py
+++ b/tests/wheel_executable_test.py
@@ -168,46 +168,6 @@ class TestExecutableRuns:
 class TestPythonEntryPoints:
     """Test that Python entry points work correctly."""
 
-    def test_mmg3d_entry_point(self) -> None:
-        """Test that mmg3d entry point works."""
-        result = subprocess.run(
-            ["mmg3d", "-h"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-        # Entry point should either show help (returncode 0) or fail gracefully
-        # Error message may be in stdout (rich logger) or stderr
-        combined = (result.stdout + result.stderr).lower()
-        assert result.returncode == 0 or "not found" in combined
-
-    def test_mmg2d_entry_point(self) -> None:
-        """Test that mmg2d entry point works."""
-        result = subprocess.run(
-            ["mmg2d", "-h"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-        # Error message may be in stdout (rich logger) or stderr
-        combined = (result.stdout + result.stderr).lower()
-        assert result.returncode == 0 or "not found" in combined
-
-    def test_mmgs_entry_point(self) -> None:
-        """Test that mmgs entry point works."""
-        result = subprocess.run(
-            ["mmgs", "-h"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-        # Error message may be in stdout (rich logger) or stderr
-        combined = (result.stdout + result.stderr).lower()
-        assert result.returncode == 0 or "not found" in combined
-
     def test_mmg_unified_entry_point(self) -> None:
         """Test that unified mmg entry point shows help."""
         result = subprocess.run(


### PR DESCRIPTION
## Summary

- Rewrite the `mmg` CLI to read the mesh once and remesh via the Python API instead of spawning a subprocess that re-reads the file. Eliminates double-read overhead and subprocess startup cost.
- Remove `mmg3d`, `mmg2d`, `mmgs` entry points — only the unified `mmg` command remains (auto-detects mesh type).
- Add structured argument parser (`_parse_args()`) supporting all MMG flags: sizing (`-hmax`, `-hmin`, `-hsiz`, `-hausd`), geometry (`-hgrad`, `-ar`), modes (`-ls`, `-lag`, `-optim`), and boolean flags (`-noinsert`, `-noswap`, `-nomove`, `-nosurf`).
- Add `_default_output_path()` following MMG convention (`input.mesh` → `input.o.mesh`).

Relates to #136 (benchmark redesign will follow in a separate PR).

## Test plan

- [x] 35 CLI tests pass (18 unit tests for `_parse_args`, 4 for output path, 13 integration)
- [x] 888 total tests pass, 0 failures
- [x] All pre-commit hooks pass (ruff, ty, codespell, etc.)
- [ ] Verify `mmg input.mesh -hmax 0.15 -o output.mesh` produces correct output
- [ ] Verify default output naming: `mmg input.mesh` creates `input.o.mesh`
- [ ] Verify auto-detection works for 3D, 2D, and surface meshes