### PR TITLE
feat: add edges parameter to Mesh constructor (#226)

### DIFF
--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -301,7 +301,17 @@ def _validate_edges(
     return edges_arr, e_refs
 
 
-def _create_impl(  # noqa: PLR0913, PLR0912, C901
+_KIND_CONFIG: dict[
+    MeshKind,
+    tuple[type[MmgMesh3D | MmgMesh2D | MmgMeshS], str, str],
+] = {
+    MeshKind.TETRAHEDRAL: (MmgMesh3D, "tetrahedra", "set_tetrahedra"),
+    MeshKind.TRIANGULAR_2D: (MmgMesh2D, "triangles", "set_triangles"),
+    MeshKind.TRIANGULAR_SURFACE: (MmgMeshS, "triangles", "set_triangles"),
+}
+
+
+def _create_impl(  # noqa: PLR0913
     vertices: NDArray[np.floating],
     cells: NDArray[np.integer],
     kind: MeshKind,
@@ -332,63 +342,31 @@ def _create_impl(  # noqa: PLR0913, PLR0912, C901
         The mesh implementation.
 
     """
+    if kind not in _KIND_CONFIG:
+        msg = f"Unknown mesh kind: {kind}"
+        raise ValueError(msg)
+
     vertices = np.ascontiguousarray(vertices, dtype=np.float64)
     cells = np.ascontiguousarray(cells, dtype=np.int32)
     cell_refs = _validate_refs(refs, cells)
     edges_arr, e_refs = _validate_edges(edges, edge_refs)
 
-    if kind == MeshKind.TETRAHEDRAL:
-        impl_3d = MmgMesh3D()
-        if edges_arr is None:
-            impl_3d.set_mesh_size(vertices=len(vertices), tetrahedra=len(cells))
-        else:
-            impl_3d.set_mesh_size(
-                vertices=len(vertices),
-                tetrahedra=len(cells),
-                edges=len(edges_arr),
-            )
-        impl_3d.set_vertices(vertices)
-        impl_3d.set_tetrahedra(cells, cell_refs)
-        if edges_arr is not None:
-            impl_3d.set_edges(edges_arr, e_refs)
-        return impl_3d
+    if kind == MeshKind.TRIANGULAR_2D and vertices.shape[1] == _DIMS_3D:
+        vertices = np.ascontiguousarray(vertices[:, :2])
 
-    if kind == MeshKind.TRIANGULAR_2D:
-        if vertices.shape[1] == _DIMS_3D:
-            vertices = np.ascontiguousarray(vertices[:, :2])
-        impl_2d = MmgMesh2D()
-        if edges_arr is None:
-            impl_2d.set_mesh_size(vertices=len(vertices), triangles=len(cells))
-        else:
-            impl_2d.set_mesh_size(
-                vertices=len(vertices),
-                triangles=len(cells),
-                edges=len(edges_arr),
-            )
-        impl_2d.set_vertices(vertices)
-        impl_2d.set_triangles(cells, cell_refs)
-        if edges_arr is not None:
-            impl_2d.set_edges(edges_arr, e_refs)
-        return impl_2d
+    impl_cls, cell_kw, setter_name = _KIND_CONFIG[kind]
+    impl = impl_cls()
 
-    if kind == MeshKind.TRIANGULAR_SURFACE:
-        impl_s = MmgMeshS()
-        if edges_arr is None:
-            impl_s.set_mesh_size(vertices=len(vertices), triangles=len(cells))
-        else:
-            impl_s.set_mesh_size(
-                vertices=len(vertices),
-                triangles=len(cells),
-                edges=len(edges_arr),
-            )
-        impl_s.set_vertices(vertices)
-        impl_s.set_triangles(cells, cell_refs)
-        if edges_arr is not None:
-            impl_s.set_edges(edges_arr, e_refs)
-        return impl_s
+    size_kwargs: dict[str, int] = {"vertices": len(vertices), cell_kw: len(cells)}
+    if edges_arr is not None:
+        size_kwargs["edges"] = len(edges_arr)
+    impl.set_mesh_size(**size_kwargs)
 
-    msg = f"Unknown mesh kind: {kind}"
-    raise ValueError(msg)
+    impl.set_vertices(vertices)
+    getattr(impl, setter_name)(cells, cell_refs)
+    if edges_arr is not None:
+        impl.set_edges(edges_arr, e_refs)
+    return impl
 
 
 @dataclass

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -1568,7 +1568,9 @@ class Mesh:
         if path.suffix.lower() in NATIVE_MESH_EXTENSIONS:
             self._impl.save(str(path))
         else:
-            pv_mesh = self.to_pyvista()
+            # include_edges=True so MMG edges (ridges, boundaries) survive
+            # the file round-trip when reading back via mmgpy.read.
+            pv_mesh = self.to_pyvista(include_edges=True)
             # Attach user fields as point data
             self._materialize_all_lazy_fields()
             for name, arr in self._user_fields.items():
@@ -2272,6 +2274,7 @@ class Mesh:
         self,
         *,
         include_refs: bool = True,
+        include_edges: bool = False,
     ) -> pv.UnstructuredGrid | pv.PolyData:
         """Convert to PyVista mesh.
 
@@ -2279,6 +2282,13 @@ class Mesh:
         ----------
         include_refs : bool
             Include reference markers as cell data.
+        include_edges : bool
+            Include MMG edges (ridges, boundary edges) as LINE cells in
+            the output. Defaults to False so the returned mesh contains
+            only the primary cell type (triangles or tetrahedra), which
+            matches typical downstream code (matplotlib tripcolor, area
+            computations, etc.). Set True for round-trip / file-save
+            workflows that need to preserve edge markers.
 
         Returns
         -------
@@ -2288,7 +2298,11 @@ class Mesh:
         """
         from mmgpy._pyvista import to_pyvista as _to_pyvista  # noqa: PLC0415
 
-        return _to_pyvista(self._impl, include_refs=include_refs)
+        return _to_pyvista(
+            self._impl,
+            include_refs=include_refs,
+            include_edges=include_edges,
+        )
 
     @property
     def vtk(self) -> pv.UnstructuredGrid | pv.PolyData:

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -75,6 +75,7 @@ _DIMS_2D = 2
 _DIMS_3D = 3
 _TETRA_VERTS = 4
 _TRI_VERTS = 3
+_EDGE_VERTS = 2
 _2D_DETECTION_TOLERANCE = 1e-8
 
 
@@ -260,11 +261,53 @@ def _detect_mesh_kind(
     raise ValueError(msg)
 
 
-def _create_impl(
+def _validate_refs(
+    refs: NDArray[np.integer] | None,
+    cells: NDArray[np.int32],
+) -> NDArray[np.int64] | None:
+    """Coerce and validate cell reference markers."""
+    if refs is None:
+        return None
+    refs_arr = np.ascontiguousarray(refs, dtype=np.int64)
+    if len(refs_arr) != len(cells):
+        msg = f"refs length ({len(refs_arr)}) must match cells length ({len(cells)})"
+        raise ValueError(msg)
+    return refs_arr
+
+
+def _validate_edges(
+    edges: NDArray[np.integer] | None,
+    edge_refs: NDArray[np.integer] | None,
+) -> tuple[NDArray[np.int32] | None, NDArray[np.int64] | None]:
+    """Coerce and validate edge connectivity and reference markers."""
+    if edges is None:
+        if edge_refs is not None:
+            msg = "edge_refs provided without edges"
+            raise ValueError(msg)
+        return None, None
+    edges_arr = np.ascontiguousarray(edges, dtype=np.int32)
+    if edges_arr.ndim != _DIMS_2D or edges_arr.shape[1] != _EDGE_VERTS:
+        msg = f"edges must have shape (n_edges, 2), got {edges_arr.shape}"
+        raise ValueError(msg)
+    if edge_refs is None:
+        return edges_arr, None
+    e_refs = np.ascontiguousarray(edge_refs, dtype=np.int64)
+    if len(e_refs) != len(edges_arr):
+        msg = (
+            f"edge_refs length ({len(e_refs)}) must match "
+            f"edges length ({len(edges_arr)})"
+        )
+        raise ValueError(msg)
+    return edges_arr, e_refs
+
+
+def _create_impl(  # noqa: PLR0913, PLR0912, C901
     vertices: NDArray[np.floating],
     cells: NDArray[np.integer],
     kind: MeshKind,
     refs: NDArray[np.int64] | None = None,
+    edges: NDArray[np.int32] | None = None,
+    edge_refs: NDArray[np.int64] | None = None,
 ) -> MmgMesh3D | MmgMesh2D | MmgMeshS:
     """Create the appropriate mesh implementation.
 
@@ -278,6 +321,10 @@ def _create_impl(
         Mesh kind to create.
     refs : ndarray, optional
         Reference markers for each cell.
+    edges : ndarray, optional
+        Edge connectivity, shape (n_edges, 2).
+    edge_refs : ndarray, optional
+        Reference markers for each edge.
 
     Returns
     -------
@@ -287,35 +334,58 @@ def _create_impl(
     """
     vertices = np.ascontiguousarray(vertices, dtype=np.float64)
     cells = np.ascontiguousarray(cells, dtype=np.int32)
-
-    if refs is not None:
-        refs = np.ascontiguousarray(refs, dtype=np.int64)
-        if len(refs) != len(cells):
-            msg = f"refs length ({len(refs)}) must match cells length ({len(cells)})"
-            raise ValueError(msg)
+    cell_refs = _validate_refs(refs, cells)
+    edges_arr, e_refs = _validate_edges(edges, edge_refs)
 
     if kind == MeshKind.TETRAHEDRAL:
-        impl = MmgMesh3D()
-        impl.set_mesh_size(vertices=len(vertices), tetrahedra=len(cells))
-        impl.set_vertices(vertices)
-        impl.set_tetrahedra(cells, refs)
-        return impl
+        impl_3d = MmgMesh3D()
+        if edges_arr is None:
+            impl_3d.set_mesh_size(vertices=len(vertices), tetrahedra=len(cells))
+        else:
+            impl_3d.set_mesh_size(
+                vertices=len(vertices),
+                tetrahedra=len(cells),
+                edges=len(edges_arr),
+            )
+        impl_3d.set_vertices(vertices)
+        impl_3d.set_tetrahedra(cells, cell_refs)
+        if edges_arr is not None:
+            impl_3d.set_edges(edges_arr, e_refs)
+        return impl_3d
 
     if kind == MeshKind.TRIANGULAR_2D:
         if vertices.shape[1] == _DIMS_3D:
             vertices = np.ascontiguousarray(vertices[:, :2])
-        impl = MmgMesh2D()
-        impl.set_mesh_size(vertices=len(vertices), triangles=len(cells))
-        impl.set_vertices(vertices)
-        impl.set_triangles(cells, refs)
-        return impl
+        impl_2d = MmgMesh2D()
+        if edges_arr is None:
+            impl_2d.set_mesh_size(vertices=len(vertices), triangles=len(cells))
+        else:
+            impl_2d.set_mesh_size(
+                vertices=len(vertices),
+                triangles=len(cells),
+                edges=len(edges_arr),
+            )
+        impl_2d.set_vertices(vertices)
+        impl_2d.set_triangles(cells, cell_refs)
+        if edges_arr is not None:
+            impl_2d.set_edges(edges_arr, e_refs)
+        return impl_2d
 
     if kind == MeshKind.TRIANGULAR_SURFACE:
-        impl = MmgMeshS()
-        impl.set_mesh_size(vertices=len(vertices), triangles=len(cells))
-        impl.set_vertices(vertices)
-        impl.set_triangles(cells, refs)
-        return impl
+        impl_s = MmgMeshS()
+        if edges_arr is None:
+            impl_s.set_mesh_size(vertices=len(vertices), triangles=len(cells))
+        else:
+            impl_s.set_mesh_size(
+                vertices=len(vertices),
+                triangles=len(cells),
+                edges=len(edges_arr),
+            )
+        impl_s.set_vertices(vertices)
+        impl_s.set_triangles(cells, cell_refs)
+        if edges_arr is not None:
+            impl_s.set_edges(edges_arr, e_refs)
+        return impl_s
 
     msg = f"Unknown mesh kind: {kind}"
     raise ValueError(msg)
@@ -512,6 +582,8 @@ class Mesh:
         source: NDArray[np.floating] | str | Path | pv.UnstructuredGrid | pv.PolyData,
         cells: NDArray[np.integer] | None = None,
         refs: NDArray[np.integer] | None = None,
+        edges: NDArray[np.integer] | None = None,
+        edge_refs: NDArray[np.integer] | None = None,
     ) -> None:
         """Initialize a Mesh from various sources."""
         # Import here to avoid circular imports
@@ -522,10 +594,17 @@ class Mesh:
         self._metric_is_tensor = False
         self._lazy_source = None
 
+        array_only_kwargs_provided = (
+            refs is not None or edges is not None or edge_refs is not None
+        )
+
         # Handle PyVista objects
         if isinstance(source, pv.UnstructuredGrid | pv.PolyData):
-            if refs is not None:
-                msg = "refs parameter is only supported when source is a vertices array"
+            if array_only_kwargs_provided:
+                msg = (
+                    "refs/edges/edge_refs parameters are only supported "
+                    "when source is a vertices array"
+                )
                 raise ValueError(msg)
             result = _read_mesh(source)
             self._impl = result._impl  # noqa: SLF001
@@ -535,8 +614,11 @@ class Mesh:
 
         # Handle file paths
         if isinstance(source, str | Path):
-            if refs is not None:
-                msg = "refs parameter is only supported when source is a vertices array"
+            if array_only_kwargs_provided:
+                msg = (
+                    "refs/edges/edge_refs parameters are only supported "
+                    "when source is a vertices array"
+                )
                 raise ValueError(msg)
             result = _read_mesh(source)
             self._impl = result._impl  # noqa: SLF001
@@ -552,9 +634,18 @@ class Mesh:
         vertices = np.asarray(source)
         cells = np.asarray(cells)
         cell_refs = np.asarray(refs) if refs is not None else None
+        edges_arr = np.asarray(edges) if edges is not None else None
+        e_refs = np.asarray(edge_refs) if edge_refs is not None else None
 
         self._kind = _detect_mesh_kind(vertices, cells)
-        self._impl = _create_impl(vertices, cells, self._kind, refs=cell_refs)
+        self._impl = _create_impl(
+            vertices,
+            cells,
+            self._kind,
+            refs=cell_refs,
+            edges=edges_arr,
+            edge_refs=e_refs,
+        )
 
     @classmethod
     def _from_impl(

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -478,6 +478,7 @@ def to_pyvista(
     mesh: MmgMesh3D,
     *,
     include_refs: bool = True,
+    include_edges: bool = False,
 ) -> pv.UnstructuredGrid: ...
 
 
@@ -486,6 +487,7 @@ def to_pyvista(
     mesh: MmgMesh2D,
     *,
     include_refs: bool = True,
+    include_edges: bool = False,
 ) -> pv.PolyData: ...
 
 
@@ -494,6 +496,7 @@ def to_pyvista(
     mesh: MmgMeshS,
     *,
     include_refs: bool = True,
+    include_edges: bool = False,
 ) -> pv.PolyData: ...
 
 
@@ -501,12 +504,19 @@ def to_pyvista(
     mesh: MmgMesh3D | MmgMesh2D | MmgMeshS,
     *,
     include_refs: bool = True,
+    include_edges: bool = False,
 ) -> pv.UnstructuredGrid | pv.PolyData:
     """Convert an mmgpy mesh to a PyVista mesh.
 
     Args:
         mesh: mmgpy mesh instance (MmgMesh3D, MmgMesh2D, or MmgMeshS).
         include_refs: If True, include element references as cell_data.
+        include_edges: If True, include MMG edges (ridges, boundary edges)
+            as LINE cells in the output. Defaults to False so the returned
+            mesh contains only the primary cell type, matching common
+            downstream expectations (e.g. matplotlib tripcolor). Set True
+            for round-trip / file-save workflows that must preserve edge
+            markers.
 
     Returns:
         PyVista mesh:
@@ -527,11 +537,23 @@ def to_pyvista(
 
     """
     if isinstance(mesh, MmgMesh3D):
-        return _mmg3d_to_pyvista(mesh, include_refs=include_refs)
+        return _mmg3d_to_pyvista(
+            mesh,
+            include_refs=include_refs,
+            include_edges=include_edges,
+        )
     if isinstance(mesh, MmgMesh2D):
-        return _mmg2d_to_pyvista(mesh, include_refs=include_refs)
+        return _mmg2d_to_pyvista(
+            mesh,
+            include_refs=include_refs,
+            include_edges=include_edges,
+        )
     if isinstance(mesh, MmgMeshS):
-        return _mmgs_to_pyvista(mesh, include_refs=include_refs)
+        return _mmgs_to_pyvista(
+            mesh,
+            include_refs=include_refs,
+            include_edges=include_edges,
+        )
 
     msg = f"Unsupported mesh type: {type(mesh)}"
     raise TypeError(msg)
@@ -544,18 +566,27 @@ def _build_lines_array(edges: NDArray[np.int32]) -> NDArray[np.int32]:
     ).ravel()
 
 
-def _mmg3d_to_pyvista(mesh: MmgMesh3D, *, include_refs: bool) -> pv.UnstructuredGrid:
+def _mmg3d_to_pyvista(
+    mesh: MmgMesh3D,
+    *,
+    include_refs: bool,
+    include_edges: bool,
+) -> pv.UnstructuredGrid:
     """Convert MmgMesh3D to PyVista UnstructuredGrid."""
     vertices = mesh.get_vertices()
 
     if include_refs:
         elements, refs = mesh.get_elements_with_refs()
-        edges, edge_refs = mesh.get_edges_with_refs()
     else:
         elements = mesh.get_elements()
-        edges = mesh.get_edges()
         refs = None
-        edge_refs = None
+
+    edges, edge_refs = (np.empty((0, 2), dtype=np.int32), None)
+    if include_edges:
+        if include_refs:
+            edges, edge_refs = mesh.get_edges_with_refs()
+        else:
+            edges = mesh.get_edges()
 
     cells_dict: dict[int, NDArray[np.int32]] = {pv.CellType.TETRA: elements}
     if len(edges) > 0:
@@ -571,19 +602,28 @@ def _mmg3d_to_pyvista(mesh: MmgMesh3D, *, include_refs: bool) -> pv.Unstructured
     return grid
 
 
-def _mmg2d_to_pyvista(mesh: MmgMesh2D, *, include_refs: bool) -> pv.PolyData:
+def _mmg2d_to_pyvista(
+    mesh: MmgMesh2D,
+    *,
+    include_refs: bool,
+    include_edges: bool,
+) -> pv.PolyData:
     """Convert MmgMesh2D to PyVista PolyData."""
     vertices_2d = mesh.get_vertices()
     vertices_3d = np.column_stack([vertices_2d, np.zeros(len(vertices_2d))])
 
     if include_refs:
         triangles, refs = mesh.get_triangles_with_refs()
-        edges, edge_refs = mesh.get_edges_with_refs()
     else:
         triangles = mesh.get_triangles()
-        edges = mesh.get_edges()
         refs = None
-        edge_refs = None
+
+    edges, edge_refs = (np.empty((0, 2), dtype=np.int32), None)
+    if include_edges:
+        if include_refs:
+            edges, edge_refs = mesh.get_edges_with_refs()
+        else:
+            edges = mesh.get_edges()
 
     faces = np.hstack(
         [np.full((len(triangles), 1), _TRIANGLE_VERTS), triangles],
@@ -601,18 +641,27 @@ def _mmg2d_to_pyvista(mesh: MmgMesh2D, *, include_refs: bool) -> pv.PolyData:
     return polydata
 
 
-def _mmgs_to_pyvista(mesh: MmgMeshS, *, include_refs: bool) -> pv.PolyData:
+def _mmgs_to_pyvista(
+    mesh: MmgMeshS,
+    *,
+    include_refs: bool,
+    include_edges: bool,
+) -> pv.PolyData:
     """Convert MmgMeshS to PyVista PolyData."""
     vertices = mesh.get_vertices()
 
     if include_refs:
         triangles, refs = mesh.get_triangles_with_refs()
-        edges, edge_refs = mesh.get_edges_with_refs()
     else:
         triangles = mesh.get_triangles()
-        edges = mesh.get_edges()
         refs = None
-        edge_refs = None
+
+    edges, edge_refs = (np.empty((0, 2), dtype=np.int32), None)
+    if include_edges:
+        if include_refs:
+            edges, edge_refs = mesh.get_edges_with_refs()
+        else:
+            edges = mesh.get_edges()
 
     faces = np.hstack(
         [np.full((len(triangles), 1), _TRIANGLE_VERTS), triangles],

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -43,6 +43,34 @@ _TRIANGULATION_WARNING = (
     "as MMG only supports triangular elements."
 )
 
+_REF_FIELDS = ("refs", "gmsh:physical", "medit:ref")
+_LINE_VERTS = 2
+
+
+def _all_faces_are_triangles(mesh: pv.PolyData) -> bool:
+    """Return True if every polygonal face in the mesh has 3 vertices."""
+    faces = np.asarray(mesh.faces)
+    i = 0
+    while i < len(faces):
+        n_verts = int(faces[i])
+        if n_verts != _TRIANGLE_VERTS:
+            return False
+        i += n_verts + 1
+    return True
+
+
+def _strip_lines(mesh: pv.PolyData) -> pv.PolyData:
+    """Return a copy of `mesh` with line cells removed.
+
+    Used before `triangulate()` because PyVista's triangulate corrupts
+    cell_data alignment when both line and face cells are present.
+    """
+    if not hasattr(mesh, "lines") or len(np.asarray(mesh.lines)) == 0:
+        return mesh
+    stripped = mesh.copy()
+    stripped.lines = np.array([], dtype=np.int32)
+    return stripped
+
 
 def _triangulate_if_needed(mesh: pv.PolyData) -> tuple[pv.PolyData, bool]:
     """Triangulate mesh if it contains non-triangular faces.
@@ -57,6 +85,8 @@ def _triangulate_if_needed(mesh: pv.PolyData) -> tuple[pv.PolyData, bool]:
     tuple[pv.PolyData, bool]
         Tuple of (triangulated_mesh, was_triangulated).
         If mesh was already all triangles, returns (mesh, False).
+        Line cells are dropped before triangulation since the caller
+        is expected to have extracted them already.
 
     """
     if mesh.n_cells == 0:
@@ -65,7 +95,13 @@ def _triangulate_if_needed(mesh: pv.PolyData) -> tuple[pv.PolyData, bool]:
     if mesh.is_all_triangles:
         return mesh, False
 
-    triangulated = mesh.triangulate()
+    if _all_faces_are_triangles(mesh):
+        # All polygonal faces are already triangles, but the mesh has line
+        # cells too. Drop those (the caller has already extracted them via
+        # `_extract_edges`) so subsequent code only sees triangles.
+        return _strip_lines(mesh), False
+
+    triangulated = _strip_lines(mesh).triangulate()
     return triangulated, True
 
 
@@ -102,6 +138,109 @@ def _extract_triangles_from_polydata(mesh: pv.PolyData) -> NDArray[np.int32]:
     return np.array(triangles, dtype=np.int32)
 
 
+def _extract_lines_from_polydata(mesh: pv.PolyData) -> NDArray[np.int32] | None:
+    """Extract line connectivity from a PolyData.lines stream.
+
+    Returns None if the mesh has no line cells.
+    """
+    if not hasattr(mesh, "lines"):
+        return None
+    raw = np.asarray(mesh.lines)
+    if raw.size == 0:
+        return None
+    edges: list[NDArray[np.int32]] = []
+    i = 0
+    while i < len(raw):
+        n_verts = int(raw[i])
+        if n_verts != _LINE_VERTS:
+            # Polylines (n>2) are not supported by MMG; skip them.
+            i += n_verts + 1
+            continue
+        edges.append(raw[i + 1 : i + 3].astype(np.int32))
+        i += n_verts + 1
+    if not edges:
+        return None
+    return np.asarray(edges, dtype=np.int32)
+
+
+def _line_connectivity(
+    mesh: pv.UnstructuredGrid | pv.PolyData,
+) -> NDArray[np.int32] | None:
+    """Return LINE cell connectivity, or None if there are no lines."""
+    if hasattr(mesh, "cells_dict") and pv.CellType.LINE in mesh.cells_dict:
+        edges = mesh.cells_dict[pv.CellType.LINE].astype(np.int32)
+    elif isinstance(mesh, pv.PolyData):
+        edges = _extract_lines_from_polydata(mesh)
+    else:
+        edges = None
+    if edges is None or len(edges) == 0:
+        return None
+    return edges
+
+
+def _refs_for_unstructured_grid_lines(
+    mesh: pv.UnstructuredGrid,
+    n_edges: int,
+) -> NDArray[np.int64] | None:
+    """Slice cell_data refs to just the LINE cells of an UnstructuredGrid."""
+    celltypes = np.asarray(mesh.celltypes)
+    line_mask = celltypes == pv.CellType.LINE
+    for field in _REF_FIELDS:
+        if field not in mesh.cell_data:
+            continue
+        arr = np.asarray(mesh.cell_data[field])
+        if arr.ndim != 1:
+            continue
+        if len(arr) == len(celltypes):
+            return arr[line_mask].astype(np.int64)
+        if len(arr) == n_edges:
+            return arr.astype(np.int64)
+    return None
+
+
+def _refs_for_polydata_lines(
+    mesh: pv.PolyData,
+    n_edges: int,
+) -> NDArray[np.int64] | None:
+    """Slice cell_data refs to just the LINE cells of a PolyData.
+
+    PolyData stores cells in a fixed order: verts, lines, polys, strips.
+    """
+    n_verts = int(mesh.n_verts)
+    n_lines = int(mesh.n_lines)
+    for field in _REF_FIELDS:
+        if field not in mesh.cell_data:
+            continue
+        arr = np.asarray(mesh.cell_data[field])
+        if arr.ndim != 1:
+            continue
+        if len(arr) == n_edges:
+            return arr.astype(np.int64)
+        if len(arr) == mesh.n_cells and n_lines == n_edges:
+            return arr[n_verts : n_verts + n_lines].astype(np.int64)
+    return None
+
+
+def _extract_edges(
+    mesh: pv.UnstructuredGrid | pv.PolyData,
+) -> tuple[NDArray[np.int32] | None, NDArray[np.int64] | None]:
+    """Extract LINE cells and matching reference markers from a PyVista mesh.
+
+    Returns (edges, refs) where either may be None. Recognised cell_data
+    field aliases for refs include `"refs"`, `"gmsh:physical"` (used by
+    meshio when reading `.msh` files) and `"medit:ref"`.
+    """
+    edges = _line_connectivity(mesh)
+    if edges is None:
+        return None, None
+
+    if isinstance(mesh, pv.UnstructuredGrid):
+        return edges, _refs_for_unstructured_grid_lines(mesh, len(edges))
+    if isinstance(mesh, pv.PolyData):
+        return edges, _refs_for_polydata_lines(mesh, len(edges))
+    return edges, None
+
+
 def _from_pyvista_to_mmg3d(mesh: pv.UnstructuredGrid) -> MmgMesh3D:
     """Convert UnstructuredGrid with tetrahedra to MmgMesh3D."""
     if pv.CellType.TETRA not in mesh.cells_dict:
@@ -110,8 +249,19 @@ def _from_pyvista_to_mmg3d(mesh: pv.UnstructuredGrid) -> MmgMesh3D:
 
     vertices = np.array(mesh.points, dtype=np.float64)
     elements = mesh.cells_dict[pv.CellType.TETRA].astype(np.int32)
+    edges, edge_refs = _extract_edges(mesh)
 
-    mmg_mesh = MmgMesh3D(vertices, elements)
+    if edges is None:
+        mmg_mesh = MmgMesh3D(vertices, elements)
+    else:
+        mmg_mesh = MmgMesh3D()
+        mmg_mesh.set_mesh_size(
+            vertices=len(vertices),
+            tetrahedra=len(elements),
+            edges=len(edges),
+        )
+        mmg_mesh.set_vertices(vertices)
+        mmg_mesh.set_tetrahedra(elements)
 
     # Preserve element refs from cell_data if present
     if "refs" in mesh.cell_data:
@@ -119,11 +269,16 @@ def _from_pyvista_to_mmg3d(mesh: pv.UnstructuredGrid) -> MmgMesh3D:
         if len(refs) == len(elements):
             mmg_mesh.set_tetrahedra(elements, refs)
 
+    if edges is not None:
+        mmg_mesh.set_edges(edges, edge_refs)
+
     return mmg_mesh
 
 
 def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
     """Convert PolyData with 2D triangles to MmgMesh2D."""
+    edges, edge_refs = _extract_edges(mesh)
+
     mesh, was_triangulated = _triangulate_if_needed(mesh)
     if was_triangulated:
         logger.warning(_TRIANGULATION_WARNING)
@@ -135,7 +290,17 @@ def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
         vertices = points
     triangles = _extract_triangles_from_polydata(mesh)
 
-    mmg_mesh = MmgMesh2D(vertices, triangles)
+    if edges is None:
+        mmg_mesh = MmgMesh2D(vertices, triangles)
+    else:
+        mmg_mesh = MmgMesh2D()
+        mmg_mesh.set_mesh_size(
+            vertices=len(vertices),
+            triangles=len(triangles),
+            edges=len(edges),
+        )
+        mmg_mesh.set_vertices(vertices)
+        mmg_mesh.set_triangles(triangles)
 
     # Preserve triangle refs from cell_data if present
     if "refs" in mesh.cell_data:
@@ -143,11 +308,16 @@ def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
         if len(refs) == len(triangles):
             mmg_mesh.set_triangles(triangles, refs)
 
+    if edges is not None:
+        mmg_mesh.set_edges(edges, edge_refs)
+
     return mmg_mesh
 
 
 def _from_pyvista_to_mmgs(mesh: pv.PolyData) -> MmgMeshS:
     """Convert PolyData with 3D surface triangles to MmgMeshS."""
+    edges, edge_refs = _extract_edges(mesh)
+
     mesh, was_triangulated = _triangulate_if_needed(mesh)
     if was_triangulated:
         logger.warning(_TRIANGULATION_WARNING)
@@ -155,13 +325,26 @@ def _from_pyvista_to_mmgs(mesh: pv.PolyData) -> MmgMeshS:
     vertices = np.array(mesh.points, dtype=np.float64)
     triangles = _extract_triangles_from_polydata(mesh)
 
-    mmg_mesh = MmgMeshS(vertices, triangles)
+    if edges is None:
+        mmg_mesh = MmgMeshS(vertices, triangles)
+    else:
+        mmg_mesh = MmgMeshS()
+        mmg_mesh.set_mesh_size(
+            vertices=len(vertices),
+            triangles=len(triangles),
+            edges=len(edges),
+        )
+        mmg_mesh.set_vertices(vertices)
+        mmg_mesh.set_triangles(triangles)
 
     # Preserve triangle refs from cell_data if present
     if "refs" in mesh.cell_data:
         refs = np.asarray(mesh.cell_data["refs"], dtype=np.int32)
         if len(refs) == len(triangles):
             mmg_mesh.set_triangles(triangles, refs)
+
+    if edges is not None:
+        mmg_mesh.set_edges(edges, edge_refs)
 
     return mmg_mesh
 
@@ -354,20 +537,36 @@ def to_pyvista(
     raise TypeError(msg)
 
 
+def _build_lines_array(edges: NDArray[np.int32]) -> NDArray[np.int32]:
+    """Build a VTK-style flat lines array (each entry: [2, v0, v1])."""
+    return np.hstack(
+        [np.full((len(edges), 1), _LINE_VERTS), edges],
+    ).ravel()
+
+
 def _mmg3d_to_pyvista(mesh: MmgMesh3D, *, include_refs: bool) -> pv.UnstructuredGrid:
     """Convert MmgMesh3D to PyVista UnstructuredGrid."""
     vertices = mesh.get_vertices()
 
     if include_refs:
         elements, refs = mesh.get_elements_with_refs()
+        edges, edge_refs = mesh.get_edges_with_refs()
     else:
         elements = mesh.get_elements()
+        edges = mesh.get_edges()
         refs = None
+        edge_refs = None
 
-    grid = pv.UnstructuredGrid({pv.CellType.TETRA: elements}, vertices)
+    cells_dict: dict[int, NDArray[np.int32]] = {pv.CellType.TETRA: elements}
+    if len(edges) > 0:
+        cells_dict[pv.CellType.LINE] = edges
+    grid = pv.UnstructuredGrid(cells_dict, vertices)
 
     if refs is not None:
-        grid.cell_data["refs"] = refs
+        if len(edges) > 0 and edge_refs is not None:
+            grid.cell_data["refs"] = np.concatenate([refs, edge_refs])
+        else:
+            grid.cell_data["refs"] = refs
 
     return grid
 
@@ -379,17 +578,25 @@ def _mmg2d_to_pyvista(mesh: MmgMesh2D, *, include_refs: bool) -> pv.PolyData:
 
     if include_refs:
         triangles, refs = mesh.get_triangles_with_refs()
+        edges, edge_refs = mesh.get_edges_with_refs()
     else:
         triangles = mesh.get_triangles()
+        edges = mesh.get_edges()
         refs = None
+        edge_refs = None
 
     faces = np.hstack(
         [np.full((len(triangles), 1), _TRIANGLE_VERTS), triangles],
     ).ravel()
-    polydata = pv.PolyData(vertices_3d, faces=faces)
+    lines = _build_lines_array(edges) if len(edges) > 0 else None
+    polydata = pv.PolyData(vertices_3d, faces=faces, lines=lines)
 
     if refs is not None:
-        polydata.cell_data["refs"] = refs
+        # PolyData cell ordering: verts, lines, polys (faces), strips.
+        if len(edges) > 0 and edge_refs is not None:
+            polydata.cell_data["refs"] = np.concatenate([edge_refs, refs])
+        else:
+            polydata.cell_data["refs"] = refs
 
     return polydata
 
@@ -400,17 +607,25 @@ def _mmgs_to_pyvista(mesh: MmgMeshS, *, include_refs: bool) -> pv.PolyData:
 
     if include_refs:
         triangles, refs = mesh.get_triangles_with_refs()
+        edges, edge_refs = mesh.get_edges_with_refs()
     else:
         triangles = mesh.get_triangles()
+        edges = mesh.get_edges()
         refs = None
+        edge_refs = None
 
     faces = np.hstack(
         [np.full((len(triangles), 1), _TRIANGLE_VERTS), triangles],
     ).ravel()
-    polydata = pv.PolyData(vertices, faces=faces)
+    lines = _build_lines_array(edges) if len(edges) > 0 else None
+    polydata = pv.PolyData(vertices, faces=faces, lines=lines)
 
     if refs is not None:
-        polydata.cell_data["refs"] = refs
+        # PolyData cell ordering: verts, lines, polys (faces), strips.
+        if len(edges) > 0 and edge_refs is not None:
+            polydata.cell_data["refs"] = np.concatenate([edge_refs, refs])
+        else:
+            polydata.cell_data["refs"] = refs
 
     return polydata
 

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -60,15 +60,30 @@ def _all_faces_are_triangles(mesh: pv.PolyData) -> bool:
 
 
 def _strip_lines(mesh: pv.PolyData) -> pv.PolyData:
-    """Return a copy of `mesh` with line cells removed.
+    """Return `mesh` without its line cells.
 
     Used before `triangulate()` because PyVista's triangulate corrupts
     cell_data alignment when both line and face cells are present.
+
+    Fast path: if the mesh has no line cells, the original object is
+    returned unchanged (no copy). Otherwise a copy is returned with
+    `lines` cleared and any per-cell `cell_data` trimmed to drop the
+    entries that belonged to the removed lines (PyVista does not do
+    this automatically). Callers must not mutate the result.
     """
     if not hasattr(mesh, "lines") or len(np.asarray(mesh.lines)) == 0:
         return mesh
+    n_verts = int(mesh.n_verts)
+    n_lines = int(mesh.n_lines)
+    n_cells_original = int(mesh.n_cells)
     stripped = mesh.copy()
     stripped.lines = np.array([], dtype=np.int32)
+    for key in list(stripped.cell_data):
+        arr = np.asarray(stripped.cell_data[key])
+        if arr.shape[0] == n_cells_original:
+            stripped.cell_data[key] = np.concatenate(
+                [arr[:n_verts], arr[n_verts + n_lines :]],
+            )
     return stripped
 
 
@@ -178,23 +193,29 @@ def _line_connectivity(
     return edges
 
 
-def _refs_for_unstructured_grid_lines(
+def _refs_for_unstructured_grid_cells(
     mesh: pv.UnstructuredGrid,
-    n_edges: int,
+    cell_type: int,
+    n_target: int,
 ) -> NDArray[np.int64] | None:
-    """Slice cell_data refs to just the LINE cells of an UnstructuredGrid."""
+    """Slice cell_data refs to just the cells matching `cell_type`.
+
+    Recognises `_REF_FIELDS` aliases. Returns the field already pre-sliced
+    to `n_target` if its length matches, otherwise filters a per-cell array
+    via the `celltypes` mask.
+    """
     celltypes = np.asarray(mesh.celltypes)
-    line_mask = celltypes == pv.CellType.LINE
+    cell_mask = celltypes == cell_type
     for field in _REF_FIELDS:
         if field not in mesh.cell_data:
             continue
         arr = np.asarray(mesh.cell_data[field])
         if arr.ndim != 1:
             continue
-        if len(arr) == len(celltypes):
-            return arr[line_mask].astype(np.int64)
-        if len(arr) == n_edges:
+        if len(arr) == n_target:
             return arr.astype(np.int64)
+        if len(arr) == len(celltypes):
+            return arr[cell_mask].astype(np.int64)
     return None
 
 
@@ -204,7 +225,8 @@ def _refs_for_polydata_lines(
 ) -> NDArray[np.int64] | None:
     """Slice cell_data refs to just the LINE cells of a PolyData.
 
-    PolyData stores cells in a fixed order: verts, lines, polys, strips.
+    PolyData stores cells in a fixed order: verts, lines, polys, strips
+    (see https://vtk.org/doc/nightly/html/classvtkPolyData.html).
     """
     n_verts = int(mesh.n_verts)
     n_lines = int(mesh.n_lines)
@@ -218,6 +240,31 @@ def _refs_for_polydata_lines(
             return arr.astype(np.int64)
         if len(arr) == mesh.n_cells and n_lines == n_edges:
             return arr[n_verts : n_verts + n_lines].astype(np.int64)
+    return None
+
+
+def _refs_for_polydata_polys(
+    mesh: pv.PolyData,
+    n_polys: int,
+) -> NDArray[np.int64] | None:
+    """Slice cell_data refs to just the polygon (face) cells of a PolyData.
+
+    PolyData stores cells in a fixed order: verts, lines, polys, strips
+    (see https://vtk.org/doc/nightly/html/classvtkPolyData.html).
+    """
+    n_verts = int(mesh.n_verts)
+    n_lines = int(mesh.n_lines)
+    for field in _REF_FIELDS:
+        if field not in mesh.cell_data:
+            continue
+        arr = np.asarray(mesh.cell_data[field])
+        if arr.ndim != 1:
+            continue
+        if len(arr) == n_polys:
+            return arr.astype(np.int64)
+        if len(arr) == mesh.n_cells:
+            start = n_verts + n_lines
+            return arr[start : start + n_polys].astype(np.int64)
     return None
 
 
@@ -235,10 +282,36 @@ def _extract_edges(
         return None, None
 
     if isinstance(mesh, pv.UnstructuredGrid):
-        return edges, _refs_for_unstructured_grid_lines(mesh, len(edges))
+        return edges, _refs_for_unstructured_grid_cells(
+            mesh,
+            pv.CellType.LINE,
+            len(edges),
+        )
     if isinstance(mesh, pv.PolyData):
         return edges, _refs_for_polydata_lines(mesh, len(edges))
     return edges, None
+
+
+def _extract_element_refs(
+    mesh: pv.UnstructuredGrid | pv.PolyData,
+    n_elements: int,
+    *,
+    cell_type: int | None = None,
+) -> NDArray[np.int64] | None:
+    """Find element refs in cell_data, recognising `_REF_FIELDS` aliases.
+
+    Handles the mixed-cell-type case (e.g. a `.msh` file with both lines
+    and triangles) by slicing the appropriate range out of a concatenated
+    cell_data array. `cell_type` is required for UnstructuredGrid inputs
+    so the right cells can be filtered.
+    """
+    if isinstance(mesh, pv.UnstructuredGrid):
+        if cell_type is None:
+            return None
+        return _refs_for_unstructured_grid_cells(mesh, cell_type, n_elements)
+    if isinstance(mesh, pv.PolyData):
+        return _refs_for_polydata_polys(mesh, n_elements)
+    return None
 
 
 def _from_pyvista_to_mmg3d(mesh: pv.UnstructuredGrid) -> MmgMesh3D:
@@ -250,6 +323,11 @@ def _from_pyvista_to_mmg3d(mesh: pv.UnstructuredGrid) -> MmgMesh3D:
     vertices = np.array(mesh.points, dtype=np.float64)
     elements = mesh.cells_dict[pv.CellType.TETRA].astype(np.int32)
     edges, edge_refs = _extract_edges(mesh)
+    elem_refs = _extract_element_refs(
+        mesh,
+        len(elements),
+        cell_type=pv.CellType.TETRA,
+    )
 
     if edges is None:
         mmg_mesh = MmgMesh3D(vertices, elements)
@@ -263,11 +341,8 @@ def _from_pyvista_to_mmg3d(mesh: pv.UnstructuredGrid) -> MmgMesh3D:
         mmg_mesh.set_vertices(vertices)
         mmg_mesh.set_tetrahedra(elements)
 
-    # Preserve element refs from cell_data if present
-    if "refs" in mesh.cell_data:
-        refs = np.asarray(mesh.cell_data["refs"], dtype=np.int32)
-        if len(refs) == len(elements):
-            mmg_mesh.set_tetrahedra(elements, refs)
+    if elem_refs is not None:
+        mmg_mesh.set_tetrahedra(elements, elem_refs)
 
     if edges is not None:
         mmg_mesh.set_edges(edges, edge_refs)
@@ -289,6 +364,7 @@ def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
     else:
         vertices = points
     triangles = _extract_triangles_from_polydata(mesh)
+    elem_refs = _extract_element_refs(mesh, len(triangles))
 
     if edges is None:
         mmg_mesh = MmgMesh2D(vertices, triangles)
@@ -302,11 +378,8 @@ def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
         mmg_mesh.set_vertices(vertices)
         mmg_mesh.set_triangles(triangles)
 
-    # Preserve triangle refs from cell_data if present
-    if "refs" in mesh.cell_data:
-        refs = np.asarray(mesh.cell_data["refs"], dtype=np.int32)
-        if len(refs) == len(triangles):
-            mmg_mesh.set_triangles(triangles, refs)
+    if elem_refs is not None:
+        mmg_mesh.set_triangles(triangles, elem_refs)
 
     if edges is not None:
         mmg_mesh.set_edges(edges, edge_refs)
@@ -324,6 +397,7 @@ def _from_pyvista_to_mmgs(mesh: pv.PolyData) -> MmgMeshS:
 
     vertices = np.array(mesh.points, dtype=np.float64)
     triangles = _extract_triangles_from_polydata(mesh)
+    elem_refs = _extract_element_refs(mesh, len(triangles))
 
     if edges is None:
         mmg_mesh = MmgMeshS(vertices, triangles)
@@ -337,11 +411,8 @@ def _from_pyvista_to_mmgs(mesh: pv.PolyData) -> MmgMeshS:
         mmg_mesh.set_vertices(vertices)
         mmg_mesh.set_triangles(triangles)
 
-    # Preserve triangle refs from cell_data if present
-    if "refs" in mesh.cell_data:
-        refs = np.asarray(mesh.cell_data["refs"], dtype=np.int32)
-        if len(refs) == len(triangles):
-            mmg_mesh.set_triangles(triangles, refs)
+    if elem_refs is not None:
+        mmg_mesh.set_triangles(triangles, elem_refs)
 
     if edges is not None:
         mmg_mesh.set_edges(edges, edge_refs)

--- a/tests/mesh_unified_test.py
+++ b/tests/mesh_unified_test.py
@@ -1132,7 +1132,7 @@ class TestMeshEdgesRoundTrip:
         edge_refs = np.array([10, 20, 30, 40], dtype=np.int64)
 
         mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
-        polydata = mesh.to_pyvista()
+        polydata = mesh.to_pyvista(include_edges=True)
         round_trip = Mesh(polydata)
 
         rt_edges, rt_refs = round_trip.get_edges_with_refs()
@@ -1159,7 +1159,7 @@ class TestMeshEdgesRoundTrip:
         edge_refs = np.array([100, 200], dtype=np.int64)
 
         mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
-        polydata = mesh.to_pyvista()
+        polydata = mesh.to_pyvista(include_edges=True)
         round_trip = Mesh(polydata)
 
         rt_edges, rt_refs = round_trip.get_edges_with_refs()
@@ -1182,7 +1182,7 @@ class TestMeshEdgesRoundTrip:
         edge_refs = np.array([5, 6], dtype=np.int64)
 
         mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
-        grid = mesh.to_pyvista()
+        grid = mesh.to_pyvista(include_edges=True)
         round_trip = Mesh(grid)
 
         rt_edges, rt_refs = round_trip.get_edges_with_refs()

--- a/tests/mesh_unified_test.py
+++ b/tests/mesh_unified_test.py
@@ -1190,7 +1190,7 @@ class TestMeshEdgesRoundTrip:
         assert sorted(rt_refs.tolist()) == [5, 6]
 
     def test_msh_file_preserves_edges(self) -> None:
-        """Reading a .msh file preserves edges with gmsh:physical refs."""
+        """Reading a .msh file preserves edges and triangles with gmsh:physical refs."""
         vertices = np.array(
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
             dtype=np.float64,
@@ -1218,6 +1218,9 @@ class TestMeshEdgesRoundTrip:
         edges, edge_refs = result.get_edges_with_refs()
         assert len(edges) == len(lines)
         assert sorted(edge_refs.tolist()) == [11, 22, 33, 44]
+
+        _, tri_refs = result.get_triangles_with_refs()
+        assert sorted(tri_refs.tolist()) == [1, 2]
 
 
 # Module exports test

--- a/tests/mesh_unified_test.py
+++ b/tests/mesh_unified_test.py
@@ -241,7 +241,7 @@ class TestMeshConstructor:
             filepath = Path(tmpdir) / "mesh.vtk"
             meshio.Mesh(tetra_vertices, [("tetra", tetra_cells)]).write(filepath)
 
-            with pytest.raises(ValueError, match="refs parameter is only supported"):
+            with pytest.raises(ValueError, match="only supported when source"):
                 Mesh(filepath, refs=np.array([1], dtype=np.int64))
 
     def test_refs_with_pyvista_raises(
@@ -252,8 +252,149 @@ class TestMeshConstructor:
         """Test that refs with PyVista source raises error."""
         grid = pv.UnstructuredGrid({pv.CellType.TETRA: tetra_cells}, tetra_vertices)
 
-        with pytest.raises(ValueError, match="refs parameter is only supported"):
+        with pytest.raises(ValueError, match="only supported when source"):
             Mesh(grid, refs=np.array([1], dtype=np.int64))
+
+    def test_2d_with_edges(self) -> None:
+        """Test creating 2D mesh with edges and edge refs."""
+        vertices = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.5, 0.5]],
+            dtype=np.float64,
+        )
+        cells = np.array(
+            [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]],
+            dtype=np.int32,
+        )
+        edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
+        edge_refs = np.array([10, 20, 30, 40], dtype=np.int64)
+        mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
+
+        assert mesh.kind == MeshKind.TRIANGULAR_2D
+        retrieved_edges, retrieved_refs = mesh.get_edges_with_refs()
+        assert len(retrieved_edges) == len(edges)
+        assert set(retrieved_refs.tolist()) == {10, 20, 30, 40}
+
+    def test_surface_with_edges(self) -> None:
+        """Test creating surface mesh with edges and edge refs."""
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.5, 0.5, 0.5],
+            ],
+            dtype=np.float64,
+        )
+        cells = np.array(
+            [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]],
+            dtype=np.int32,
+        )
+        edges = np.array([[0, 1], [2, 3]], dtype=np.int32)
+        edge_refs = np.array([100, 200], dtype=np.int64)
+        mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
+
+        assert mesh.kind == MeshKind.TRIANGULAR_SURFACE
+        retrieved_edges, retrieved_refs = mesh.get_edges_with_refs()
+        assert len(retrieved_edges) == len(edges)
+        assert set(retrieved_refs.tolist()) == {100, 200}
+
+    def test_tetrahedral_with_edges(self) -> None:
+        """Test creating tetrahedral mesh with edges (ridge markers)."""
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        cells = np.array([[0, 1, 2, 3]], dtype=np.int32)
+        edges = np.array([[0, 1], [1, 2]], dtype=np.int32)
+        edge_refs = np.array([5, 6], dtype=np.int64)
+        mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
+
+        assert mesh.kind == MeshKind.TETRAHEDRAL
+        retrieved_edges, retrieved_refs = mesh.get_edges_with_refs()
+        assert len(retrieved_edges) == len(edges)
+        assert set(retrieved_refs.tolist()) == {5, 6}
+
+    def test_edges_without_refs(self) -> None:
+        """Test that edges can be passed without explicit edge_refs."""
+        vertices = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+            dtype=np.float64,
+        )
+        cells = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+        edges = np.array([[0, 1], [2, 3]], dtype=np.int32)
+        mesh = Mesh(vertices, cells, edges=edges)
+
+        retrieved_edges, _ = mesh.get_edges_with_refs()
+        assert len(retrieved_edges) == len(edges)
+
+    def test_edges_invalid_shape_raises(
+        self,
+        triangle_2d_vertices: np.ndarray,
+        triangle_cells: np.ndarray,
+    ) -> None:
+        """Test that wrong edge shape raises a clear error."""
+        bad_edges = np.array([[0, 1, 2]], dtype=np.int32)
+        with pytest.raises(ValueError, match="edges must have shape"):
+            Mesh(triangle_2d_vertices, triangle_cells, edges=bad_edges)
+
+    def test_edge_refs_length_mismatch_raises(
+        self,
+        triangle_2d_vertices: np.ndarray,
+        triangle_cells: np.ndarray,
+    ) -> None:
+        """Test that mismatched edge_refs length raises error."""
+        edges = np.array([[0, 1], [1, 2]], dtype=np.int32)
+        edge_refs = np.array([1], dtype=np.int64)
+        with pytest.raises(ValueError, match="edge_refs length"):
+            Mesh(
+                triangle_2d_vertices,
+                triangle_cells,
+                edges=edges,
+                edge_refs=edge_refs,
+            )
+
+    def test_edge_refs_without_edges_raises(
+        self,
+        triangle_2d_vertices: np.ndarray,
+        triangle_cells: np.ndarray,
+    ) -> None:
+        """Test that edge_refs without edges raises error."""
+        with pytest.raises(ValueError, match="edge_refs provided without edges"):
+            Mesh(
+                triangle_2d_vertices,
+                triangle_cells,
+                edge_refs=np.array([1], dtype=np.int64),
+            )
+
+    def test_edges_with_file_raises(
+        self,
+        tetra_vertices: np.ndarray,
+        tetra_cells: np.ndarray,
+    ) -> None:
+        """Test that edges with file source raises error."""
+        with TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "mesh.vtk"
+            meshio.Mesh(tetra_vertices, [("tetra", tetra_cells)]).write(filepath)
+
+            with pytest.raises(ValueError, match="only supported when source"):
+                Mesh(filepath, edges=np.array([[0, 1]], dtype=np.int32))
+
+    def test_edges_with_pyvista_raises(
+        self,
+        tetra_vertices: np.ndarray,
+        tetra_cells: np.ndarray,
+    ) -> None:
+        """Test that edges with PyVista source raises error."""
+        grid = pv.UnstructuredGrid({pv.CellType.TETRA: tetra_cells}, tetra_vertices)
+
+        with pytest.raises(ValueError, match="only supported when source"):
+            Mesh(grid, edges=np.array([[0, 1]], dtype=np.int32))
 
     def test_missing_cells_raises(self, tetra_vertices: np.ndarray) -> None:
         """Test that missing cells parameter raises error."""
@@ -972,6 +1113,111 @@ class TestReadFunction:
             assert isinstance(result, Mesh)
             # Should have 2 triangles from concatenated blocks
             assert len(result.get_triangles()) == 2
+
+
+class TestMeshEdgesRoundTrip:
+    """Round-trip tests for edge markers via PyVista and file formats."""
+
+    def test_pyvista_roundtrip_2d(self) -> None:
+        """Edges and edge refs survive Mesh -> to_pyvista -> Mesh."""
+        vertices = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.5, 0.5]],
+            dtype=np.float64,
+        )
+        cells = np.array(
+            [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]],
+            dtype=np.int32,
+        )
+        edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
+        edge_refs = np.array([10, 20, 30, 40], dtype=np.int64)
+
+        mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
+        polydata = mesh.to_pyvista()
+        round_trip = Mesh(polydata)
+
+        rt_edges, rt_refs = round_trip.get_edges_with_refs()
+        assert len(rt_edges) == len(edges)
+        assert sorted(rt_refs.tolist()) == [10, 20, 30, 40]
+
+    def test_pyvista_roundtrip_surface(self) -> None:
+        """Edges survive surface mesh round-trip."""
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.5, 0.5, 0.5],
+            ],
+            dtype=np.float64,
+        )
+        cells = np.array(
+            [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]],
+            dtype=np.int32,
+        )
+        edges = np.array([[0, 1], [2, 3]], dtype=np.int32)
+        edge_refs = np.array([100, 200], dtype=np.int64)
+
+        mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
+        polydata = mesh.to_pyvista()
+        round_trip = Mesh(polydata)
+
+        rt_edges, rt_refs = round_trip.get_edges_with_refs()
+        assert len(rt_edges) == len(edges)
+        assert sorted(rt_refs.tolist()) == [100, 200]
+
+    def test_pyvista_roundtrip_tetrahedral(self) -> None:
+        """Ridge edges survive 3D mesh round-trip."""
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        cells = np.array([[0, 1, 2, 3]], dtype=np.int32)
+        edges = np.array([[0, 1], [1, 2]], dtype=np.int32)
+        edge_refs = np.array([5, 6], dtype=np.int64)
+
+        mesh = Mesh(vertices, cells, edges=edges, edge_refs=edge_refs)
+        grid = mesh.to_pyvista()
+        round_trip = Mesh(grid)
+
+        rt_edges, rt_refs = round_trip.get_edges_with_refs()
+        assert len(rt_edges) == len(edges)
+        assert sorted(rt_refs.tolist()) == [5, 6]
+
+    def test_msh_file_preserves_edges(self) -> None:
+        """Reading a .msh file preserves edges with gmsh:physical refs."""
+        vertices = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+            dtype=np.float64,
+        )
+        triangles = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+        lines = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
+
+        msh_mesh = meshio.Mesh(
+            points=vertices,
+            cells=[("line", lines), ("triangle", triangles)],
+            cell_data={
+                "gmsh:physical": [
+                    np.array([11, 22, 33, 44], dtype=np.int32),
+                    np.array([1, 2], dtype=np.int32),
+                ],
+            },
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "mesh.msh"
+            msh_mesh.write(filepath, file_format="gmsh22")
+
+            result = read(filepath)
+
+        edges, edge_refs = result.get_edges_with_refs()
+        assert len(edges) == len(lines)
+        assert sorted(edge_refs.tolist()) == [11, 22, 33, 44]
 
 
 # Module exports test


### PR DESCRIPTION
## Summary

Closes #226. Adds support for edge markers (refs) on the `Mesh` class so they can be used as boundary-condition tags.

- `Mesh(vertices, cells, edges=..., edge_refs=...)` mirrors the `refs=` pattern from #224
- `from_pyvista` extracts LINE cells and recognises `refs`, `gmsh:physical`, `medit:ref` aliases — `.msh` files now keep their physical-group markers when read through `mmgpy.read()`
- `to_pyvista` writes edges back as LINE cells so `Mesh -> pyvista -> Mesh` round-trips preserve markers
- Triangulation strips line cells first (PyVista corrupts cell_data when triangulating a mesh with mixed lines + faces)

## Example

```python
import numpy as np
from mmgpy import Mesh

vertices = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.5, 0.5]])
triangles = np.array([[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]])
edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]])
edge_refs = np.array([10, 20, 30, 40])

mesh = Mesh(vertices, triangles, edges=edges, edge_refs=edge_refs)
```

For Gmsh users:

```python
mesh = mmgpy.read("model.msh")  # gmsh:physical refs on lines now preserved
e, r = mesh.get_edges_with_refs()
```

## Test plan

- [x] Constructor accepts `edges`/`edge_refs` for tetrahedral, 2D triangular, and 3D surface meshes
- [x] Validation errors: invalid edge shape, mismatched `edge_refs` length, `edge_refs` without `edges`, refs/edges with non-array sources
- [x] PyVista round-trip preserves edges + refs for all three mesh kinds
- [x] `.msh` files written via meshio with `gmsh:physical` markers reload with edge refs intact
- [x] Existing tests still pass (907 passed, 26 skipped)
- [x] Ruff lint clean