### PR TITLE
feat: add refs parameter to Mesh constructor

### DIFF
--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -264,6 +264,7 @@ def _create_impl(
     vertices: NDArray[np.floating],
     cells: NDArray[np.integer],
     kind: MeshKind,
+    refs: NDArray[np.int64] | None = None,
 ) -> MmgMesh3D | MmgMesh2D | MmgMeshS:
     """Create the appropriate mesh implementation.
 
@@ -275,6 +276,8 @@ def _create_impl(
         Cell connectivity.
     kind : MeshKind
         Mesh kind to create.
+    refs : ndarray, optional
+        Reference markers for each cell.
 
     Returns
     -------
@@ -285,17 +288,42 @@ def _create_impl(
     vertices = np.ascontiguousarray(vertices, dtype=np.float64)
     cells = np.ascontiguousarray(cells, dtype=np.int32)
 
+    if refs is None:
+        if kind == MeshKind.TETRAHEDRAL:
+            return MmgMesh3D(vertices, cells)
+        if kind == MeshKind.TRIANGULAR_2D:
+            if vertices.shape[1] == _DIMS_3D:
+                vertices = np.ascontiguousarray(vertices[:, :2])
+            return MmgMesh2D(vertices, cells)
+        if kind == MeshKind.TRIANGULAR_SURFACE:
+            return MmgMeshS(vertices, cells)
+        msg = f"Unknown mesh kind: {kind}"
+        raise ValueError(msg)
+
+    refs = np.ascontiguousarray(refs, dtype=np.int64)
+
     if kind == MeshKind.TETRAHEDRAL:
-        return MmgMesh3D(vertices, cells)
+        impl = MmgMesh3D()
+        impl.set_mesh_size(vertices=len(vertices), tetrahedra=len(cells))
+        impl.set_vertices(vertices)
+        impl.set_tetrahedra(cells, refs)
+        return impl
 
     if kind == MeshKind.TRIANGULAR_2D:
-        # Ensure 2D vertices
         if vertices.shape[1] == _DIMS_3D:
             vertices = np.ascontiguousarray(vertices[:, :2])
-        return MmgMesh2D(vertices, cells)
+        impl = MmgMesh2D()
+        impl.set_mesh_size(vertices=len(vertices), triangles=len(cells))
+        impl.set_vertices(vertices)
+        impl.set_triangles(cells, refs)
+        return impl
 
     if kind == MeshKind.TRIANGULAR_SURFACE:
-        return MmgMeshS(vertices, cells)
+        impl = MmgMeshS()
+        impl.set_mesh_size(vertices=len(vertices), triangles=len(cells))
+        impl.set_vertices(vertices)
+        impl.set_triangles(cells, refs)
+        return impl
 
     msg = f"Unknown mesh kind: {kind}"
     raise ValueError(msg)
@@ -491,6 +519,7 @@ class Mesh:
         self,
         source: NDArray[np.floating] | str | Path | pv.UnstructuredGrid | pv.PolyData,
         cells: NDArray[np.integer] | None = None,
+        refs: NDArray[np.integer] | None = None,
     ) -> None:
         """Initialize a Mesh from various sources."""
         # Import here to avoid circular imports
@@ -524,9 +553,10 @@ class Mesh:
 
         vertices = np.asarray(source)
         cells = np.asarray(cells)
+        cell_refs = np.asarray(refs, dtype=np.int64) if refs is not None else None
 
         self._kind = _detect_mesh_kind(vertices, cells)
-        self._impl = _create_impl(vertices, cells, self._kind)
+        self._impl = _create_impl(vertices, cells, self._kind, refs=cell_refs)
 
     @classmethod
     def _from_impl(

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -288,19 +288,11 @@ def _create_impl(
     vertices = np.ascontiguousarray(vertices, dtype=np.float64)
     cells = np.ascontiguousarray(cells, dtype=np.int32)
 
-    if refs is None:
-        if kind == MeshKind.TETRAHEDRAL:
-            return MmgMesh3D(vertices, cells)
-        if kind == MeshKind.TRIANGULAR_2D:
-            if vertices.shape[1] == _DIMS_3D:
-                vertices = np.ascontiguousarray(vertices[:, :2])
-            return MmgMesh2D(vertices, cells)
-        if kind == MeshKind.TRIANGULAR_SURFACE:
-            return MmgMeshS(vertices, cells)
-        msg = f"Unknown mesh kind: {kind}"
-        raise ValueError(msg)
-
-    refs = np.ascontiguousarray(refs, dtype=np.int64)
+    if refs is not None:
+        refs = np.ascontiguousarray(refs, dtype=np.int64)
+        if len(refs) != len(cells):
+            msg = f"refs length ({len(refs)}) must match cells length ({len(cells)})"
+            raise ValueError(msg)
 
     if kind == MeshKind.TETRAHEDRAL:
         impl = MmgMesh3D()
@@ -532,6 +524,9 @@ class Mesh:
 
         # Handle PyVista objects
         if isinstance(source, pv.UnstructuredGrid | pv.PolyData):
+            if refs is not None:
+                msg = "refs parameter is only supported when source is a vertices array"
+                raise ValueError(msg)
             result = _read_mesh(source)
             self._impl = result._impl  # noqa: SLF001
             self._kind = result._kind  # noqa: SLF001
@@ -540,6 +535,9 @@ class Mesh:
 
         # Handle file paths
         if isinstance(source, str | Path):
+            if refs is not None:
+                msg = "refs parameter is only supported when source is a vertices array"
+                raise ValueError(msg)
             result = _read_mesh(source)
             self._impl = result._impl  # noqa: SLF001
             self._kind = result._kind  # noqa: SLF001
@@ -553,7 +551,7 @@ class Mesh:
 
         vertices = np.asarray(source)
         cells = np.asarray(cells)
-        cell_refs = np.asarray(refs, dtype=np.int64) if refs is not None else None
+        cell_refs = np.asarray(refs) if refs is not None else None
 
         self._kind = _detect_mesh_kind(vertices, cells)
         self._impl = _create_impl(vertices, cells, self._kind, refs=cell_refs)

--- a/tests/mesh_unified_test.py
+++ b/tests/mesh_unified_test.py
@@ -173,6 +173,45 @@ class TestMeshConstructor:
         assert mesh.kind == MeshKind.TETRAHEDRAL
         assert len(mesh.get_vertices()) == 4
 
+    def test_tetrahedral_with_refs(
+        self,
+        tetra_vertices: np.ndarray,
+        tetra_cells: np.ndarray,
+    ) -> None:
+        """Test creating tetrahedral mesh with cell refs."""
+        refs = np.array([5], dtype=np.int64)
+        mesh = Mesh(tetra_vertices, tetra_cells, refs=refs)
+
+        assert mesh.kind == MeshKind.TETRAHEDRAL
+        _, retrieved_refs = mesh.get_tetrahedra_with_refs()
+        np.testing.assert_array_equal(retrieved_refs, refs)
+
+    def test_2d_with_refs(
+        self,
+        triangle_2d_vertices: np.ndarray,
+        triangle_cells: np.ndarray,
+    ) -> None:
+        """Test creating 2D mesh with cell refs."""
+        refs = np.array([3], dtype=np.int64)
+        mesh = Mesh(triangle_2d_vertices, triangle_cells, refs=refs)
+
+        assert mesh.kind == MeshKind.TRIANGULAR_2D
+        _, retrieved_refs = mesh.get_triangles_with_refs()
+        np.testing.assert_array_equal(retrieved_refs, refs)
+
+    def test_surface_with_refs(
+        self,
+        triangle_3d_vertices: np.ndarray,
+        triangle_cells: np.ndarray,
+    ) -> None:
+        """Test creating surface mesh with cell refs."""
+        refs = np.array([7], dtype=np.int64)
+        mesh = Mesh(triangle_3d_vertices, triangle_cells, refs=refs)
+
+        assert mesh.kind == MeshKind.TRIANGULAR_SURFACE
+        _, retrieved_refs = mesh.get_triangles_with_refs()
+        np.testing.assert_array_equal(retrieved_refs, refs)
+
     def test_missing_cells_raises(self, tetra_vertices: np.ndarray) -> None:
         """Test that missing cells parameter raises error."""
         with pytest.raises(ValueError, match="cells parameter is required"):

--- a/tests/mesh_unified_test.py
+++ b/tests/mesh_unified_test.py
@@ -173,44 +173,87 @@ class TestMeshConstructor:
         assert mesh.kind == MeshKind.TETRAHEDRAL
         assert len(mesh.get_vertices()) == 4
 
-    def test_tetrahedral_with_refs(
-        self,
-        tetra_vertices: np.ndarray,
-        tetra_cells: np.ndarray,
-    ) -> None:
+    def test_tetrahedral_with_refs(self) -> None:
         """Test creating tetrahedral mesh with cell refs."""
-        refs = np.array([5], dtype=np.int64)
-        mesh = Mesh(tetra_vertices, tetra_cells, refs=refs)
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 1.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        cells = np.array([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=np.int32)
+        refs = np.array([1, 2], dtype=np.int64)
+        mesh = Mesh(vertices, cells, refs=refs)
 
         assert mesh.kind == MeshKind.TETRAHEDRAL
         _, retrieved_refs = mesh.get_tetrahedra_with_refs()
         np.testing.assert_array_equal(retrieved_refs, refs)
 
-    def test_2d_with_refs(
-        self,
-        triangle_2d_vertices: np.ndarray,
-        triangle_cells: np.ndarray,
-    ) -> None:
+    def test_2d_with_refs(self) -> None:
         """Test creating 2D mesh with cell refs."""
-        refs = np.array([3], dtype=np.int64)
-        mesh = Mesh(triangle_2d_vertices, triangle_cells, refs=refs)
+        vertices = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+            dtype=np.float64,
+        )
+        cells = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+        refs = np.array([10, 20], dtype=np.int64)
+        mesh = Mesh(vertices, cells, refs=refs)
 
         assert mesh.kind == MeshKind.TRIANGULAR_2D
         _, retrieved_refs = mesh.get_triangles_with_refs()
         np.testing.assert_array_equal(retrieved_refs, refs)
 
-    def test_surface_with_refs(
-        self,
-        triangle_3d_vertices: np.ndarray,
-        triangle_cells: np.ndarray,
-    ) -> None:
+    def test_surface_with_refs(self) -> None:
         """Test creating surface mesh with cell refs."""
-        refs = np.array([7], dtype=np.int64)
-        mesh = Mesh(triangle_3d_vertices, triangle_cells, refs=refs)
+        vertices = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.5], [0.0, 1.0, 0.0]],
+            dtype=np.float64,
+        )
+        cells = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+        refs = np.array([7, 8], dtype=np.int64)
+        mesh = Mesh(vertices, cells, refs=refs)
 
         assert mesh.kind == MeshKind.TRIANGULAR_SURFACE
         _, retrieved_refs = mesh.get_triangles_with_refs()
         np.testing.assert_array_equal(retrieved_refs, refs)
+
+    def test_refs_length_mismatch_raises(
+        self,
+        tetra_vertices: np.ndarray,
+        tetra_cells: np.ndarray,
+    ) -> None:
+        """Test that mismatched refs length raises error."""
+        refs = np.array([1, 2], dtype=np.int64)
+        with pytest.raises(ValueError, match="refs length"):
+            Mesh(tetra_vertices, tetra_cells, refs=refs)
+
+    def test_refs_with_file_raises(
+        self,
+        tetra_vertices: np.ndarray,
+        tetra_cells: np.ndarray,
+    ) -> None:
+        """Test that refs with file source raises error."""
+        with TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "mesh.vtk"
+            meshio.Mesh(tetra_vertices, [("tetra", tetra_cells)]).write(filepath)
+
+            with pytest.raises(ValueError, match="refs parameter is only supported"):
+                Mesh(filepath, refs=np.array([1], dtype=np.int64))
+
+    def test_refs_with_pyvista_raises(
+        self,
+        tetra_vertices: np.ndarray,
+        tetra_cells: np.ndarray,
+    ) -> None:
+        """Test that refs with PyVista source raises error."""
+        grid = pv.UnstructuredGrid({pv.CellType.TETRA: tetra_cells}, tetra_vertices)
+
+        with pytest.raises(ValueError, match="refs parameter is only supported"):
+            Mesh(grid, refs=np.array([1], dtype=np.int64))
 
     def test_missing_cells_raises(self, tetra_vertices: np.ndarray) -> None:
         """Test that missing cells parameter raises error."""


### PR DESCRIPTION
## Summary

- Add optional `refs` parameter to `Mesh(vertices, cells, refs=...)` for passing cell reference markers (region/boundary IDs) when constructing from arrays
- Works for all mesh types: tetrahedral, 2D triangular, and 3D surface

## Example

```python
import numpy as np
from mmgpy import Mesh

vertices = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.5, 0.5]])
triangles = np.array([[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]])
refs = np.array([1, 2, 1, 2])

mesh = Mesh(vertices, triangles, refs=refs)
```

For Medit-style arrays with the ref as the 4th column:
```python
mesh = Mesh(vertices, data[:, :3], refs=data[:, 3])
```

Closes #223

## Test plan

- [x] Test refs for tetrahedral meshes
- [x] Test refs for 2D triangular meshes
- [x] Test refs for surface meshes
- [x] Existing tests still pass (58 passed)
- [x] Ruff lint clean