### PR TITLE
switch screenshot examples to .show() and clarify CI skip-list comments

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,8 +58,8 @@ jobs:
           for f in examples/**/*.py; do
             case "$f" in
               examples/ui/*) continue ;;  # UI examples need a display server
-              examples/mmg2d/implicit_2d_domain_meshing.py) continue ;;  # requires specific input assets
-              examples/mmgs/implicit_surface_domain_meshing.py) continue ;;  # requires specific input assets
+              examples/mmg2d/implicit_2d_domain_meshing.py) continue ;;  # references assets/multi-mat-rmc.sol which is not in the repo
+              examples/mmgs/implicit_surface_domain_meshing.py) continue ;;  # MMG analysis fails on this asset combination, needs investigation
             esac
             echo "::group::Running $f"
             uv run python "$f"

--- a/.github/workflows/daily-docs-test.yml
+++ b/.github/workflows/daily-docs-test.yml
@@ -68,11 +68,9 @@ jobs:
           source .venv/bin/activate
           for f in examples/**/*.py; do
             case "$f" in
-              examples/ui/*) continue ;;
-              examples/mmg2d/implicit_2d_domain_meshing.py) continue ;;
-              examples/mmgs/implicit_surface_domain_meshing.py) continue ;;
-              # Trame-based viewer that calls app.run() and never returns under CI.
-              examples/mmg2d/interactive_remesh_preview.py) continue ;;
+              examples/ui/*) continue ;;  # UI examples need a display server
+              examples/mmg2d/implicit_2d_domain_meshing.py) continue ;;  # references assets/multi-mat-rmc.sol which is not in the repo
+              examples/mmgs/implicit_surface_domain_meshing.py) continue ;;  # MMG analysis fails on this asset combination, needs investigation
             esac
             echo "::group::Running $f"
             timeout --signal=SIGTERM --kill-after=10s 5m python "$f"

--- a/examples/mmg2d/levelset_discretization.py
+++ b/examples/mmg2d/levelset_discretization.py
@@ -27,8 +27,6 @@ This is essential for:
 - Fluid-structure interaction
 """
 
-from pathlib import Path
-
 import numpy as np
 import pyvista as pv
 from scipy.spatial import Delaunay
@@ -145,7 +143,7 @@ def main() -> None:
     )
     circle = pv.Spline(circle_points, 100)
 
-    pl = pv.Plotter(shape=(1, 2), window_size=(1400, 700), off_screen=True)
+    pl = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
 
     pl.subplot(0, 0)
     pl.add_mesh(
@@ -182,9 +180,7 @@ def main() -> None:
     pl.add_title("After: Mesh edges conform to interface")
     pl.view_xy()
 
-    output_path = Path(__file__).parent / "levelset_discretization.png"
-    pl.screenshot(output_path)
-    print(f"\nImage saved to: {output_path}")
+    pl.show()
 
 
 if __name__ == "__main__":

--- a/examples/mmg3d/ellipsoid_levelset.py
+++ b/examples/mmg3d/ellipsoid_levelset.py
@@ -28,8 +28,6 @@ After level-set discretization, MMG creates:
 For a surface-only mesh, see examples/mmgs/ellipsoid_sdf.py.
 """
 
-from pathlib import Path
-
 import numpy as np
 import pyvista as pv
 
@@ -176,7 +174,7 @@ def main() -> None:
     )
 
     # Visualization
-    pl = pv.Plotter(shape=(1, 2), window_size=(1400, 700), off_screen=True)
+    pl = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
 
     # Left: Surface mesh
     pl.subplot(0, 0)
@@ -208,9 +206,7 @@ def main() -> None:
     pl.link_views()
     pl.camera_position = [(3, 2, 1.5), center, (0, 0, 1)]
 
-    output_path = Path(__file__).parent / "ellipsoid_levelset.png"
-    pl.screenshot(output_path)
-    print(f"\nImage saved to: {output_path}")
+    pl.show()
 
 
 if __name__ == "__main__":

--- a/examples/mmg3d/hessian_adaptation.py
+++ b/examples/mmg3d/hessian_adaptation.py
@@ -23,13 +23,10 @@ initial uniform mesh, and runs anisotropic remeshing so the new mesh
 refines along the front and stays coarse elsewhere.
 
 A corner of the cube is clipped away so the interior refinement around
-the spherical front is visible. The script writes
-``hessian_adaptation.png`` next to itself.
+the spherical front is visible.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import numpy as np
 import pyvista as pv
@@ -93,7 +90,7 @@ def main() -> None:
         f"Adapted: {adapted.n_points} vertices, {n_tets_out} tetrahedra",
     )
 
-    pl = pv.Plotter(shape=(1, 2), off_screen=True, window_size=(1300, 650))
+    pl = pv.Plotter(shape=(1, 2), window_size=(1300, 650))
     sphere = pv.Sphere(radius=0.3, center=(0.5, 0.5, 0.5)).clip_box(
         bounds=(0.5, 1.05, 0.5, 1.05, 0.5, 1.05),
         invert=True,
@@ -135,9 +132,7 @@ def main() -> None:
     pl.link_views()
     pl.camera_position = [(2.6, 2.4, 2.6), (0.5, 0.5, 0.5), (0, 0, 1)]
 
-    out_path = Path(__file__).with_suffix(".png")
-    pl.show(screenshot=str(out_path))
-    print(f"Wrote {out_path}")
+    pl.show()
 
 
 if __name__ == "__main__":

--- a/examples/mmg3d/levelset_discretization.py
+++ b/examples/mmg3d/levelset_discretization.py
@@ -26,8 +26,6 @@ Key insight: After level-set discretization, MMG creates:
 To visualize the solid gyroid, extract the surface of ref=3 tetrahedra.
 """
 
-from pathlib import Path
-
 import numpy as np
 import pyvista as pv
 
@@ -154,7 +152,7 @@ def main() -> None:
     print(f"  Result: {n_tri} triangles, {n_pts} vertices")
 
     # Visualization
-    pl = pv.Plotter(shape=(1, 2), window_size=(1400, 700), off_screen=True)
+    pl = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
 
     pl.subplot(0, 0)
     pl.add_mesh(
@@ -179,10 +177,7 @@ def main() -> None:
     pl.link_views()
     pl.camera_position = [(2.5, 2.5, 2.5), (0, 0, 0), (0, 0, 1)]
 
-    # Save image
-    output_path = Path(__file__).parent / "levelset_discretization.png"
-    pl.screenshot(output_path)
-    print(f"\nImage saved to: {output_path}")
+    pl.show()
 
 
 if __name__ == "__main__":

--- a/examples/mmgs/ellipsoid_sdf.py
+++ b/examples/mmgs/ellipsoid_sdf.py
@@ -26,7 +26,6 @@ For a volumetric mesh with tetrahedra, see examples/mmg3d/ellipsoid_levelset.py.
 
 import time
 from dataclasses import dataclass
-from pathlib import Path
 
 import numpy as np
 import pyvista as pv
@@ -136,7 +135,7 @@ def main() -> None:
         print()
 
     # Visualization: 3 rows (methods) x 2 columns (before/after)
-    pl = pv.Plotter(shape=(3, 2), window_size=(1200, 1400), off_screen=True)
+    pl = pv.Plotter(shape=(3, 2), window_size=(1200, 1400))
 
     for row, result in enumerate(results):
         # Left: Original extraction
@@ -170,9 +169,7 @@ def main() -> None:
     pl.link_views()
     pl.camera_position = [(3, 2, 1.5), center, (0, 0, 1)]
 
-    output_path = Path(__file__).parent / "ellipsoid_sdf.png"
-    pl.screenshot(output_path)
-    print(f"Image saved to: {output_path}")
+    pl.show()
 
     # Print summary table
     print("\n" + "=" * 70)


### PR DESCRIPTION
## Summary
Five examples used `off_screen=True` + `pl.screenshot(path)` to write PNGs that nothing consumes (the canonical docs images live in `docs/assets/`). Switch them to plain `pl.show()` so the gallery is uniform: dev sees the window, CI runs them headless via `PYVISTA_OFF_SCREEN=true`. Tighten the CI skip-list comments while we're here.

## Changes
- `examples/mmg{2d,3d}/levelset_discretization.py`, `examples/mmg3d/{hessian_adaptation,ellipsoid_levelset}.py`, `examples/mmgs/ellipsoid_sdf.py`: drop `off_screen=True`, drop the screenshot save block, drop the now-unused `pathlib.Path` import. The 3D hessian docstring also claimed it wrote a PNG, removed.
- `.github/workflows/build-and-test.yml`: replace the catch-all "requires specific input assets" comment with the real reason for each (`mmg2d/implicit_2d_domain_meshing.py` references `assets/multi-mat-rmc.sol` which is not in the repo; `mmgs/implicit_surface_domain_meshing.py` MMG analysis fails on its asset combination).
- `.github/workflows/daily-docs-test.yml`: same comment fixes, plus unskip `examples/mmg2d/interactive_remesh_preview.py` (the previous skip claimed it was Trame-based and hung. it's PyVista with widgets, runs in 2s offscreen).

## Notes
- Smoke-tested each converted example with `PYVISTA_OFF_SCREEN=true MPLBACKEND=Agg`, all exit 0 in under 3 minutes.
- Stacks on top of #240.