### PR TITLE
Release v0.11.0

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.11.0"
+  version: "0.12.0.dev0"
 
 package:
   name: mmgpy

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.9.0.dev0"
+  version: "0.11.0"
 
 package:
   name: mmgpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.11.0.dev0"
+version = "0.11.0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.11.0"
+version = "0.12.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.11.0.dev0"
+    assert mmgpy.__version__ == "0.11.0"
 
 
 def test_mmg_version() -> None:

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.11.0"
+    assert mmgpy.__version__ == "0.12.0.dev0"
 
 
 def test_mmg_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1461,7 +1461,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.11.0.dev0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "meshio" },

--- a/uv.lock
+++ b/uv.lock
@@ -1461,7 +1461,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.11.0"
+version = "0.12.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "meshio" },


### PR DESCRIPTION
## Summary

Release v0.11.0. Bumps version, then bumps to 0.12.0.dev0 for ongoing work.

The v0.11.0 GitHub release has already been published from this branch's first commit (commit hash will be preserved when this PR is merged with a merge commit, **not** squash):
https://github.com/kmarchais/mmgpy/releases/tag/v0.11.0

## What's new in v0.11.0

- Add `edges` and `edge_refs` parameters to `Mesh` constructor (#226)
- Recognise `gmsh:physical` / `medit:ref` cell_data field aliases when reading from PyVista, so `.msh` files preserve both edge and element refs across read/write
- Make LINE cells in `to_pyvista()` opt-in via `include_edges=True`

## Bumps

- `pyproject.toml`, `tests/mmgpy_test.py`, `conda/recipe.yaml`, `uv.lock` — note `conda/recipe.yaml` was stuck at `0.9.0.dev0` and is now caught up

## Merge instructions

**Merge with "Create a merge commit", not Squash.** The v0.11.0 release tag points to the first commit on this branch; squashing would orphan the tag.