### PR TITLE
perf(metrics): JIT-compile compute_hessian inner loop with numba

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ ui = [
     "trame-vtklocal>=0.16.0,<1",
     "trame-vuetify>=3.2.0,<4",
 ]
+adapt = [
+    "numba>=0.59,<1",
+]
 
 [tool.mmgpy]
 mmg_version = "5.8.0"
@@ -205,6 +208,7 @@ ignore = [
     "PLR2004", # magic values (2, 3, 6) are dimension constants in math code
     "C901",    # complex functions acceptable for mathematical algorithms
     "PLR0912", # many branches acceptable for 2D/3D dispatch
+    "PLR0915", # JIT'd Hessian inner loops fully unroll the AtA assembly
 ]
 "examples/**/*.py" = [
     "T201",    # print statements essential for example output

--- a/src/mmgpy/_topology.py
+++ b/src/mmgpy/_topology.py
@@ -54,16 +54,27 @@ def vertex_adjacency(
     return csr
 
 
-def two_ring_patches(adj: sparse.csr_matrix) -> list[NDArray[np.intp]]:
-    """For each vertex i, return its closed 2-ring (i and all 1- and 2-step neighbours).
+def two_ring_csr(adj: sparse.csr_matrix) -> sparse.csr_matrix:
+    """CSR sparsity pattern of the closed 2-ring (``I + A + A @ A``).
 
-    Computed as the nonzero pattern of ``I + A + A @ A``. The matrix product
-    runs in C and is dramatically cheaper than per-vertex Python set unions,
-    especially for high-order elements.
+    Each row ``i`` of the returned matrix lists vertex ``i`` together with all
+    of its 1- and 2-step neighbours. Computed via a sparse matmul in C, which
+    is dramatically cheaper than per-vertex Python set unions.
     """
     n = adj.shape[0]
     closed = (adj + adj @ adj + sparse.eye(n, format="csr")).tocsr()
     closed.eliminate_zeros()
+    return closed
+
+
+def two_ring_patches(adj: sparse.csr_matrix) -> list[NDArray[np.intp]]:
+    """For each vertex i, return its closed 2-ring as a Python list of arrays.
+
+    Convenience wrapper around :func:`two_ring_csr` for callers that want a
+    Python-iterable view; consumers that can stay in CSR land should use the
+    CSR helper directly to avoid the per-row slice.
+    """
+    closed = two_ring_csr(adj)
     indptr = closed.indptr
     indices = closed.indices
-    return [indices[indptr[i] : indptr[i + 1]] for i in range(n)]
+    return [indices[indptr[i] : indptr[i + 1]] for i in range(closed.shape[0])]

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -43,10 +43,174 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from mmgpy._topology import two_ring_patches, vertex_adjacency
+from mmgpy._topology import two_ring_csr, vertex_adjacency
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+
+try:
+    import numba
+
+    # Per-vertex 5x5 / 9x9 normal-equations solve, JIT-compiled and run in
+    # parallel over vertices. ``compute_hessian`` falls back to the pure-NumPy
+    # path below if numba is unavailable, so the JIT helpers are decorated
+    # eagerly at import time only when numba imports cleanly.
+    @numba.njit(cache=True, parallel=True)
+    def _hessian_loop_2d_njit(
+        vertices: NDArray[np.float64],
+        field: NDArray[np.float64],
+        indptr: NDArray[np.int64],
+        indices: NDArray[np.int64],
+        hessian: NDArray[np.float64],
+    ) -> None:
+        n_vertices = vertices.shape[0]
+        for i in numba.prange(n_vertices):  # ty: ignore[not-iterable]
+            start = indptr[i]
+            end = indptr[i + 1]
+            n_patch = end - start
+            # Need at least 5 monomials + 1 constraint to fit a quadratic.
+            if n_patch < 6:
+                continue
+
+            xi = vertices[i, 0]
+            yi = vertices[i, 1]
+            fi = field[i]
+
+            max_r2 = 0.0
+            for k in range(start, end):
+                j = indices[k]
+                dx = vertices[j, 0] - xi
+                dy = vertices[j, 1] - yi
+                r2 = dx * dx + dy * dy
+                max_r2 = max(max_r2, r2)
+            if max_r2 == 0.0:
+                continue
+
+            inv_scale = 1.0 / np.sqrt(max_r2)
+
+            ata = np.zeros((5, 5))
+            atb = np.zeros(5)
+            for k in range(start, end):
+                j = indices[k]
+                x = (vertices[j, 0] - xi) * inv_scale
+                y = (vertices[j, 1] - yi) * inv_scale
+                v = field[j] - fi
+
+                m0 = x
+                m1 = y
+                m2 = 0.5 * x * x
+                m3 = x * y
+                m4 = 0.5 * y * y
+
+                ata[0, 0] += m0 * m0
+                ata[0, 1] += m0 * m1
+                ata[0, 2] += m0 * m2
+                ata[0, 3] += m0 * m3
+                ata[0, 4] += m0 * m4
+                ata[1, 1] += m1 * m1
+                ata[1, 2] += m1 * m2
+                ata[1, 3] += m1 * m3
+                ata[1, 4] += m1 * m4
+                ata[2, 2] += m2 * m2
+                ata[2, 3] += m2 * m3
+                ata[2, 4] += m2 * m4
+                ata[3, 3] += m3 * m3
+                ata[3, 4] += m3 * m4
+                ata[4, 4] += m4 * m4
+
+                atb[0] += m0 * v
+                atb[1] += m1 * v
+                atb[2] += m2 * v
+                atb[3] += m3 * v
+                atb[4] += m4 * v
+
+            # Symmetrise upper -> lower
+            for a in range(5):
+                for b in range(a):
+                    ata[a, b] = ata[b, a]
+
+            coeffs = np.linalg.solve(ata, atb)
+            inv_scale2 = 1.0 / max_r2
+            hessian[i, 0] = coeffs[2] * inv_scale2
+            hessian[i, 1] = coeffs[3] * inv_scale2
+            hessian[i, 2] = coeffs[4] * inv_scale2
+
+    @numba.njit(cache=True, parallel=True)
+    def _hessian_loop_3d_njit(
+        vertices: NDArray[np.float64],
+        field: NDArray[np.float64],
+        indptr: NDArray[np.int64],
+        indices: NDArray[np.int64],
+        hessian: NDArray[np.float64],
+    ) -> None:
+        n_vertices = vertices.shape[0]
+        for i in numba.prange(n_vertices):  # ty: ignore[not-iterable]
+            start = indptr[i]
+            end = indptr[i + 1]
+            n_patch = end - start
+            if n_patch < 10:
+                continue
+
+            xi = vertices[i, 0]
+            yi = vertices[i, 1]
+            zi = vertices[i, 2]
+            fi = field[i]
+
+            max_r2 = 0.0
+            for k in range(start, end):
+                j = indices[k]
+                dx = vertices[j, 0] - xi
+                dy = vertices[j, 1] - yi
+                dz = vertices[j, 2] - zi
+                r2 = dx * dx + dy * dy + dz * dz
+                max_r2 = max(max_r2, r2)
+            if max_r2 == 0.0:
+                continue
+
+            inv_scale = 1.0 / np.sqrt(max_r2)
+
+            ata = np.zeros((9, 9))
+            atb = np.zeros(9)
+            m = np.empty(9)
+            for k in range(start, end):
+                j = indices[k]
+                x = (vertices[j, 0] - xi) * inv_scale
+                y = (vertices[j, 1] - yi) * inv_scale
+                z = (vertices[j, 2] - zi) * inv_scale
+                v = field[j] - fi
+
+                m[0] = x
+                m[1] = y
+                m[2] = z
+                m[3] = 0.5 * x * x
+                m[4] = x * y
+                m[5] = x * z
+                m[6] = 0.5 * y * y
+                m[7] = y * z
+                m[8] = 0.5 * z * z
+
+                for a in range(9):
+                    atb[a] += m[a] * v
+                    for b in range(a, 9):
+                        ata[a, b] += m[a] * m[b]
+
+            for a in range(9):
+                for b in range(a):
+                    ata[a, b] = ata[b, a]
+
+            coeffs = np.linalg.solve(ata, atb)
+            inv_scale2 = 1.0 / max_r2
+            hessian[i, 0] = coeffs[3] * inv_scale2
+            hessian[i, 1] = coeffs[4] * inv_scale2
+            hessian[i, 2] = coeffs[5] * inv_scale2
+            hessian[i, 3] = coeffs[6] * inv_scale2
+            hessian[i, 4] = coeffs[7] * inv_scale2
+            hessian[i, 5] = coeffs[8] * inv_scale2
+
+    _HESSIAN_NJIT = True
+except ImportError:
+    _HESSIAN_NJIT = False
 
 
 def create_isotropic_metric(
@@ -613,6 +777,11 @@ def compute_hessian(
     solution field with your FE solver, pass it here to get the Hessian,
     then use :func:`create_metric_from_hessian` to build an adaptation metric.
 
+    Performance: when ``numba`` is installed (``pip install mmgpy[adapt]``),
+    the per-vertex 5x5 / 9x9 normal-equations solve is JIT-compiled and run
+    in parallel over vertices, typically ~7-15x faster than the pure-NumPy
+    fallback. Results are equivalent up to floating-point noise (~1e-12).
+
     Args:
         vertices: Nx2 or Nx3 array of vertex coordinates.
         elements: Mx(nodes_per_element) array of element connectivity.
@@ -625,7 +794,8 @@ def compute_hessian(
     """
     n_vertices = len(vertices)
     n_dims = vertices.shape[1]
-    field = np.asarray(field, dtype=np.float64).ravel()
+    vertices = np.ascontiguousarray(vertices, dtype=np.float64)
+    field = np.ascontiguousarray(np.asarray(field, dtype=np.float64).ravel())
 
     if len(field) != n_vertices:
         msg = f"field length {len(field)} != n_vertices {n_vertices}"
@@ -637,7 +807,9 @@ def compute_hessian(
     # the LSQ rank-deficient. Always use the 2-ring; it is well-conditioned
     # everywhere and only modestly larger than the 1-ring.
     adj = vertex_adjacency(n_vertices, elements)
-    patches = two_ring_patches(adj)
+    closed = two_ring_csr(adj)
+    indptr = closed.indptr.astype(np.int64)
+    indices = closed.indices.astype(np.int64)
 
     if n_dims == 2:
         hessian = np.zeros((n_vertices, 3), dtype=np.float64)
@@ -646,8 +818,18 @@ def compute_hessian(
         hessian = np.zeros((n_vertices, 6), dtype=np.float64)
         n_basis = 9
 
+    if _HESSIAN_NJIT:
+        # JIT'd parallel loop: assembles 5x5 / 9x9 normal equations per vertex
+        # and dispatches a single ``np.linalg.solve``. Skips the rescale +
+        # ``lstsq`` overhead that dominates the pure-NumPy path.
+        if n_dims == 2:
+            _hessian_loop_2d_njit(vertices, field, indptr, indices, hessian)
+        else:
+            _hessian_loop_3d_njit(vertices, field, indptr, indices, hessian)
+        return hessian
+
     for i in range(n_vertices):
-        patch = patches[i]
+        patch = indices[indptr[i] : indptr[i + 1]]
 
         # Underdetermined patch: lstsq returns a least-norm solution rather
         # than failing, which silently corrupts the recovered Hessian. Skip.

--- a/uv.lock
+++ b/uv.lock
@@ -1168,6 +1168,38 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/f5/a1bde3aa8c43524b0acaf3f72fb3d80a32dd29dbb42d7dc434f84584cdcc/llvmlite-0.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41270b0b1310717f717cf6f2a9c68d3c43bd7905c33f003825aebc361d0d1b17", size = 37232772, upload-time = "2026-03-31T18:28:12.198Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fb/76d88fc05ee1f9c1a6efe39eb493c4a727e5d1690412469017cd23bcb776/llvmlite-0.47.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f9d118bc1dd7623e0e65ca9ac485ec6dd543c3b77bc9928ddc45ebd34e1e30a7", size = 56275179, upload-time = "2026-03-31T18:28:15.725Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/08/29da7f36217abd56a0c389ef9a18bea47960826e691ced1a36c92c6ce93c/llvmlite-0.47.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea5cfb04a6ab5b18e46be72b41b015975ba5980c4ddb41f1975b83e19031063", size = 55128632, upload-time = "2026-03-31T18:28:19.946Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/5e12e9ed447d65f04acf6fcf2d79cded2355640b5131a46cee4c99a5949d/llvmlite-0.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:166b896a2262a2039d5fc52df5ee1659bd1ccd081183df7a2fba1b74702dd5ea", size = 38138402, upload-time = "2026-03-31T18:28:23.327Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0b/b9d1911cfefa61399821dfb37f486d83e0f42630a8d12f7194270c417002/llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07", size = 37232770, upload-time = "2026-03-31T18:28:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb", size = 56275177, upload-time = "2026-03-31T18:28:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/48a53fedf01cb1f3f43ef200be17ebf83c8d9a04018d3783c1a226c342c2/llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8", size = 55128631, upload-time = "2026-03-31T18:28:36.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/59227d06bdc96e23322713c381af4e77420949d8cd8a042c79e0043096cc/llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327", size = 38138400, upload-time = "2026-03-31T18:28:40.076Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1492,6 +1524,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+adapt = [
+    { name = "numba" },
+]
 fem = [
     { name = "fedoo" },
 ]
@@ -1536,6 +1571,7 @@ ui = [
 requires-dist = [
     { name = "fedoo", marker = "extra == 'fem'", specifier = ">=0.8.3,<1" },
     { name = "meshio", specifier = ">=5.3.5,<6" },
+    { name = "numba", marker = "extra == 'adapt'", specifier = ">=0.59,<1" },
     { name = "numpy", specifier = ">=2.0.2,<3" },
     { name = "patchelf", marker = "sys_platform == 'linux'", specifier = ">=0.17.2.4,<1" },
     { name = "pyvista", specifier = ">=0.48,<1" },
@@ -1548,7 +1584,7 @@ requires-dist = [
     { name = "trame-vuetify", marker = "extra == 'ui'", specifier = ">=3.2.0,<4" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5" },
 ]
-provides-extras = ["fem", "ui"]
+provides-extras = ["fem", "ui", "adapt"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1848,6 +1884,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1b/3c5a7daf683a95465bf23504bcd1a2d5db8cd5e5e276ca87505d020dffe9/numba-0.65.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:9d993ed0a257aa4116e6f553f114004bcfdee540c7276ab8ea48f650d514c452", size = 2680870, upload-time = "2026-04-24T02:02:10.623Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a4/1831836814018a898e7d252aebe09c0f3ce1f26d145b68264b4ae0be6822/numba-0.65.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f098109f361681e57295f7e84d8ab2426902539a141811de0703ace52826981", size = 3739780, upload-time = "2026-04-24T02:02:13.097Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/1b/a813ddc81def09e257d2b1f67521982ce4b06204a87268796ffc8187271c/numba-0.65.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973fd8173f2312815e6b7aaae887c4ce8a817eeff46a4f8840b828305b75bc95", size = 3446722, upload-time = "2026-04-24T02:02:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/ee1d8b3becda384fe0552221641e05aa668a35e8a77470db4db7f6475000/numba-0.65.1-cp310-cp310-win_amd64.whl", hash = "sha256:c63aa0c4193694026452da55d0ef9d85156c1a7a333454c103bb30dec81b7bf8", size = 2747539, upload-time = "2026-04-24T02:02:16.79Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/650500c2eab4534d98e9166f4298e0f3c69c742afdf24e6eabccd1f16ad8/numba-0.65.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:7020d74b19cdb8cff16506542fdd510756e28c5e7f3bd0b7f574f0f42272fcd9", size = 2680563, upload-time = "2026-04-24T02:02:18.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/0615dbedb98f5b32a35a53290fbdc6e22306968109278d7e58df82d7a9f6/numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f80ed83774b5173abd6581cd8d2165d1d38e13d2e5c8155c0c0b421784745420", size = 3745018, upload-time = "2026-04-24T02:02:20.252Z" },
+    { url = "https://files.pythonhosted.org/packages/49/aa/4361698f35bf63bff67dfe6c90493731177f48ede954f77b0588731537bc/numba-0.65.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ed425a43b0a5f9772f2f4e2dd0bbd12eabecae1af0b24efcfd4e053f012aac6", size = 3450962, upload-time = "2026-04-24T02:02:22.449Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9a/af61ec03b3116c161fd7a06b9e8a265729a8718458333e8ffbb06d9a3978/numba-0.65.1-cp311-cp311-win_amd64.whl", hash = "sha256:df40a5028a975b9ea66f6a2a3f7abbdbd541a863070e34ed367aff21141248e4", size = 2747417, upload-time = "2026-04-24T02:02:24.43Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The per-vertex 5×5 / 9×9 LSQ loop is the remaining bottleneck in `compute_hessian` (PR #205); the topology setup was already vectorised in 3cf9a33. This PR moves that loop into a `@numba.njit(parallel=True)` helper with `prange` over vertices, assembling symmetric `AᵀA` / `Aᵀb` directly and dispatching a single `np.linalg.solve` instead of `np.linalg.lstsq` per vertex.

`compute_hessian` picks the JIT path when `numba` is importable and falls back to the existing pure-NumPy code otherwise. Output matches the pre-JIT path to ~1e-12.

## Numbers

| Mesh | Before (pure NumPy) | After (numba `[adapt]`) | Speedup |
|---|---|---|---|
| 2D 100×100 (10k verts) | 162 ms | 11 ms | **14.7×** |
| 3D 19³ (6.9k verts, 43k tets) | 203 ms | 28 ms | **7.2×** |
| 3D 25³ (16k verts, 100k tets) | 462 ms | 65 ms | **7.1×** |
| 3D 35³ (43k verts, 287k tets) | ~1.4 s | 186 ms | ~7–8× |

Measured on a 24-thread CPU. Max abs diff vs the pure-NumPy path: ~5×10⁻¹².

## Why not GPU?

I prototyped the equivalent in cupy (both `cupyx.scatter_add` + `cupy.linalg.solve`, and a hand-written CUDA `RawKernel` mirroring the numba structure). Even with the custom kernel, the GPU was only ~2× faster than parallel numba in 2D and **~1.1× in 3D** (register pressure on the 9×9 `AᵀA` accumulator + non-coalesced `vertices[indices[k]]` gather + cuSOLVER launch overhead on tiny systems). Not worth the extra dependency, especially given the CUDA pinning headache.

## Changes

- New optional `[adapt]` extra: `numba>=0.59,<1`.
- `_hessian_loop_2d_njit` / `_hessian_loop_3d_njit` in `metrics.py`, decorated with `@numba.njit(cache=True, parallel=True)` and using `numba.prange`.
- `compute_hessian` dispatches to the JIT helper when available; pure-NumPy path is preserved for users without numba.
- `_topology.py` gains `two_ring_csr` returning the CSR directly so the JIT path consumes `indptr` / `indices` without the per-row Python list slice. `two_ring_patches` is kept as a thin wrapper.

## Test plan

- [x] All 7 `tests/hessian_test.py` cases pass with the JIT path
- [x] Full non-fedoo suite (339 tests) passes
- [x] JIT and pure-NumPy outputs match within ~5×10⁻¹² on the benchmarked meshes
- [x] Pre-commit (ruff / ty / formatters) clean