### PR TITLE
Release v0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.10.0.dev0"
+version = "0.10.0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.10.0"
+version = "0.11.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.10.0.dev0"
+    assert mmgpy.__version__ == "0.10.0"
 
 
 def test_mmg_version() -> None:

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.10.0"
+    assert mmgpy.__version__ == "0.11.0.dev0"
 
 
 def test_mmg_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1461,7 +1461,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.10.0.dev0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "meshio" },

--- a/uv.lock
+++ b/uv.lock
@@ -1461,7 +1461,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.10.0"
+version = "0.11.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "meshio" },


### PR DESCRIPTION
## What's new in v0.10.0

### Features
- Add `refs` parameter to `Mesh` constructor for passing cell reference markers (#224)

### Fixes
- Use `MMGS_Get_triangleQuality` directly and add API coverage docs (#217)
- Use same-job relative benchmark comparison for PRs (#219)

### Refactors
- Rewrite unified mmg CLI to use Python API directly (#221)
- Redesign benchmarks with diagnostic feature isolation matrix (#222)

### CI
- Update GitHub Actions to Node.js 24 compatible versions
- Pin `astral-sh/setup-uv` to v8.0.0