### PR TITLE
add mmg2d.generate() for boundary-edge triangulation

### DIFF
--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -65,37 +65,6 @@ plane = pv.Plane()
 remeshed_plane = plane.mmg.remesh(hsiz=0.1)
 ```
 
-## Generating a 2D Mesh from Boundary Edges
-
-`mmgpy.mmg2d.generate` triangulates a 2D domain described by a vertex+edge outline. Internally it drives the same `MMG2D_mmg2dmesh` entry point that the standalone executable uses when fed a `.mesh` file with no triangles.
-
-```python
-import numpy as np
-from mmgpy import mmg2d
-
-verts = np.array(
-    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
-    dtype=np.float64,
-)
-edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
-
-mesh = mmg2d.generate(verts, edges, hmax=0.1)
-mesh.save("square.vtk")
-```
-
-The same code path is selected automatically by the `.mmg` accessor when the input PolyData has only `LINE` cells:
-
-```python
-import pyvista as pv
-import mmgpy  # noqa: F401  -- registers the accessor
-
-verts = np.column_stack([verts, np.zeros(len(verts))])
-lines = np.column_stack([np.full(len(edges), 2), edges]).ravel()
-outline = pv.PolyData(verts, lines=lines)
-
-mesh = outline.mmg.remesh(hmax=0.1)
-```
-
 ## Saving Meshes
 
 Use PyVista's `save()`:
@@ -136,6 +105,32 @@ remeshed.save("output.vtu")    # VTK XML format
 torus = pv.ParametricTorus()
 remeshed_torus = torus.mmg.remesh(hmax=0.1)
 remeshed_torus.save("torus.mesh")
+```
+
+## Generating a 2D Mesh from Boundary Edges
+
+`mmgpy.mmg2d.generate` triangulates a 2D domain described by a vertex+edge outline. Internally it drives the same `MMG2D_mmg2dmesh` entry point that the standalone executable uses when fed a `.mesh` file with no triangles.
+
+```python
+import numpy as np
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers the accessor
+from mmgpy import mmg2d
+
+verts = np.array(
+    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+    dtype=np.float64,
+)
+edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
+
+mesh = mmg2d.generate(verts, edges, hmax=0.1)
+
+# Equivalent via the .mmg accessor: a line-only PolyData is auto-routed
+# through the same generation path.
+verts_3d = np.column_stack([verts, np.zeros(len(verts))])
+lines = np.column_stack([np.full(len(edges), 2), edges]).ravel()
+outline = pv.PolyData(verts_3d, lines=lines)
+mesh = outline.mmg.remesh(hmax=0.1)
 ```
 
 ## Tips

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -65,6 +65,37 @@ plane = pv.Plane()
 remeshed_plane = plane.mmg.remesh(hsiz=0.1)
 ```
 
+## Generating a 2D Mesh from Boundary Edges
+
+`mmgpy.mmg2d.generate` triangulates a 2D domain described by a vertex+edge outline. Internally it drives the same `MMG2D_mmg2dmesh` entry point that the standalone executable uses when fed a `.mesh` file with no triangles.
+
+```python
+import numpy as np
+from mmgpy import mmg2d
+
+verts = np.array(
+    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+    dtype=np.float64,
+)
+edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
+
+mesh = mmg2d.generate(verts, edges, hmax=0.1)
+mesh.save("square.vtk")
+```
+
+The same code path is selected automatically by the `.mmg` accessor when the input PolyData has only `LINE` cells:
+
+```python
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers the accessor
+
+verts = np.column_stack([verts, np.zeros(len(verts))])
+lines = np.column_stack([np.full(len(edges), 2), edges]).ravel()
+outline = pv.PolyData(verts, lines=lines)
+
+mesh = outline.mmg.remesh(hmax=0.1)
+```
+
 ## Saving Meshes
 
 Use PyVista's `save()`:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `mmgpy.mmg2d.generate(boundary_vertices, boundary_edges, ...)` triangulates a 2D domain from a vertex+edge outline via MMG2D's mesh-generation path. The `.mmg` accessor auto-routes line-only `pv.PolyData` through the same path so `outline.mmg.remesh(hmax=...)` produces a triangulation directly.
 - Promoted six high-value MMG flags to typed fields on the options dataclasses: `nreg` and `anisosize` on all three (`Mmg3DOptions`, `Mmg2DOptions`, `MmgSOptions`); `opnbdy` and `nofem` on `Mmg3DOptions` / `Mmg2DOptions`; `optim_les` on `Mmg3DOptions` (forwarded as `optimLES`); `keep_ref` on `MmgSOptions` (forwarded as `keepRef`). Niche options (`octree`, `numsubdomain`, `isoref`, `nosizreq`, `xreg`, `xreg_val`, `rmc`, `3dmedit`) remain as `**kwargs` on `remesh(...)`.
 
 ### Removed

--- a/examples/mmg2d/triangulate_outline.py
+++ b/examples/mmg2d/triangulate_outline.py
@@ -46,7 +46,7 @@ def naca_airfoil(n: int = 80, thickness: float = 0.12) -> np.ndarray:
             - 0.1260 * x
             - 0.3516 * x**2
             + 0.2843 * x**3
-            - 0.1015 * x**4
+            - 0.1036 * x**4
         )
     )
     upper = np.column_stack([x, yt])

--- a/examples/mmg2d/triangulate_outline.py
+++ b/examples/mmg2d/triangulate_outline.py
@@ -1,0 +1,107 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "mmgpy",
+#     "matplotlib",
+#     "numpy",
+# ]
+#
+# [tool.uv.sources]
+# mmgpy = { path = "../.." }
+# ///
+
+"""Triangulate a 2D domain from its boundary outline.
+
+When MMG2D is given a vertex+edge input with no triangles it switches to its
+mesh-generation path and produces a Delaunay triangulation that conforms to
+the supplied edges. ``mmgpy.mmg2d.generate`` exposes that path so a closed
+polygon (here a NACA-like airfoil contour) can be triangulated without going
+through a ``.mesh`` file or a temporary triangulation.
+
+Run::
+
+    uv run examples/mmg2d/triangulate_outline.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.tri import Triangulation
+
+from mmgpy import mmg2d
+
+
+def naca_airfoil(n: int = 80, thickness: float = 0.12) -> np.ndarray:
+    """Sample points along a NACA 4-digit symmetric airfoil contour."""
+    beta = np.linspace(0.0, np.pi, n // 2 + 1)
+    x = 0.5 * (1.0 - np.cos(beta))
+    yt = (
+        5.0
+        * thickness
+        * (
+            0.2969 * np.sqrt(x)
+            - 0.1260 * x
+            - 0.3516 * x**2
+            + 0.2843 * x**3
+            - 0.1015 * x**4
+        )
+    )
+    upper = np.column_stack([x, yt])
+    lower = np.column_stack([x[-2:0:-1], -yt[-2:0:-1]])
+    return np.vstack([upper, lower])
+
+
+def closed_polygon_edges(n_points: int) -> np.ndarray:
+    """Return the (n, 2) edge connectivity for a closed polygon."""
+    idx = np.arange(n_points, dtype=np.int32)
+    return np.column_stack([idx, np.roll(idx, -1)])
+
+
+def main() -> None:
+    """Triangulate a NACA airfoil contour and plot the result."""
+    contour = naca_airfoil(n=80)
+    edges = closed_polygon_edges(len(contour))
+
+    mesh = mmg2d.generate(contour, edges, hmax=0.05, hgrad=1.3, verbose=-1)
+    points = np.asarray(mesh.points[:, :2])
+    triangles = np.asarray(mesh.regular_faces)
+
+    print(f"input  : {len(contour)} boundary vertices, {len(edges)} edges")
+    print(f"output : {mesh.n_points} vertices, {len(triangles)} triangles")
+
+    fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+
+    axes[0].plot(
+        np.append(contour[:, 0], contour[0, 0]),
+        np.append(contour[:, 1], contour[0, 1]),
+        "k-",
+        linewidth=1.0,
+    )
+    axes[0].fill(contour[:, 0], contour[:, 1], color="0.85")
+    axes[0].set_title(f"Input outline ({len(contour)} pts)")
+    axes[0].set_aspect("equal")
+
+    tri = Triangulation(points[:, 0], points[:, 1], triangles)
+    axes[1].triplot(tri, "C0-", linewidth=0.4)
+    axes[1].set_title(f"Triangulation ({len(triangles)} tris)")
+    axes[1].set_aspect("equal")
+
+    for ax in axes:
+        ax.set_xlim(-0.05, 1.05)
+        ax.set_ylim(-0.2, 0.2)
+        ax.set_xticks([0, 0.5, 1])
+        ax.set_yticks([-0.1, 0, 0.1])
+
+    fig.suptitle("mmg2d.generate: triangulating a NACA airfoil outline")
+    fig.tight_layout()
+
+    out = Path(__file__).with_suffix(".png")
+    fig.savefig(out, dpi=150, bbox_inches="tight", facecolor="white")
+    print(f"figure saved to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mmgpy/_generate.py
+++ b/src/mmgpy/_generate.py
@@ -1,0 +1,129 @@
+"""mmg2d mesh generation from boundary edges.
+
+The C entry point ``MMG2D_mmg2dmesh`` triangulates a vertex+edge input when
+no triangles are supplied (see ``src/bindings/mmg_mesh_2d.cpp`` near the
+``"mesh generation from edges"`` branch). This module exposes that mode as
+a documented Python API.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from mmgpy._mmgpy import MmgMesh2D
+from mmgpy._pyvista import to_pyvista
+
+if TYPE_CHECKING:
+    import pyvista as pv
+    from numpy.typing import ArrayLike
+
+
+_DIMS_2D = 2
+_EDGE_VERTS = 2
+
+
+def generate(  # noqa: PLR0913  -- the standard MMG sizing knobs are explicit by design
+    boundary_vertices: ArrayLike,
+    boundary_edges: ArrayLike,
+    *,
+    refs: ArrayLike | None = None,
+    hmin: float | None = None,
+    hmax: float | None = None,
+    hausd: float | None = None,
+    hgrad: float | None = None,
+    **opts: Any,  # noqa: ANN401  -- forwarded to MmgMesh2D.remesh
+) -> pv.PolyData:
+    """Triangulate a 2D domain from its boundary edges.
+
+    When MMG2D is fed a vertex+edge input with no triangles, it switches to
+    its mesh-generation path (``MMG2D_mmg2dmesh``) and produces a Delaunay
+    triangulation that conforms to the supplied edges. ``generate`` exposes
+    that path directly so callers can build a 2D mesh from a polygon outline
+    without going through a ``.mesh`` file.
+
+    Parameters
+    ----------
+    boundary_vertices : array_like, shape ``(n, 2)``
+        Vertex coordinates in the plane.
+    boundary_edges : array_like, shape ``(m, 2)``
+        Edge connectivity (zero-indexed) into ``boundary_vertices``.
+    refs : array_like, shape ``(m,)``, optional
+        Per-edge reference markers. Useful for tagging different boundary
+        segments so they can be distinguished in the output via
+        ``cell_data["refs"]``.
+    hmin, hmax, hausd, hgrad : float, optional
+        Standard MMG sizing knobs. ``hmax`` is the most useful here as it
+        caps element size; without it MMG falls back to its default.
+    **opts : Any
+        Additional MMG options forwarded to the C++ remesh call (e.g.
+        ``verbose=-1``, ``hsiz=0.05``).
+
+    Returns
+    -------
+    pv.PolyData
+        Triangulated 2D mesh embedded at ``z=0``. Boundary edges are kept
+        as ``LINE`` cells with their references in ``cell_data["refs"]``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mmgpy import mmg2d
+    >>> verts = np.array(
+    ...     [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+    ... )
+    >>> edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]])
+    >>> mesh = mmg2d.generate(verts, edges, hmax=0.2)
+    >>> mesh.n_cells > 0
+    True
+
+    """
+    verts = np.ascontiguousarray(np.asarray(boundary_vertices, dtype=np.float64))
+    if verts.ndim != _DIMS_2D or verts.shape[1] != _DIMS_2D:
+        msg = f"boundary_vertices must have shape (n, 2); got {verts.shape}"
+        raise ValueError(msg)
+
+    edges = np.ascontiguousarray(np.asarray(boundary_edges, dtype=np.int32))
+    if edges.ndim != _DIMS_2D or edges.shape[1] != _EDGE_VERTS:
+        msg = f"boundary_edges must have shape (m, 2); got {edges.shape}"
+        raise ValueError(msg)
+    if len(edges) == 0:
+        msg = "boundary_edges must contain at least one edge"
+        raise ValueError(msg)
+
+    edge_refs = None
+    if refs is not None:
+        edge_refs = np.ascontiguousarray(np.asarray(refs, dtype=np.int64))
+        if edge_refs.shape != (len(edges),):
+            msg = (
+                f"refs must have shape ({len(edges)},) matching boundary_edges; "
+                f"got {edge_refs.shape}"
+            )
+            raise ValueError(msg)
+
+    mesh = MmgMesh2D()
+    mesh.set_mesh_size(
+        vertices=len(verts),
+        triangles=0,
+        quadrilaterals=0,
+        edges=len(edges),
+    )
+    mesh.set_vertices(verts)
+    mesh.set_edges(edges, edge_refs)
+
+    options: dict[str, Any] = dict(opts)
+    for name, value in (
+        ("hmin", hmin),
+        ("hmax", hmax),
+        ("hausd", hausd),
+        ("hgrad", hgrad),
+    ):
+        if value is not None:
+            options.setdefault(name, value)
+
+    mesh.remesh(**options)
+    return to_pyvista(mesh, include_refs=True, include_edges=True)
+
+
+__all__ = ["generate"]

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -29,6 +29,7 @@ import pyvista as pv
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from typing import TypeGuard
 
     import numpy as np
     from numpy.typing import NDArray
@@ -117,6 +118,49 @@ def _attach_sol_fields(
 
 _LOCAL_SIZING_SHAPES = ("sphere", "box", "cylinder", "from_point")
 _MMG_FIELD_NAMES = ("metric", "displacement", "levelset", "tensor")
+
+
+def _is_line_only_polydata(
+    dataset: pv.UnstructuredGrid | pv.PolyData,
+) -> TypeGuard[pv.PolyData]:
+    """Return True if *dataset* is a PolyData carrying only LINE cells.
+
+    Used by the ``.mmg.remesh`` accessor to detect inputs that should go
+    through the mmg2d edge-triangulation path
+    (:func:`mmgpy.mmg2d.generate`) instead of the standard remesh pipeline.
+    """
+    if not isinstance(dataset, pv.PolyData):
+        return False
+    n_lines = int(dataset.n_lines)
+    if n_lines == 0:
+        return False
+    n_polys = (
+        int(dataset.n_cells) - int(dataset.n_verts) - n_lines - int(dataset.n_strips)
+    )
+    return n_polys == 0
+
+
+def _generate_from_line_polydata(
+    dataset: pv.PolyData,
+    options: dict[str, Any],
+) -> pv.PolyData:
+    """Run :func:`mmgpy.mmg2d.generate` on a line-only PolyData."""
+    import numpy as np  # noqa: PLC0415
+
+    from mmgpy._generate import generate  # noqa: PLC0415
+    from mmgpy._pyvista import (  # noqa: PLC0415
+        _extract_lines_from_polydata,
+        _refs_for_polydata_lines,
+    )
+
+    edges = _extract_lines_from_polydata(dataset)
+    if edges is None:
+        msg = "PolyData has line cells but no extractable LINE pairs"
+        raise ValueError(msg)
+    refs = _refs_for_polydata_lines(dataset, len(edges))
+    points = np.asarray(dataset.points, dtype=np.float64)
+    vertices = points[:, :2]
+    return generate(vertices, edges, refs=refs, **options)
 
 
 def _build_mesh_with_mmg_fields(dataset: pv.UnstructuredGrid | pv.PolyData) -> _Mesh:
@@ -565,6 +609,22 @@ class MmgAccessor:
             cells.
 
         """
+        if isinstance(self._dataset, pv.PolyData) and _is_line_only_polydata(
+            self._dataset,
+        ):
+            if opts is not None:
+                if options:
+                    msg = "pass either an options object or kwargs, not both"
+                    raise TypeError(msg)
+                options = dict(opts.to_dict())
+            if local_sizing:
+                msg = (
+                    "local_sizing is not supported when generating a 2D mesh "
+                    "from a line-only PolyData"
+                )
+                raise ValueError(msg)
+            return _generate_from_line_polydata(self._dataset, options)
+
         constraints = _split_constraint_kwargs(options)
         mesh = _build_mesh_with_mmg_fields(self._dataset)
         _apply_constraint_markers(mesh, self._dataset, constraints)

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -159,6 +159,14 @@ def _generate_from_line_polydata(
         raise ValueError(msg)
     refs = _refs_for_polydata_lines(dataset, len(edges))
     points = np.asarray(dataset.points, dtype=np.float64)
+    z_span = float(np.ptp(points[:, 2]))
+    xy_span = float(np.ptp(points[:, :2]))
+    if z_span > max(1e-9, 1e-6 * xy_span):
+        msg = (
+            "mmg2d.generate routing requires a planar (z=const) PolyData; "
+            f"got z range {z_span:.3g} over xy span {xy_span:.3g}"
+        )
+        raise ValueError(msg)
     vertices = points[:, :2]
     return generate(vertices, edges, refs=refs, **options)
 
@@ -607,6 +615,13 @@ class MmgAccessor:
             2D and surface results as ``PolyData``. Element references
             survive in ``cell_data["refs"]`` and MMG edges in ``LINE``
             cells.
+
+        Notes
+        -----
+        If the dataset is a ``PolyData`` carrying only ``LINE`` cells,
+        ``remesh()`` is auto-routed through :func:`mmgpy.mmg2d.generate`
+        to triangulate the outline. The dataset must be planar
+        (constant ``z``); ``local_sizing`` is not supported on this path.
 
         """
         if isinstance(self._dataset, pv.PolyData) and _is_line_only_polydata(

--- a/src/mmgpy/_remesh.py
+++ b/src/mmgpy/_remesh.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mmgpy._generate import generate as _generate_2d
 from mmgpy._mmgpy import mmg2d as _mmg2d_cpp
 from mmgpy._mmgpy import mmg3d as _mmg3d_cpp
 from mmgpy._mmgpy import mmgs as _mmgs_cpp
@@ -182,6 +183,8 @@ class mmg3d:
 
 class mmg2d:
     """2D mesh remeshing."""
+
+    generate = staticmethod(_generate_2d)
 
     @staticmethod
     def remesh(

--- a/tests/mmg2d_test.py
+++ b/tests/mmg2d_test.py
@@ -393,3 +393,119 @@ def test_mesh_topology_consistency(
     assert all(ct > 0 for ct in ref_cell_types), (
         f"Reference mesh has invalid cell type values: {ref_cell_types}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Mesh generation from boundary edges (mmg2d.generate)
+# ---------------------------------------------------------------------------
+
+
+def _unit_square_outline() -> tuple[np.ndarray, np.ndarray]:
+    verts = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+        dtype=np.float64,
+    )
+    edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
+    return verts, edges
+
+
+def test_generate_unit_square() -> None:
+    """generate() produces a non-empty triangulation of the unit square."""
+    verts, edges = _unit_square_outline()
+    mesh = mmg2d.generate(verts, edges, hmax=0.2, verbose=-1)
+
+    assert isinstance(mesh, pv.PolyData)
+    assert mesh.n_points >= len(verts)
+    assert mesh.n_faces > 0
+    triangles = np.asarray(mesh.regular_faces)
+    assert triangles.shape[1] == 3
+    assert mesh.area == pytest.approx(1.0, rel=0.01)
+
+
+def test_generate_preserves_boundary_edges() -> None:
+    """All input boundary edges are present in the output as LINE cells."""
+    verts, edges = _unit_square_outline()
+    mesh = mmg2d.generate(verts, edges, hmax=0.5, verbose=-1)
+
+    assert mesh.n_lines >= len(edges)
+    points_2d = np.asarray(mesh.points[:, :2])
+
+    def edge_endpoints(line_pair: np.ndarray) -> set[tuple[float, float]]:
+        return {
+            tuple(np.round(points_2d[line_pair[0]], 8)),
+            tuple(np.round(points_2d[line_pair[1]], 8)),
+        }
+
+    raw_lines = np.asarray(mesh.lines).reshape(-1, 3)
+    line_pairs = raw_lines[:, 1:]
+    line_segments = [edge_endpoints(p) for p in line_pairs]
+
+    for v0, v1 in edges:
+        seg = {
+            tuple(np.round(verts[v0], 8)),
+            tuple(np.round(verts[v1], 8)),
+        }
+        # Each input edge endpoint pair should be the boundary of at least
+        # one output LINE cell (output edges may subdivide, so we only
+        # require both input vertices to appear among the boundary nodes).
+        endpoints = {pt for seg_pts in line_segments for pt in seg_pts}
+        assert seg.issubset(endpoints), f"input edge {(v0, v1)} not on boundary"
+
+
+def test_generate_with_refs() -> None:
+    """Per-edge refs survive into cell_data['refs']."""
+    verts, edges = _unit_square_outline()
+    refs = np.array([1, 2, 3, 4], dtype=np.int64)
+    mesh = mmg2d.generate(verts, edges, refs=refs, hmax=0.5, verbose=-1)
+
+    assert "refs" in mesh.cell_data
+    cell_refs = np.asarray(mesh.cell_data["refs"])
+    line_refs = cell_refs[: mesh.n_lines]
+    assert set(np.unique(line_refs)).issubset({1, 2, 3, 4})
+
+
+def test_generate_input_validation() -> None:
+    """Bad inputs raise ValueError with informative messages."""
+    verts, edges = _unit_square_outline()
+    with pytest.raises(ValueError, match="boundary_vertices"):
+        mmg2d.generate(verts.reshape(-1), edges, verbose=-1)
+    with pytest.raises(ValueError, match="boundary_edges"):
+        mmg2d.generate(verts, edges.reshape(-1), verbose=-1)
+    with pytest.raises(ValueError, match="at least one edge"):
+        mmg2d.generate(verts, np.empty((0, 2), dtype=np.int32), verbose=-1)
+    with pytest.raises(ValueError, match="refs must have shape"):
+        mmg2d.generate(verts, edges, refs=np.array([1, 2]), verbose=-1)
+
+
+def test_accessor_routes_line_only_polydata() -> None:
+    """A line-only PolyData routed through .mmg.remesh() triggers generate()."""
+    verts, edges = _unit_square_outline()
+    verts_3d = np.column_stack([verts, np.zeros(len(verts))])
+    lines = np.column_stack(
+        [np.full(len(edges), 2, dtype=np.int32), edges],
+    ).ravel()
+    poly = pv.PolyData(verts_3d, lines=lines)
+
+    assert poly.n_lines == len(edges)
+    assert poly.n_faces == 0
+
+    out = poly.mmg.remesh(hmax=0.2, verbose=-1)
+    assert isinstance(out, pv.PolyData)
+    assert out.n_faces > 0
+    assert out.area == pytest.approx(1.0, rel=0.01)
+
+
+def test_accessor_mixed_polydata_uses_remesh() -> None:
+    """A PolyData with triangles still goes through the regular remesh path."""
+    verts, _ = _unit_square_outline()
+    verts_3d = np.column_stack([verts, np.zeros(len(verts))])
+    triangles = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+    faces = np.column_stack(
+        [np.full(len(triangles), 3, dtype=np.int32), triangles],
+    ).ravel()
+    poly = pv.PolyData(verts_3d, faces=faces)
+
+    assert poly.n_lines == 0
+    out = poly.mmg.remesh(hmax=0.3, verbose=-1)
+    assert isinstance(out, pv.PolyData)
+    assert out.n_faces > 0

--- a/tests/mmg2d_test.py
+++ b/tests/mmg2d_test.py
@@ -416,7 +416,7 @@ def test_generate_unit_square() -> None:
 
     assert isinstance(mesh, pv.PolyData)
     assert mesh.n_points >= len(verts)
-    assert mesh.n_faces > 0
+    assert (mesh.n_cells - mesh.n_lines) > 0
     triangles = np.asarray(mesh.regular_faces)
     assert triangles.shape[1] == 3
     assert mesh.area == pytest.approx(1.0, rel=0.01)
@@ -461,7 +461,7 @@ def test_generate_with_refs() -> None:
     assert "refs" in mesh.cell_data
     cell_refs = np.asarray(mesh.cell_data["refs"])
     line_refs = cell_refs[: mesh.n_lines]
-    assert set(np.unique(line_refs)).issubset({1, 2, 3, 4})
+    assert set(np.unique(line_refs)) == {1, 2, 3, 4}
 
 
 def test_generate_input_validation() -> None:
@@ -487,11 +487,11 @@ def test_accessor_routes_line_only_polydata() -> None:
     poly = pv.PolyData(verts_3d, lines=lines)
 
     assert poly.n_lines == len(edges)
-    assert poly.n_faces == 0
+    assert (poly.n_cells - poly.n_lines) == 0
 
     out = poly.mmg.remesh(hmax=0.2, verbose=-1)
     assert isinstance(out, pv.PolyData)
-    assert out.n_faces > 0
+    assert (out.n_cells - out.n_lines) > 0
     assert out.area == pytest.approx(1.0, rel=0.01)
 
 
@@ -508,4 +508,4 @@ def test_accessor_mixed_polydata_uses_remesh() -> None:
     assert poly.n_lines == 0
     out = poly.mmg.remesh(hmax=0.3, verbose=-1)
     assert isinstance(out, pv.PolyData)
-    assert out.n_faces > 0
+    assert (out.n_cells - out.n_lines) > 0


### PR DESCRIPTION
## Summary

Surfaces MMG2D's existing edge-only generation path as a documented Python API. Closes gap #07 from the audit.

## Changes

- `mmgpy.mmg2d.generate(boundary_vertices, boundary_edges, *, refs=None, hmin, hmax, hausd, hgrad, **opts)` triangulates a 2D domain from a vertex+edge outline via `MMG2D_mmg2dmesh`
- `.mmg.remesh()` accessor auto-routes line-only `pv.PolyData` to the same path
- Example `examples/mmg2d/triangulate_outline.py` (NACA airfoil contour)
- Tests in `tests/mmg2d_test.py` covering generation, refs, validation, and accessor routing
- Docs and changelog entry