### PR TITLE
auto-route VTK :metric/:ls point_data arrays into mesh solutions

### DIFF
--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -54,21 +54,14 @@ _LINE_VERTS = 2
 
 # Substring hints used by MMG's VTK reader to auto-route point_data arrays
 # into solution slots. See mmg-src/src/common/vtkparser.cpp (strstr matches
-# on `:metric` and `:ls`). First key matching a hint wins; users can still
-# override by assigning `mmg_mesh["metric"] = ...` after `from_pyvista`.
-_METRIC_HINTS = (":metric",)
-_LS_HINTS = (":ls",)
-
-
-def _find_solution_array(
-    point_data: Any,  # noqa: ANN401 - pyvista.DataSetAttributes is not a Mapping
-    hints: tuple[str, ...],
-) -> tuple[str, NDArray[np.float64]] | None:
-    """Return the first ``(key, array)`` whose key contains any hint."""
-    for key in point_data:
-        if any(hint in key for hint in hints):
-            return key, np.asarray(point_data[key], dtype=np.float64)
-    return None
+# on `:metric` and `:ls`). Substrings are intentionally narrow to mirror
+# upstream; widening them would diverge from MMG's behaviour. First key
+# matching a hint wins; users can still override by assigning
+# `mmg_mesh["metric"] = ...` after `from_pyvista`.
+_SOLUTION_HINTS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("metric", (":metric",)),
+    ("levelset", (":ls",)),
+)
 
 
 def _apply_solution_aliases(
@@ -83,15 +76,20 @@ def _apply_solution_aliases(
     """
     if not point_data:
         return
-    for slot, hints in (("metric", _METRIC_HINTS), ("levelset", _LS_HINTS)):
-        found = _find_solution_array(point_data, hints)
-        if found is None:
-            continue
-        key, arr = found
-        if arr.ndim == 1:
-            arr = arr.reshape(-1, 1)
+    matches: dict[str, tuple[str, NDArray[np.float64]]] = {}
+    for key in point_data:
+        for slot, hints in _SOLUTION_HINTS:
+            if slot in matches:
+                continue
+            if any(hint in key for hint in hints):
+                matches[slot] = (key, np.asarray(point_data[key], dtype=np.float64))
+                break
+        if len(matches) == len(_SOLUTION_HINTS):
+            break
+    for slot, (key, arr) in matches.items():
+        shaped = arr.reshape(-1, 1) if arr.ndim == 1 else arr
         try:
-            mmg_mesh[slot] = arr
+            mmg_mesh[slot] = shaped
         except (RuntimeError, ValueError) as exc:
             logger.warning(
                 "Skipping point_data[%r] for %s slot: %s",
@@ -489,6 +487,10 @@ def _from_pyvista_to_mmg3d(
 def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
     """Convert PolyData with 2D triangles to MmgMesh2D."""
     edges, edge_refs = _extract_edges(mesh)
+    # Capture point_data before triangulation: PyVista's triangulate() can
+    # reset attached arrays. If triangulation adds points (rare for n-gons),
+    # row counts may mismatch the final mesh — _apply_solution_aliases will
+    # log and skip rather than crash.
     source_point_data = mesh.point_data
 
     mesh, was_triangulated = _triangulate_if_needed(mesh)
@@ -529,6 +531,7 @@ def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
 def _from_pyvista_to_mmgs(mesh: pv.PolyData) -> MmgMeshS:
     """Convert PolyData with 3D surface triangles to MmgMeshS."""
     edges, edge_refs = _extract_edges(mesh)
+    # See _from_pyvista_to_mmg2d for why we snapshot point_data pre-triangulate.
     source_point_data = mesh.point_data
 
     mesh, was_triangulated = _triangulate_if_needed(mesh)

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -52,6 +52,54 @@ _TRIANGULATION_WARNING = (
 _REF_FIELDS = ("refs", "gmsh:physical", "medit:ref")
 _LINE_VERTS = 2
 
+# Substring hints used by MMG's VTK reader to auto-route point_data arrays
+# into solution slots. See mmg-src/src/common/vtkparser.cpp (strstr matches
+# on `:metric` and `:ls`). First key matching a hint wins; users can still
+# override by assigning `mmg_mesh["metric"] = ...` after `from_pyvista`.
+_METRIC_HINTS = (":metric",)
+_LS_HINTS = (":ls",)
+
+
+def _find_solution_array(
+    point_data: Any,  # noqa: ANN401 - pyvista.DataSetAttributes is not a Mapping
+    hints: tuple[str, ...],
+) -> tuple[str, NDArray[np.float64]] | None:
+    """Return the first ``(key, array)`` whose key contains any hint."""
+    for key in point_data:
+        if any(hint in key for hint in hints):
+            return key, np.asarray(point_data[key], dtype=np.float64)
+    return None
+
+
+def _apply_solution_aliases(
+    mmg_mesh: MmgMesh3D | MmgMesh2D | MmgMeshS,
+    point_data: Any,  # noqa: ANN401 - pyvista.DataSetAttributes is not a Mapping
+) -> None:
+    """Auto-populate ``metric`` / ``levelset`` from VTK-style array names.
+
+    Mirrors MMG's own VTK reader: any ``point_data`` key containing
+    ``":metric"`` or ``":ls"`` is forwarded to the matching solution slot.
+    On multiple matches, the first key wins (insertion order).
+    """
+    if not point_data:
+        return
+    for slot, hints in (("metric", _METRIC_HINTS), ("levelset", _LS_HINTS)):
+        found = _find_solution_array(point_data, hints)
+        if found is None:
+            continue
+        key, arr = found
+        if arr.ndim == 1:
+            arr = arr.reshape(-1, 1)
+        try:
+            mmg_mesh[slot] = arr
+        except (RuntimeError, ValueError) as exc:
+            logger.warning(
+                "Skipping point_data[%r] for %s slot: %s",
+                key,
+                slot,
+                exc,
+            )
+
 
 def _all_faces_are_triangles(mesh: pv.PolyData) -> bool:
     """Return True if every polygonal face in the mesh has 3 vertices."""
@@ -433,12 +481,15 @@ def _from_pyvista_to_mmg3d(
     if triangles is not None:
         mmg_mesh.set_triangles(triangles, tri_refs)
 
+    _apply_solution_aliases(mmg_mesh, mesh.point_data)
+
     return mmg_mesh
 
 
 def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
     """Convert PolyData with 2D triangles to MmgMesh2D."""
     edges, edge_refs = _extract_edges(mesh)
+    source_point_data = mesh.point_data
 
     mesh, was_triangulated = _triangulate_if_needed(mesh)
     if was_triangulated:
@@ -470,12 +521,15 @@ def _from_pyvista_to_mmg2d(mesh: pv.PolyData) -> MmgMesh2D:
     if edges is not None:
         mmg_mesh.set_edges(edges, edge_refs)
 
+    _apply_solution_aliases(mmg_mesh, source_point_data)
+
     return mmg_mesh
 
 
 def _from_pyvista_to_mmgs(mesh: pv.PolyData) -> MmgMeshS:
     """Convert PolyData with 3D surface triangles to MmgMeshS."""
     edges, edge_refs = _extract_edges(mesh)
+    source_point_data = mesh.point_data
 
     mesh, was_triangulated = _triangulate_if_needed(mesh)
     if was_triangulated:
@@ -502,6 +556,8 @@ def _from_pyvista_to_mmgs(mesh: pv.PolyData) -> MmgMeshS:
 
     if edges is not None:
         mmg_mesh.set_edges(edges, edge_refs)
+
+    _apply_solution_aliases(mmg_mesh, source_point_data)
 
     return mmg_mesh
 

--- a/tests/vtk_alias_test.py
+++ b/tests/vtk_alias_test.py
@@ -1,0 +1,252 @@
+"""Auto-detect VTK / VTU solution arrays (``:metric``, ``:ls``) on import.
+
+MMG's VTK reader uses substring matching on point_data names to populate
+solution slots (see ``mmg-src/src/common/vtkparser.cpp``). ``from_pyvista``
+mirrors that behaviour so a ``.vtu`` produced by stand-alone MMG can be
+round-tripped through PyVista without manually re-assigning fields.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+from mmgpy import from_pyvista
+from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
+
+
+@pytest.fixture
+def tetra_grid() -> pv.UnstructuredGrid:
+    """Two-tetra UnstructuredGrid for 3D conversion tests."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+            [0.5, 0.5, 1.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.5, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    cells = np.array([[0, 1, 2, 3], [1, 4, 2, 5]], dtype=np.int32)
+    return pv.UnstructuredGrid({pv.CellType.TETRA: cells}, vertices)
+
+
+@pytest.fixture
+def triangle_polydata_2d() -> pv.PolyData:
+    """Planar PolyData (z=0) for MmgMesh2D conversion tests."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    faces = np.array([3, 0, 1, 2, 3, 0, 2, 3])
+    return pv.PolyData(vertices, faces=faces)
+
+
+@pytest.fixture
+def triangle_polydata_3d() -> pv.PolyData:
+    """Non-planar PolyData for MmgMeshS conversion tests."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+            [0.5, 0.5, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    faces = np.array([3, 0, 1, 2, 3, 0, 1, 3, 3, 1, 2, 3, 3, 0, 2, 3])
+    return pv.PolyData(vertices, faces=faces)
+
+
+class TestMetricAlias:
+    """``point_data[*:metric]`` should populate ``mesh["metric"]``."""
+
+    def test_unstructured_grid_metric(self, tetra_grid: pv.UnstructuredGrid) -> None:
+        """``sol:metric`` on an UnstructuredGrid routes to ``mesh["metric"]``."""
+        sizes = np.linspace(0.1, 0.4, tetra_grid.n_points)
+        tetra_grid.point_data["sol:metric"] = sizes
+
+        mesh = from_pyvista(tetra_grid)
+
+        assert isinstance(mesh, MmgMesh3D)
+        np.testing.assert_array_almost_equal(
+            mesh["metric"].reshape(-1),
+            sizes,
+        )
+
+    def test_polydata_2d_metric(
+        self,
+        triangle_polydata_2d: pv.PolyData,
+    ) -> None:
+        """Hint matching works for 2D PolyData inputs."""
+        sizes = np.linspace(0.05, 0.2, triangle_polydata_2d.n_points)
+        triangle_polydata_2d.point_data["mymesh:metric"] = sizes
+
+        mesh = from_pyvista(triangle_polydata_2d)
+
+        assert isinstance(mesh, MmgMesh2D)
+        np.testing.assert_array_almost_equal(
+            mesh["metric"].reshape(-1),
+            sizes,
+        )
+
+    def test_polydata_3d_metric(
+        self,
+        triangle_polydata_3d: pv.PolyData,
+    ) -> None:
+        """Hint matching works for surface PolyData inputs."""
+        sizes = np.full(triangle_polydata_3d.n_points, 0.1)
+        triangle_polydata_3d.point_data["foo:metric:0"] = sizes
+
+        mesh = from_pyvista(triangle_polydata_3d)
+
+        assert isinstance(mesh, MmgMeshS)
+        np.testing.assert_array_almost_equal(
+            mesh["metric"].reshape(-1),
+            sizes,
+        )
+
+
+class TestLevelsetAlias:
+    """``point_data[*:ls]`` should populate ``mesh["levelset"]``."""
+
+    def test_unstructured_grid_levelset(
+        self,
+        tetra_grid: pv.UnstructuredGrid,
+    ) -> None:
+        """``foo:ls`` routes to ``mesh["levelset"]``."""
+        values = np.linspace(-1.0, 1.0, tetra_grid.n_points)
+        tetra_grid.point_data["foo:ls"] = values
+
+        mesh = from_pyvista(tetra_grid)
+
+        np.testing.assert_array_almost_equal(
+            mesh["levelset"].reshape(-1),
+            values,
+        )
+
+    def test_polydata_2d_levelset(
+        self,
+        triangle_polydata_2d: pv.PolyData,
+    ) -> None:
+        """Hint matching populates levelset on a 2D PolyData."""
+        values = np.array([-0.5, 0.5, 0.5, -0.5], dtype=np.float64)
+        triangle_polydata_2d.point_data["sol:ls"] = values
+
+        mesh = from_pyvista(triangle_polydata_2d)
+
+        np.testing.assert_array_almost_equal(
+            mesh["levelset"].reshape(-1),
+            values,
+        )
+
+
+class TestMultipleHints:
+    """Both metric and levelset coexist; first match wins on duplicates."""
+
+    def test_metric_and_levelset_together(
+        self,
+        tetra_grid: pv.UnstructuredGrid,
+    ) -> None:
+        """Both slots populate independently when both hints are present."""
+        metric = np.full(tetra_grid.n_points, 0.2)
+        ls = np.linspace(-1.0, 1.0, tetra_grid.n_points)
+        tetra_grid.point_data["sol:metric"] = metric
+        tetra_grid.point_data["sol:ls"] = ls
+
+        mesh = from_pyvista(tetra_grid)
+
+        np.testing.assert_array_almost_equal(mesh["metric"].reshape(-1), metric)
+        np.testing.assert_array_almost_equal(mesh["levelset"].reshape(-1), ls)
+
+    def test_first_metric_match_wins(
+        self,
+        tetra_grid: pv.UnstructuredGrid,
+    ) -> None:
+        """When multiple arrays match a hint, the first key wins."""
+        first = np.full(tetra_grid.n_points, 0.1)
+        second = np.full(tetra_grid.n_points, 0.5)
+        tetra_grid.point_data["a:metric"] = first
+        tetra_grid.point_data["b:metric"] = second
+
+        mesh = from_pyvista(tetra_grid)
+
+        np.testing.assert_array_almost_equal(mesh["metric"].reshape(-1), first)
+
+
+class TestExplicitOverride:
+    """Caller can still override the auto-populated slot after conversion."""
+
+    def test_explicit_metric_after_conversion(
+        self,
+        tetra_grid: pv.UnstructuredGrid,
+    ) -> None:
+        """An explicit assignment overrides the auto-populated value."""
+        auto = np.full(tetra_grid.n_points, 0.2)
+        explicit = np.full(tetra_grid.n_points, 0.05)
+        tetra_grid.point_data["sol:metric"] = auto
+
+        mesh = from_pyvista(tetra_grid)
+        mesh["metric"] = explicit.reshape(-1, 1)
+
+        np.testing.assert_array_almost_equal(
+            mesh["metric"].reshape(-1),
+            explicit,
+        )
+
+
+class TestNoMatch:
+    """Arrays whose names do not contain ``:metric`` or ``:ls`` are ignored."""
+
+    def test_ref_field_does_not_match(
+        self,
+        tetra_grid: pv.UnstructuredGrid,
+    ) -> None:
+        """``medit:ref`` does not contain ``:metric`` or ``:ls`` and is ignored."""
+        sentinel = np.arange(tetra_grid.n_points, dtype=np.float64)
+        tetra_grid.point_data["medit:ref"] = sentinel
+
+        mesh = from_pyvista(tetra_grid)
+        explicit = np.full(tetra_grid.n_points, 0.3)
+        mesh["metric"] = explicit.reshape(-1, 1)
+
+        np.testing.assert_array_almost_equal(
+            mesh["metric"].reshape(-1),
+            explicit,
+        )
+
+    def test_no_point_data(self, tetra_grid: pv.UnstructuredGrid) -> None:
+        """Conversion with empty point_data does not raise."""
+        from_pyvista(tetra_grid)
+
+
+class TestSizeMismatch:
+    """Bad-shape point_data is skipped with a warning, not a hard error."""
+
+    def test_wrong_length_emits_warning(
+        self,
+        tetra_grid: pv.UnstructuredGrid,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A mismatched-length point_data array is logged and skipped."""
+        bogus = np.zeros(tetra_grid.n_points + 5)
+        # PyVista refuses to attach mismatched-length point_data, so we hit
+        # the runtime path by attaching it as field_data and aliasing — skip
+        # if pyvista enforces the length here.
+        try:
+            tetra_grid.point_data["sol:metric"] = bogus
+        except (ValueError, RuntimeError):
+            pytest.skip("pyvista rejected mismatched point_data length")
+
+        with caplog.at_level(logging.WARNING, logger="mmgpy"):
+            from_pyvista(tetra_grid)

--- a/tests/vtk_alias_test.py
+++ b/tests/vtk_alias_test.py
@@ -233,20 +233,21 @@ class TestNoMatch:
 class TestSizeMismatch:
     """Bad-shape point_data is skipped with a warning, not a hard error."""
 
-    def test_wrong_length_emits_warning(
+    def test_wrong_inner_dim_emits_warning(
         self,
         tetra_grid: pv.UnstructuredGrid,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A mismatched-length point_data array is logged and skipped."""
-        bogus = np.zeros(tetra_grid.n_points + 5)
-        # PyVista refuses to attach mismatched-length point_data, so we hit
-        # the runtime path by attaching it as field_data and aliasing — skip
-        # if pyvista enforces the length here.
-        try:
-            tetra_grid.point_data["sol:metric"] = bogus
-        except (ValueError, RuntimeError):
-            pytest.skip("pyvista rejected mismatched point_data length")
+        """An (N, k) array with unsupported ``k`` is logged and skipped."""
+        # MmgMesh3D["metric"] accepts (N, 1) or (N, 6); (N, 7) is rejected by
+        # the C++ setter, which is exactly the runtime path we want to cover.
+        bogus = np.zeros((tetra_grid.n_points, 7), dtype=np.float64)
+        tetra_grid.point_data["sol:metric"] = bogus
 
         with caplog.at_level(logging.WARNING, logger="mmgpy"):
-            from_pyvista(tetra_grid)
+            mesh = from_pyvista(tetra_grid)
+
+        assert "sol:metric" in caplog.text
+        assert "metric" in caplog.text
+        # Slot remained at its default (N, 1) instead of being overwritten.
+        assert mesh["metric"].shape == (tetra_grid.n_points, 1)


### PR DESCRIPTION
## Summary

- mirrors MMG's VTK reader: scans `point_data` for keys containing `:metric` / `:ls`
- routes matches into `mesh["metric"]` / `mesh["levelset"]` during `from_pyvista`
- first key wins on duplicates; explicit post-conversion assignment overrides

## Changes

- `src/mmgpy/_pyvista.py`: `_METRIC_HINTS`, `_LS_HINTS`, `_apply_solution_aliases`
- wired into the three `_from_pyvista_to_*` conversion functions
- `tests/vtk_alias_test.py`: 10 regression tests across 3D / 2D / surface

## Notes

- addresses gap #04 from the audit
- `medit:ref` is unchanged (no `:metric` / `:ls` substring)
- size-mismatched arrays are logged and skipped, not raised