### PR TITLE
fix(examples): drop explicit off_screen=False in smooth_surface_remeshing

### DIFF
--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 6 * * *" # 6 AM UTC daily
   workflow_dispatch: # Allow manual triggering
-  pull_request: # TEMPORARY: verify fix in PR, revert before merge
 
 jobs:
   test-released-docs:
@@ -30,9 +29,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          # On PRs, check out the PR HEAD so we exercise the proposed examples
-          # against the released package. On schedule/dispatch, use the released tag.
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || format('v{0}', steps.version.outputs.version) }}
+          ref: v${{ steps.version.outputs.version }}
 
       - uses: astral-sh/setup-uv@v8.0.0
         with:

--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 6 * * *" # 6 AM UTC daily
   workflow_dispatch: # Allow manual triggering
+  pull_request: # TEMPORARY: verify fix in PR, revert before merge
 
 jobs:
   test-released-docs:
@@ -29,7 +30,9 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: v${{ steps.version.outputs.version }}
+          # On PRs, check out the PR HEAD so we exercise the proposed examples
+          # against the released package. On schedule/dispatch, use the released tag.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || format('v{0}', steps.version.outputs.version) }}
 
       - uses: astral-sh/setup-uv@v8.0.0
         with:

--- a/examples/mmgs/smooth_surface_remeshing.py
+++ b/examples/mmgs/smooth_surface_remeshing.py
@@ -19,15 +19,10 @@ import mmgpy  # noqa: F401  -- registers the .mmg accessor and Medit reader
 
 INPUT_FILE = Path(__file__).parent.parent.parent / "assets" / "rodin.mesh"
 
-SCREENSHOT = False
-
 mesh = pv.read(INPUT_FILE)
 result = mesh.mmg.remesh(hausd=0.001, angle=0, verbose=-1)
 
-pl = pv.Plotter(off_screen=SCREENSHOT)
+pl = pv.Plotter()
 pl.add_mesh(result, show_edges=True)
 pl.camera.elevation = -30
-if SCREENSHOT:
-    pl.show(screenshot="smooth_surface_remeshing.png")
-else:
-    pl.show()
+pl.show()


### PR DESCRIPTION
## Summary

Daily Docs Test has been failing every day for at least a week because `examples/mmgs/smooth_surface_remeshing.py` hangs on `pl.show()` until the per-example 5m timeout fires (exit 124).

## Root cause

The example explicitly forced `pv.Plotter(off_screen=False)`, which overrides the workflow's `PYVISTA_OFF_SCREEN=true` env var. With Xvfb available, `pl.show()` then waits forever for an interactive window close. Every other example either passes `off_screen=True` or omits the kwarg entirely, so the env var takes effect and `show()` returns immediately.

## Changes

- `examples/mmgs/smooth_surface_remeshing.py`: drop the `SCREENSHOT` toggle and the explicit `off_screen=` arg, just call `pv.Plotter()` and `pl.show()`. Local interactive runs still pop a window; CI sets `PYVISTA_OFF_SCREEN=true` and runs headless.

## Notes

The Daily Docs Test workflow checks out the released tag (`v0.12.0`), which still contains the bug, so the daily run will stay red until `v0.13.0` ships. Verified locally with `PYVISTA_OFF_SCREEN=true uv run python examples/mmgs/smooth_surface_remeshing.py` — exits 0.

## Test plan

- [x] Example exits cleanly under `PYVISTA_OFF_SCREEN=true` locally
- [ ] CI green on this PR