### PR TITLE
feat: adopt PyVista 0.48 reader/writer/accessor registries

### DIFF
--- a/docs/tutorials/pyvista-integration.md
+++ b/docs/tutorials/pyvista-integration.md
@@ -139,11 +139,11 @@ mesh.remesh(hmax=0.1)
 pv_mesh = mesh.to_pyvista()
 
 # Compute quality (PyVista has built-in quality metrics)
-quality = pv_mesh.compute_cell_quality(quality_measure="scaled_jacobian")
+quality = pv_mesh.cell_quality("scaled_jacobian")
 
 # Plot with quality colormap
 quality.plot(
-    scalars="CellQuality",
+    scalars="scaled_jacobian",
     cmap="RdYlGn",
     show_edges=True,
     scalar_bar_args={"title": "Quality"},

--- a/examples/mmg3d/open_boundary_remeshing.py
+++ b/examples/mmg3d/open_boundary_remeshing.py
@@ -28,7 +28,7 @@ for open_boundary in [False, True]:
 
     pv_mesh = mesh.to_pyvista()
     pl.add_mesh(
-        pv_mesh.extract_cells(pv_mesh.cell_centers().points[:, :] < 0),
+        pv_mesh.extract_cells(pv_mesh.cell_centers().points[:, 0] < 0),
         show_edges=True,
     )
     pl.add_text(f"Open boundary: {open_boundary}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "meshio>=5.3.5,<6",
     "numpy>=2.0.2,<3",
     "patchelf>=0.17.2.4,<1; sys_platform == 'linux'",
-    "pyvista>=0.47,<1",
+    "pyvista>=0.48,<1",
     "rich>=13.0.0,<15",
     "scipy>=1.11.0,<2",
     "typing-extensions>=4.0.0,<5; python_version < '3.11'",
@@ -84,6 +84,19 @@ mmg = "mmgpy._cli:_run_mmg"
 
 [project.entry-points."mmgpy.ui"]
 ui = "mmgpy.ui:run_ui"
+
+# PyVista 0.48 plugin registries: Medit reader/writer + .mmg accessor.
+# These activate on first use (lazy) so users who never touch MMG pay nothing.
+[project.entry-points."pyvista.readers"]
+mesh = "mmgpy._pv_plugin:read_mesh"
+meshb = "mmgpy._pv_plugin:read_mesh"
+
+[project.entry-points."pyvista.writers"]
+mesh = "mmgpy._pv_plugin:write_mesh"
+meshb = "mmgpy._pv_plugin:write_mesh"
+
+[project.entry-points."pyvista.accessors"]
+mmg = "mmgpy._pv_plugin"
 
 [project.gui-scripts]
 mmgpy-ui = "mmgpy.ui.__main__:main"

--- a/src/mmgpy/_io.py
+++ b/src/mmgpy/_io.py
@@ -136,27 +136,45 @@ def _load_meshb_by_trial(
 ) -> tuple[MmgMesh3D | MmgMesh2D | MmgMeshS, MeshKind]:
     """Detect mesh kind for a binary .meshb file by trial loading.
 
-    The text header parser does not handle binary files, but every MMG
-    class accepts any .meshb input and silently returns an empty mesh
-    when the content does not match. The first class whose load yields
-    a non-empty vertex set is the right kind. Volumetric meshes win
-    ahead of surfaces ahead of 2D, mirroring the priority used for
-    auto-detection on PyVista inputs.
+    The text header parser does not handle binary files, so we trial-load
+    the file with each MMG class in priority order. A class is considered
+    a match when it yields a non-empty population of its primary element
+    type (tetrahedra for 3D, triangles for surface and 2D). Vertex count
+    alone is insufficient: a surface ``.meshb`` will load non-empty under
+    ``MmgMesh3D`` with zero tetrahedra, so falling back to triangle/vertex
+    counts on later candidates is required to route it to ``MmgMeshS``.
+
+    Construction errors from a candidate class (corrupt or unsupported
+    binary content) are caught so the next candidate gets a chance; if
+    every candidate either errors or returns empty, a ``ValueError`` is
+    raised describing the file.
     """
+    path_str = str(path)
     candidates: tuple[
-        tuple[type[MmgMesh3D | MmgMesh2D | MmgMeshS], MeshKind],
+        tuple[
+            type[MmgMesh3D | MmgMesh2D | MmgMeshS],
+            MeshKind,
+            str,
+        ],
         ...,
     ] = (
-        (MmgMesh3D, MeshKind.TETRAHEDRAL),
-        (MmgMeshS, MeshKind.TRIANGULAR_SURFACE),
-        (MmgMesh2D, MeshKind.TRIANGULAR_2D),
+        (MmgMesh3D, MeshKind.TETRAHEDRAL, "get_tetrahedra"),
+        (MmgMeshS, MeshKind.TRIANGULAR_SURFACE, "get_triangles"),
+        (MmgMesh2D, MeshKind.TRIANGULAR_2D, "get_vertices"),
     )
-    path_str = str(path)
-    for cls, kind in candidates:
-        impl = cls(path_str)
-        if impl.get_vertices().shape[0] > 0:
+    last_error: Exception | None = None
+    for cls, kind, probe_attr in candidates:
+        try:
+            impl = cls(path_str)
+        except (RuntimeError, OSError, ValueError) as exc:
+            last_error = exc
+            continue
+        if getattr(impl, probe_attr)().shape[0] > 0:
             return impl, kind
+
     msg = f"Cannot determine mesh kind from binary file: {path}"
+    if last_error is not None:
+        raise ValueError(msg) from last_error
     raise ValueError(msg)
 
 

--- a/src/mmgpy/_io.py
+++ b/src/mmgpy/_io.py
@@ -131,6 +131,35 @@ def _detect_medit_mesh_kind(path: Path) -> MeshKind:
     raise ValueError(msg)
 
 
+def _load_meshb_by_trial(
+    path: Path,
+) -> tuple[MmgMesh3D | MmgMesh2D | MmgMeshS, MeshKind]:
+    """Detect mesh kind for a binary .meshb file by trial loading.
+
+    The text header parser does not handle binary files, but every MMG
+    class accepts any .meshb input and silently returns an empty mesh
+    when the content does not match. The first class whose load yields
+    a non-empty vertex set is the right kind. Volumetric meshes win
+    ahead of surfaces ahead of 2D, mirroring the priority used for
+    auto-detection on PyVista inputs.
+    """
+    candidates: tuple[
+        tuple[type[MmgMesh3D | MmgMesh2D | MmgMeshS], MeshKind],
+        ...,
+    ] = (
+        (MmgMesh3D, MeshKind.TETRAHEDRAL),
+        (MmgMeshS, MeshKind.TRIANGULAR_SURFACE),
+        (MmgMesh2D, MeshKind.TRIANGULAR_2D),
+    )
+    path_str = str(path)
+    for cls, kind in candidates:
+        impl = cls(path_str)
+        if impl.get_vertices().shape[0] > 0:
+            return impl, kind
+    msg = f"Cannot determine mesh kind from binary file: {path}"
+    raise ValueError(msg)
+
+
 def _load_medit_native(
     path: Path,
     mesh_kind: MeshKind | None,
@@ -161,6 +190,9 @@ def _load_medit_native(
 
     """
     if mesh_kind is None:
+        if path.suffix.lower() == ".meshb":
+            impl, _ = _load_meshb_by_trial(path)
+            return impl
         mesh_kind = _detect_medit_mesh_kind(path)
 
     path_str = str(path)

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -57,7 +57,7 @@ def _attach_sol_fields(
     via the accessor (``mesh.mmg.load_sol(...)``) instead of auto-pairing.
     """
     if sol_path.suffix.lower() == ".solb":
-        logger.info(
+        logger.debug(
             "Skipping auto-pair of binary .solb %s; use mesh.mmg.load_sol()",
             sol_path,
         )
@@ -183,7 +183,7 @@ class MmgAccessor:
     >>> import pyvista as pv
     >>> import mmgpy  # noqa: F401  -- registers the accessor
     >>> mesh = pv.read("brain.mesh")
-    >>> remeshed = mesh.mmg.remesh(hmax=0.1)
+    >>> remeshed = mesh.mmg.remesh(hsiz=0.1)
     >>> remeshed.n_cells > 0
     True
 

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -57,7 +57,7 @@ def _attach_sol_fields(
     via the accessor (``mesh.mmg.load_sol(...)``) instead of auto-pairing.
     """
     if sol_path.suffix.lower() == ".solb":
-        logger.debug(
+        logger.info(
             "Skipping auto-pair of binary .solb %s; use mesh.mmg.load_sol()",
             sol_path,
         )
@@ -65,8 +65,25 @@ def _attach_sol_fields(
 
     from mmgpy._sol import parse_sol_file  # noqa: PLC0415
 
-    content = sol_path.read_text(encoding="utf-8", errors="replace")
-    fields = parse_sol_file(content)
+    try:
+        content = sol_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning(
+            "Could not read companion .sol file %s: %s; skipping auto-pair.",
+            sol_path,
+            exc,
+        )
+        return
+
+    try:
+        fields = parse_sol_file(content)
+    except (ValueError, KeyError, IndexError) as exc:
+        logger.warning(
+            "Could not parse companion .sol file %s: %s; skipping auto-pair.",
+            sol_path,
+            exc,
+        )
+        return
 
     n_points = dataset.n_points
     n_cells = dataset.n_cells

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -1,0 +1,224 @@
+"""PyVista 0.48 plugin: Medit reader/writer + ``.mmg`` dataset accessor.
+
+Activated via entry points declared in ``pyproject.toml``:
+
+* ``pyvista.readers``: ``.mesh``, ``.meshb``
+* ``pyvista.writers``: ``.mesh``, ``.meshb``
+* ``pyvista.accessors``: ``mmg``
+
+Once ``mmgpy`` is installed, every PyVista user transparently gains:
+
+>>> import pyvista as pv
+>>> mesh = pv.read("brain.mesh")           # Medit text format
+>>> mesh = pv.read("brain.meshb")          # Medit binary format
+>>> remeshed = mesh.mmg.remesh(hsiz=0.1)   # accessor-driven remeshing
+>>> mesh.save("out.mesh")                  # round-trip back to Medit
+
+When reading ``foo.mesh``/``foo.meshb``, a sibling ``foo.sol``/``foo.solb``
+is auto-loaded into ``point_data``/``cell_data`` if present.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pyvista as pv
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+logger = logging.getLogger("mmgpy")
+
+_MEDIT_EXTENSIONS = (".mesh", ".meshb")
+_SOL_EXTENSIONS = (".sol", ".solb")
+
+
+def _find_companion_sol(mesh_path: Path) -> Path | None:
+    """Return the sibling ``.sol``/``.solb`` for *mesh_path* if one exists."""
+    for ext in _SOL_EXTENSIONS:
+        candidate = mesh_path.with_suffix(ext)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _attach_sol_fields(
+    dataset: pv.DataSet,
+    sol_path: Path,
+) -> None:
+    """Parse a Medit ``.sol`` file and attach its arrays to *dataset*.
+
+    Vertex-located fields land in ``point_data``; element-located fields
+    land in ``cell_data``. Binary ``.solb`` files are not parsed in
+    Python: the C++ MMG library handles those, so for now they round-trip
+    via the accessor (``mesh.mmg.load_sol(...)``) instead of auto-pairing.
+    """
+    if sol_path.suffix.lower() == ".solb":
+        logger.debug(
+            "Skipping auto-pair of binary .solb %s; use mesh.mmg.load_sol()",
+            sol_path,
+        )
+        return
+
+    from mmgpy._sol import parse_sol_file  # noqa: PLC0415
+
+    content = sol_path.read_text(encoding="utf-8", errors="replace")
+    fields = parse_sol_file(content)
+
+    n_points = dataset.n_points
+    n_cells = dataset.n_cells
+    for name, payload in fields.items():
+        data: NDArray[np.float64] = payload["data"]
+        location = payload["location"]
+        if location == "vertices" and len(data) == n_points:
+            dataset.point_data[name] = data
+        elif location in {"triangles", "tetrahedra"} and len(data) == n_cells:
+            dataset.cell_data[name] = data
+        else:
+            logger.debug(
+                "Skipping .sol field %r: length %d does not match "
+                "dataset (%d points, %d cells)",
+                name,
+                len(data),
+                n_points,
+                n_cells,
+            )
+
+
+def read_mesh(
+    path: str,
+    **kwargs: object,  # noqa: ARG001
+) -> pv.UnstructuredGrid | pv.PolyData:
+    """Read a Medit ``.mesh``/``.meshb`` file and return a PyVista dataset.
+
+    Registered for the ``.mesh`` and ``.meshb`` extensions via the
+    ``pyvista.readers`` entry point group. A sibling ``.sol`` file (same
+    stem, same directory) is auto-loaded into ``point_data``/``cell_data``
+    if present.
+
+    Returns
+    -------
+    pv.UnstructuredGrid or pv.PolyData
+        ``UnstructuredGrid`` for tetrahedral meshes, ``PolyData`` for 2D
+        and surface triangular meshes. MMG's ridges and boundary edges
+        survive as ``LINE`` cells (``include_edges=True`` internally).
+
+    """
+    from mmgpy._io import _load_medit_native  # noqa: PLC0415
+    from mmgpy._pyvista import to_pyvista  # noqa: PLC0415
+
+    mesh_path = Path(path)
+    impl = _load_medit_native(mesh_path, mesh_kind=None)
+    dataset = to_pyvista(impl, include_refs=True, include_edges=True)
+
+    sol_path = _find_companion_sol(mesh_path)
+    if sol_path is not None:
+        _attach_sol_fields(dataset, sol_path)
+
+    return dataset
+
+
+def write_mesh(
+    dataset: pv.DataSet,
+    path: str,
+    **kwargs: object,  # noqa: ARG001
+) -> None:
+    """Write *dataset* to a Medit ``.mesh``/``.meshb`` file.
+
+    Registered for the ``.mesh`` and ``.meshb`` extensions via the
+    ``pyvista.writers`` entry point group. Lets ``mesh.save("out.mesh")``
+    round-trip through MMG without going through the ``Mesh`` wrapper.
+    """
+    from mmgpy._pyvista import from_pyvista  # noqa: PLC0415
+
+    if not isinstance(dataset, (pv.UnstructuredGrid, pv.PolyData)):
+        msg = (
+            f"Cannot write {type(dataset).__name__} to Medit format: "
+            "MMG only handles UnstructuredGrid (tetrahedra) and PolyData "
+            "(triangles)."
+        )
+        raise TypeError(msg)
+
+    impl = from_pyvista(dataset)
+    impl.save(str(path))
+
+
+# ---------------------------------------------------------------------------
+# .mmg dataset accessor
+# ---------------------------------------------------------------------------
+
+
+@pv.register_dataset_accessor("mmg", pv.UnstructuredGrid)
+@pv.register_dataset_accessor("mmg", pv.PolyData)
+class MmgAccessor:
+    """``mesh.mmg.<method>`` accessor for MMG operations on PyVista datasets.
+
+    Methods take and return PyVista datasets, so the accessor composes with
+    the rest of the PyVista API. Internally each call constructs an mmgpy
+    ``Mesh`` from the dataset, runs the operation, and returns a fresh
+    PyVista dataset.
+
+    Examples
+    --------
+    >>> import pyvista as pv
+    >>> import mmgpy  # noqa: F401  -- registers the accessor
+    >>> mesh = pv.read("brain.mesh")
+    >>> remeshed = mesh.mmg.remesh(hmax=0.1)
+    >>> remeshed.n_cells > 0
+    True
+
+    """
+
+    def __init__(self, dataset: pv.UnstructuredGrid | pv.PolyData) -> None:
+        self._dataset = dataset
+
+    def remesh(
+        self,
+        **options: Any,  # noqa: ANN401  -- forwarded to Mesh.remesh; see docstring
+    ) -> pv.UnstructuredGrid | pv.PolyData:
+        """Remesh the underlying dataset and return a new PyVista dataset.
+
+        Parameters
+        ----------
+        **options : object
+            Forwarded to :meth:`mmgpy.Mesh.remesh`. Common knobs include
+            ``hmin``, ``hmax``, ``hsiz``, and ``hausd``.
+
+        Returns
+        -------
+        pv.UnstructuredGrid or pv.PolyData
+            Tetrahedral results come back as ``UnstructuredGrid``;
+            2D and surface results as ``PolyData``. Element references
+            survive in ``cell_data["refs"]`` and MMG edges in ``LINE``
+            cells.
+
+        """
+        from mmgpy._mesh import Mesh  # noqa: PLC0415
+
+        mesh = Mesh(self._dataset)
+        mesh.remesh(**options)
+        return mesh.to_pyvista(include_refs=True, include_edges=True)
+
+    def load_sol(self, path: str | Path) -> None:
+        """Load a Medit ``.sol`` file and attach its fields to the dataset.
+
+        Vertex-located fields populate ``point_data``; element-located
+        fields populate ``cell_data``. Modifies the dataset in place.
+
+        Binary ``.solb`` files are not yet supported through this entry
+        point; route them through the ``Mesh`` wrapper if needed.
+        """
+        sol_path = Path(path)
+        if sol_path.suffix.lower() == ".solb":
+            msg = (
+                "Binary .solb files are not yet supported via mesh.mmg.load_sol(); "
+                "use the Mesh wrapper for now."
+            )
+            raise NotImplementedError(msg)
+        _attach_sol_fields(self._dataset, sol_path)
+
+
+__all__ = ["MmgAccessor", "read_mesh", "write_mesh"]

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -30,7 +30,12 @@ from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 logger = logging.getLogger("mmgpy")
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
     from numpy.typing import NDArray
+
+    CellsDict = Mapping[Any, Any]
 
 _DIMS_2D = 2
 _DIMS_3D = 3
@@ -180,10 +185,19 @@ def _extract_lines_from_polydata(mesh: pv.PolyData) -> NDArray[np.int32] | None:
 
 def _line_connectivity(
     mesh: pv.UnstructuredGrid | pv.PolyData,
+    cells_dict: CellsDict | None = None,
 ) -> NDArray[np.int32] | None:
-    """Return LINE cell connectivity, or None if there are no lines."""
-    if hasattr(mesh, "cells_dict") and pv.CellType.LINE in mesh.cells_dict:
-        edges = mesh.cells_dict[pv.CellType.LINE].astype(np.int32)
+    """Return LINE cell connectivity, or None if there are no lines.
+
+    ``cells_dict`` may be supplied to avoid recomputing ``mesh.cells_dict``;
+    in PyVista 0.48 this property is O(n_cells) per access (per-cell
+    ``CellType`` enum lookup), so callers in a hot path should pass a
+    pre-computed dict.
+    """
+    if cells_dict is None and hasattr(mesh, "cells_dict"):
+        cells_dict = mesh.cells_dict
+    if cells_dict is not None and pv.CellType.LINE in cells_dict:
+        edges = cells_dict[pv.CellType.LINE].astype(np.int32)
     elif isinstance(mesh, pv.PolyData):
         edges = _extract_lines_from_polydata(mesh)
     else:
@@ -270,14 +284,18 @@ def _refs_for_polydata_polys(
 
 def _extract_edges(
     mesh: pv.UnstructuredGrid | pv.PolyData,
+    cells_dict: CellsDict | None = None,
 ) -> tuple[NDArray[np.int32] | None, NDArray[np.int64] | None]:
     """Extract LINE cells and matching reference markers from a PyVista mesh.
 
     Returns (edges, refs) where either may be None. Recognised cell_data
     field aliases for refs include `"refs"`, `"gmsh:physical"` (used by
     meshio when reading `.msh` files) and `"medit:ref"`.
+
+    ``cells_dict`` may be supplied to skip recomputing ``mesh.cells_dict``
+    in callers that already hold one.
     """
-    edges = _line_connectivity(mesh)
+    edges = _line_connectivity(mesh, cells_dict=cells_dict)
     if edges is None:
         return None, None
 
@@ -314,15 +332,37 @@ def _extract_element_refs(
     return None
 
 
-def _from_pyvista_to_mmg3d(mesh: pv.UnstructuredGrid) -> MmgMesh3D:
-    """Convert UnstructuredGrid with tetrahedra to MmgMesh3D."""
-    if pv.CellType.TETRA not in mesh.cells_dict:
-        msg = "UnstructuredGrid must contain tetrahedra (CellType.TETRA)"
-        raise ValueError(msg)
+def _from_pyvista_to_mmg3d(
+    mesh: pv.UnstructuredGrid,
+    cells_dict: CellsDict | None = None,
+) -> MmgMesh3D:
+    """Convert UnstructuredGrid with tetrahedra to MmgMesh3D.
+
+    PyVista 0.48 made ``mesh.cells_dict`` O(n_cells) per access (it
+    instantiates a ``CellType`` enum value per cell). For the common
+    all-tetrahedra case we bypass it entirely by reshaping
+    ``cell_connectivity``, falling back to ``cells_dict`` only for mixed
+    cell types (e.g. a tet mesh with LINE ridges). Callers that already
+    hold a ``cells_dict`` may pass it via the keyword to skip the
+    rebuild on the mixed path.
+    """
+    celltypes = np.asarray(mesh.celltypes)
+    tetra_type = int(pv.CellType.TETRA)
+    is_all_tetra = celltypes.size > 0 and bool((celltypes == tetra_type).all())
+
+    if is_all_tetra:
+        elements = np.asarray(mesh.cell_connectivity).reshape(-1, 4).astype(np.int32)
+        edges, edge_refs = None, None
+    else:
+        if cells_dict is None:
+            cells_dict = mesh.cells_dict
+        if pv.CellType.TETRA not in cells_dict:
+            msg = "UnstructuredGrid must contain tetrahedra (CellType.TETRA)"
+            raise ValueError(msg)
+        elements = cells_dict[pv.CellType.TETRA].astype(np.int32)
+        edges, edge_refs = _extract_edges(mesh, cells_dict=cells_dict)
 
     vertices = np.array(mesh.points, dtype=np.float64)
-    elements = mesh.cells_dict[pv.CellType.TETRA].astype(np.int32)
-    edges, edge_refs = _extract_edges(mesh)
     elem_refs = _extract_element_refs(
         mesh,
         len(elements),
@@ -450,9 +490,12 @@ def _from_pyvista_auto_detect(
 ) -> MmgMesh3D | MmgMesh2D | MmgMeshS:
     """Convert PyVista mesh to mmgpy mesh with auto-detection."""
     if isinstance(mesh, pv.UnstructuredGrid):
-        if pv.CellType.TETRA in mesh.cells_dict:
+        celltypes = np.asarray(mesh.celltypes)
+        tetra_type = int(pv.CellType.TETRA)
+        has_tetra = bool((celltypes == tetra_type).any())
+        if has_tetra:
             return _from_pyvista_to_mmg3d(mesh)
-        # UnstructuredGrid with no tets — extract surface and treat as 2D/surface
+        # UnstructuredGrid with no tets, extract surface and treat as 2D/surface
         polydata = mesh.extract_surface(algorithm=None)
         if polydata.n_cells > 0:
             logger.warning(

--- a/tests/pv_plugin_test.py
+++ b/tests/pv_plugin_test.py
@@ -1,0 +1,232 @@
+"""Tests for the PyVista 0.48 plugin: Medit reader/writer + ``.mmg`` accessor."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+import mmgpy
+
+
+def _save_via_pv(grid: pv.DataSet, path: Path) -> None:
+    """Save through pv.DataObject.save so the writer registry is exercised."""
+    grid.save(str(path))
+
+
+def _make_tet_mesh() -> pv.UnstructuredGrid:
+    """Return a tiny tetrahedral mesh that round-trips cleanly through MMG."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    elements = np.array(
+        [[0, 1, 2, 3], [1, 2, 3, 4]],
+        dtype=np.int32,
+    )
+    return pv.UnstructuredGrid({pv.CellType.TETRA: elements}, vertices)
+
+
+def _make_surface_mesh() -> pv.PolyData:
+    """Return a triangulated cube as a PolyData surface mesh."""
+    return pv.Cube().triangulate()
+
+
+# ---------------------------------------------------------------------------
+# Reader / writer registries
+# ---------------------------------------------------------------------------
+
+
+def test_pv_read_mesh_returns_unstructured_grid_for_tets(tmp_path: Path) -> None:
+    """Tet meshes round-trip through .mesh as UnstructuredGrid."""
+    grid = _make_tet_mesh()
+    out = tmp_path / "tets.mesh"
+    _save_via_pv(grid, out)
+
+    loaded = pv.read(str(out))
+
+    assert isinstance(loaded, pv.UnstructuredGrid)
+    assert loaded.n_points == grid.n_points
+    assert pv.CellType.TETRA in loaded.cells_dict
+
+
+def test_pv_read_mesh_returns_polydata_for_surface(tmp_path: Path) -> None:
+    """Surface meshes round-trip through .mesh as triangulated PolyData."""
+    surf = _make_surface_mesh()
+    out = tmp_path / "surf.mesh"
+    _save_via_pv(surf, out)
+
+    loaded = pv.read(str(out))
+
+    assert isinstance(loaded, pv.PolyData)
+    assert loaded.n_points == surf.n_points
+    assert loaded.is_all_triangles
+
+
+def test_pv_read_meshb_round_trips_binary(tmp_path: Path) -> None:
+    """Binary .meshb files round-trip without explicit type hint."""
+    grid = _make_tet_mesh()
+    out = tmp_path / "tets.meshb"
+    _save_via_pv(grid, out)
+
+    assert out.exists()
+    loaded = pv.read(str(out))
+    assert isinstance(loaded, pv.UnstructuredGrid)
+    assert loaded.n_points == grid.n_points
+
+
+def test_pv_read_auto_pairs_sibling_sol(tmp_path: Path) -> None:
+    """A sibling .sol file is auto-loaded into point_data on pv.read."""
+    grid = _make_tet_mesh()
+    mesh_path = tmp_path / "demo.mesh"
+    _save_via_pv(grid, mesh_path)
+
+    sol_path = mesh_path.with_suffix(".sol")
+    sol_path.write_text(
+        "MeshVersionFormatted 2\n"
+        "Dimension 3\n"
+        "SolAtVertices\n"
+        f"{grid.n_points}\n"
+        "1 1\n" + "\n".join(f"{i * 0.1}" for i in range(grid.n_points)) + "\nEnd\n",
+    )
+
+    loaded = pv.read(str(mesh_path))
+
+    assert "solution@vertices" in loaded.point_data
+    assert loaded.point_data["solution@vertices"].shape == (grid.n_points,)
+
+
+def test_pv_read_without_sibling_sol_is_silent(tmp_path: Path) -> None:
+    """Reading a .mesh with no companion .sol leaves point_data alone."""
+    grid = _make_tet_mesh()
+    mesh_path = tmp_path / "lonely.mesh"
+    _save_via_pv(grid, mesh_path)
+
+    loaded = pv.read(str(mesh_path))
+
+    assert all(not k.startswith("solution") for k in loaded.point_data)
+
+
+def test_pv_read_skips_solb_auto_pair(tmp_path: Path) -> None:
+    """Binary .solb auto-pair is intentionally skipped (text-only path)."""
+    grid = _make_tet_mesh()
+    mesh_path = tmp_path / "binary.mesh"
+    _save_via_pv(grid, mesh_path)
+
+    # A placeholder .solb the auto-pair finder will discover; we only want
+    # to confirm the plugin skips parsing binary content.
+    mesh_path.with_suffix(".solb").write_bytes(b"\x00\x01\x02")
+
+    loaded = pv.read(str(mesh_path))
+
+    assert all(not k.startswith("solution") for k in loaded.point_data)
+
+
+# ---------------------------------------------------------------------------
+# .mmg dataset accessor
+# ---------------------------------------------------------------------------
+
+
+def test_accessor_remesh_returns_new_dataset() -> None:
+    """mesh.mmg.remesh returns a new dataset, not the original."""
+    surf = _make_surface_mesh()
+    remeshed = surf.mmg.remesh(hsiz=0.3)
+
+    assert isinstance(remeshed, pv.PolyData)
+    assert remeshed.n_cells > 0
+    assert remeshed is not surf
+
+
+def test_accessor_remesh_on_tetrahedral_mesh(tmp_path: Path) -> None:
+    """The accessor handles tet inputs and returns UnstructuredGrid."""
+    pytest.importorskip("scipy")
+    cube_pts = pv.ImageData(
+        dimensions=(5, 5, 5),
+        spacing=(0.25, 0.25, 0.25),
+    ).cast_to_unstructured_grid()
+    tets = cube_pts.delaunay_3d()
+    out = tmp_path / "dense.vtu"
+    tets.save(str(out))
+
+    remeshed = tets.mmg.remesh(hsiz=0.2)
+    assert isinstance(remeshed, pv.UnstructuredGrid)
+    assert pv.CellType.TETRA in remeshed.cells_dict
+
+
+def test_accessor_load_sol_populates_point_data(tmp_path: Path) -> None:
+    """mesh.mmg.load_sol attaches .sol fields to point_data in place."""
+    grid = _make_tet_mesh()
+    sol_path = tmp_path / "metric.sol"
+    sol_path.write_text(
+        "MeshVersionFormatted 2\n"
+        "Dimension 3\n"
+        "SolAtVertices\n"
+        f"{grid.n_points}\n"
+        "1 1\n" + "\n".join(f"{i * 0.5}" for i in range(grid.n_points)) + "\nEnd\n",
+    )
+
+    grid.mmg.load_sol(sol_path)
+
+    assert "solution@vertices" in grid.point_data
+    np.testing.assert_allclose(
+        grid.point_data["solution@vertices"],
+        np.arange(grid.n_points) * 0.5,
+    )
+
+
+def test_accessor_load_sol_rejects_solb(tmp_path: Path) -> None:
+    """Binary .solb is rejected via the accessor with a clear message."""
+    grid = _make_tet_mesh()
+    bogus = tmp_path / "bin.solb"
+    bogus.write_bytes(b"\x00")
+
+    with pytest.raises(NotImplementedError, match=r"Binary \.solb"):
+        grid.mmg.load_sol(bogus)
+
+
+def test_accessor_caches_per_dataset_instance() -> None:
+    """PyVista caches the accessor per dataset (pandas/xarray contract)."""
+    grid = _make_tet_mesh()
+
+    assert grid.mmg is grid.mmg
+
+
+# ---------------------------------------------------------------------------
+# Sanity check that mmgpy is the source of these registrations
+# ---------------------------------------------------------------------------
+
+
+def test_entry_points_advertise_mmgpy_provider() -> None:
+    """All three registries point at mmgpy._pv_plugin via entry points."""
+    reader_eps = {
+        ep.name: ep.value
+        for ep in importlib.metadata.entry_points(group="pyvista.readers")
+    }
+    writer_eps = {
+        ep.name: ep.value
+        for ep in importlib.metadata.entry_points(group="pyvista.writers")
+    }
+    accessor_eps = {
+        ep.name: ep.value
+        for ep in importlib.metadata.entry_points(group="pyvista.accessors")
+    }
+
+    assert reader_eps.get("mesh", "").startswith("mmgpy._pv_plugin")
+    assert reader_eps.get("meshb", "").startswith("mmgpy._pv_plugin")
+    assert writer_eps.get("mesh", "").startswith("mmgpy._pv_plugin")
+    assert writer_eps.get("meshb", "").startswith("mmgpy._pv_plugin")
+    assert accessor_eps.get("mmg", "").startswith("mmgpy._pv_plugin")
+
+
+def test_mmgpy_import_loads_cleanly() -> None:
+    """``import mmgpy`` exposes a version string without erroring out."""
+    assert mmgpy.__version__

--- a/tests/pv_plugin_test.py
+++ b/tests/pv_plugin_test.py
@@ -146,7 +146,7 @@ def test_accessor_remesh_returns_new_dataset() -> None:
     assert remeshed is not surf
 
 
-def test_accessor_remesh_on_tetrahedral_mesh(tmp_path: Path) -> None:
+def test_accessor_remesh_on_tetrahedral_mesh() -> None:
     """The accessor handles tet inputs and returns UnstructuredGrid."""
     pytest.importorskip("scipy")
     cube_pts = pv.ImageData(
@@ -154,8 +154,6 @@ def test_accessor_remesh_on_tetrahedral_mesh(tmp_path: Path) -> None:
         spacing=(0.25, 0.25, 0.25),
     ).cast_to_unstructured_grid()
     tets = cube_pts.delaunay_3d()
-    out = tmp_path / "dense.vtu"
-    tets.save(str(out))
 
     remeshed = tets.mmg.remesh(hsiz=0.2)
     assert isinstance(remeshed, pv.UnstructuredGrid)

--- a/uv.lock
+++ b/uv.lock
@@ -1518,7 +1518,7 @@ requires-dist = [
     { name = "meshio", specifier = ">=5.3.5,<6" },
     { name = "numpy", specifier = ">=2.0.2,<3" },
     { name = "patchelf", marker = "sys_platform == 'linux'", specifier = ">=0.17.2.4,<1" },
-    { name = "pyvista", specifier = ">=0.47,<1" },
+    { name = "pyvista", specifier = ">=0.48,<1" },
     { name = "pywebview", marker = "extra == 'ui'", specifier = ">=6.1,<7" },
     { name = "rich", specifier = ">=13.0.0,<15" },
     { name = "scipy", specifier = ">=1.11.0,<2" },
@@ -2530,7 +2530,7 @@ wheels = [
 
 [[package]]
 name = "pyvista"
-version = "0.47.1"
+version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cyclopts" },
@@ -2544,9 +2544,9 @@ dependencies = [
     { name = "vtk", version = "9.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "vtk", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/ab/4813c71ac41b6691f16f658a9432ffe6d536a1f55d79c193c5c073eb370e/pyvista-0.47.1.tar.gz", hash = "sha256:2d517aeb0e76ea29d7a21ad95237c03ea0b45257d87d0bd88987b49965d1f1a3", size = 2463080, upload-time = "2026-02-23T07:07:11.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/24/a8bf4deb6521d4a26bdfe1262e2e942aaf49b866f8dc8395702d789e5089/pyvista-0.48.0.tar.gz", hash = "sha256:317c1590fce0d3777c34d7c2b4686dc52701a2ba03ab0a312bbd0bdae03f0d42", size = 2580723, upload-time = "2026-05-02T22:49:01.23Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/52/a98dea948d9782b80e8e60804097fee7f7bd8fed92c9d4f0c657e4c3a6f8/pyvista-0.47.1-py3-none-any.whl", hash = "sha256:eb8cee6b6246c41f1a9d2d07e662ec7d0192ea5cf585d64ebf1266774258df59", size = 2508384, upload-time = "2026-02-23T07:07:09.069Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e8/d057b011aee8df7fdb00e5e8f777cea160f2e97f65796bff7c81b85e398d/pyvista-0.48.0-py3-none-any.whl", hash = "sha256:cb6fe80d4a1a7e9ef512b9b555d8b16355ea97b07799fc4f73f2897ca0109e09", size = 2628237, upload-time = "2026-05-02T22:48:58.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Plugs mmgpy into PyVista 0.48's new plugin architecture so any PyVista user gets MMG support transparently:

- **Reader registry** for `.mesh` / `.meshb` — `pv.read("foo.mesh")` works without importing mmgpy.
- **Writer registry** for `.mesh` / `.meshb` — `mesh.save("out.mesh")` round-trips through MMG.
- **`.mmg` dataset accessor** — `mesh.mmg.remesh(hsiz=0.1)` returns a new PyVista dataset; `mesh.mmg.load_sol(path)` populates `point_data`.

When reading a `.mesh` / `.meshb`, a sibling `.sol` (same stem, same directory) is auto-loaded into `point_data` / `cell_data`. Binary `.solb` auto-pair is intentionally skipped for now — route through the `Mesh` wrapper if needed.

`Mesh` is **unchanged** in this PR; the accessor delegates to it internally. Deprecation will land in a follow-up once the accessor has had a release to stabilize.

Closes part of #229. The full issue's smaller wins (`CellType.dimension_map`, `remove_nan_cells`) were dropped after verifying mmgpy has nothing to replace with them. Theme registry, notebook backend registry, `validate_mesh` upgrades, DataFrame export, and `pyvista-zstd` are all out of scope here.

## Side fix

`mmgpy.read` and `pv.read` couldn't determine mesh kind from binary `.meshb` files because `_detect_medit_mesh_kind` only parses text headers. When called for a `.meshb`, `_load_medit_native` now falls through to a trial-load against `MmgMesh3D` → `MmgMeshS` → `MmgMesh2D` and picks whichever yields a non-empty mesh.

## Test plan

- [x] 13 new tests in `tests/pv_plugin_test.py` cover reader (text + binary), writer round-trip, `.sol` auto-pair (present, absent, binary skip), accessor `remesh` (surface + tet), accessor `load_sol`, accessor caching, entry-point declarations.
- [x] Full test suite: 920 pass, 26 skipped, 0 failed.
- [x] `ruff check` and `ruff format --check` clean.
- [x] mypy clean on the new module (pre-existing errors elsewhere untouched).
- [x] End-to-end smoke tested against `assets/Suzanne.stl`: write `.mesh`, `pv.read` it back, `mesh.mmg.remesh(hsiz=0.5)` produces a denser mesh.