### PR TITLE
ci(daily-docs): drop main-conftest overlay, bound runtime, skip Trame

### DIFF
--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -35,16 +35,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install system dependencies for VTK
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgl1-mesa-dev xvfb
-
-      - name: Start Xvfb
-        run: |
-          Xvfb :99 -screen 0 1024x768x24 &
-          echo "DISPLAY=:99" >> $GITHUB_ENV
-
       - name: Install mmgpy from PyPI with test dependencies
         run: |
           uv venv

--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -50,15 +50,6 @@ jobs:
           uv venv
           uv pip install mmgpy pytest pytest-codeblocks
 
-      - name: Patch conftest to avoid VTK at module level
-        run: |
-          # The released conftest.py creates VTK objects at module level
-          # which segfaults under pytest with PyPI VTK wheels.
-          # Use the fixed conftest from main (can be removed once a release
-          # includes the fixed conftest).
-          git fetch origin main
-          git show origin/main:docs/conftest.py > docs/conftest.py
-
       - name: Test documentation code blocks
         env:
           PYVISTA_OFF_SCREEN: "true"

--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -15,6 +15,9 @@ jobs:
           - "3.14"
 
     runs-on: ubuntu-latest
+    # Bound the whole job; individual example timeouts (below) still catch
+    # specific hangs without burning through the GitHub default 6h budget.
+    timeout-minutes: 30
 
     steps:
       - name: Get latest PyPI version
@@ -77,8 +80,10 @@ jobs:
               examples/ui/*) continue ;;
               examples/mmg2d/implicit_2d_domain_meshing.py) continue ;;
               examples/mmgs/implicit_surface_domain_meshing.py) continue ;;
+              # Trame-based viewer that calls app.run() and never returns under CI.
+              examples/mmg2d/interactive_remesh_preview.py) continue ;;
             esac
             echo "::group::Running $f"
-            python "$f"
+            timeout --signal=SIGTERM --kill-after=10s 5m python "$f"
             echo "::endgroup::"
           done

--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -35,6 +35,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install system dependencies for VTK
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev xvfb
+
+      - name: Start Xvfb
+        run: |
+          Xvfb :99 -screen 0 1024x768x24 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
+
       - name: Install mmgpy from PyPI with test dependencies
         run: |
           uv venv

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -151,6 +151,20 @@ _tmp_dir = tempfile.mkdtemp(prefix="mmgpy_docs_")
 atexit.register(shutil.rmtree, _tmp_dir, ignore_errors=True)
 
 
+def _build_mesh(verts: np.ndarray, cells: np.ndarray) -> MeshType:
+    """Build a Mesh from raw arrays, compatible with both released and main APIs.
+
+    ``Mesh._from_arrays`` was added after v0.11.0 to bypass the deprecation
+    warning. The released package does not expose it, so the daily docs job
+    (which runs main's conftest against the PyPI build) must fall back to the
+    public constructor there.
+    """
+    factory = getattr(Mesh, "_from_arrays", None)
+    if factory is not None:
+        return factory(verts, cells)
+    return Mesh(verts, cells)
+
+
 def _fake_read(
     source: str | Path | pv.UnstructuredGrid | pv.PolyData,
     mesh_kind: MeshKind | None = None,
@@ -161,10 +175,10 @@ def _fake_read(
     name = str(source)
     kind = _classify_filename(name)
     if kind == "2d":
-        return Mesh._from_arrays(_VERTS_2D.copy(), _CELLS_2D.copy())  # noqa: SLF001
+        return _build_mesh(_VERTS_2D.copy(), _CELLS_2D.copy())
     if kind == "surface":
-        return Mesh._from_arrays(_VERTS_SURF.copy(), _CELLS_SURF.copy())  # noqa: SLF001
-    return Mesh._from_arrays(_VERTS_3D.copy(), _CELLS_3D.copy())  # noqa: SLF001
+        return _build_mesh(_VERTS_SURF.copy(), _CELLS_SURF.copy())
+    return _build_mesh(_VERTS_3D.copy(), _CELLS_3D.copy())
 
 
 def _patched_save(self: MeshType, filename: str | Path) -> None:

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -151,20 +151,6 @@ _tmp_dir = tempfile.mkdtemp(prefix="mmgpy_docs_")
 atexit.register(shutil.rmtree, _tmp_dir, ignore_errors=True)
 
 
-def _build_mesh(verts: np.ndarray, cells: np.ndarray) -> MeshType:
-    """Build a Mesh from raw arrays, compatible with both released and main APIs.
-
-    ``Mesh._from_arrays`` was added after v0.11.0 to bypass the deprecation
-    warning. The released package does not expose it, so the daily docs job
-    (which runs main's conftest against the PyPI build) must fall back to the
-    public constructor there.
-    """
-    factory = getattr(Mesh, "_from_arrays", None)
-    if factory is not None:
-        return factory(verts, cells)
-    return Mesh(verts, cells)
-
-
 def _fake_read(
     source: str | Path | pv.UnstructuredGrid | pv.PolyData,
     mesh_kind: MeshKind | None = None,
@@ -175,10 +161,10 @@ def _fake_read(
     name = str(source)
     kind = _classify_filename(name)
     if kind == "2d":
-        return _build_mesh(_VERTS_2D.copy(), _CELLS_2D.copy())
+        return Mesh._from_arrays(_VERTS_2D.copy(), _CELLS_2D.copy())  # noqa: SLF001
     if kind == "surface":
-        return _build_mesh(_VERTS_SURF.copy(), _CELLS_SURF.copy())
-    return _build_mesh(_VERTS_3D.copy(), _CELLS_3D.copy())
+        return Mesh._from_arrays(_VERTS_SURF.copy(), _CELLS_SURF.copy())  # noqa: SLF001
+    return Mesh._from_arrays(_VERTS_3D.copy(), _CELLS_3D.copy())  # noqa: SLF001
 
 
 def _patched_save(self: MeshType, filename: str | Path) -> None:


### PR DESCRIPTION
## Summary

The Daily Docs Test was failing for two distinct reasons that share the same root cause: the job mixed v0.11.0 (checkout + binary) with `main`'s `docs/conftest.py`, an incoherent triple. Today's PR simplifies the job to **(released tag, released binary, released conftest)** and bounds runtime so future hangs fail fast.

This is intentionally aligned with the **v0.12.0 release shipping later today**: v0.12 carries the VTK-safe conftest from main, so the overlay step is no longer needed and is removed entirely.

## Changes

- **Drop the `Patch conftest to avoid VTK at module level` step.** Was a workaround for v0.11.0's module-level VTK segfault; v0.12 ships the fix natively. Removing it eliminates the API-drift class of bug we just hit (`Mesh._from_arrays` missing in v0.11.0).
- **Skip `examples/mmg2d/interactive_remesh_preview.py`.** Trame viewer calling `app.run()`; never returns headlessly and was responsible for the cancelled 6h-runs (Apr 28 – May 2).
- **Wrap each example in a 5-minute `timeout`** and cap the job at `timeout-minutes: 30` so any future hang fails fast instead of burning a full GitHub job slot.

## Order of operations

1. Merge this PR.
2. Tag and publish `v0.12.0` to PyPI.
3. Tomorrow's 6 AM UTC cron picks up `v0.12.0` automatically and runs the simplified workflow end-to-end.

## Test plan

- [x] `pytest --codeblocks docs/api/index.md` passes locally against `main`.
- [x] `daily-docs-test.yml` passes YAML lint.
- [ ] First scheduled run against `v0.12.0` succeeds on both 3.10 and 3.14.
- [ ] No example exceeds the 5-minute budget; Trame example is skipped.