### PR TITLE
add Dosol + Clean_isoSurf bindings

### DIFF
--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -222,7 +222,15 @@ PYBIND11_MODULE(_mmgpy, m) {
           "    levelset: Nx1 array of scalar level-set values per vertex.\n"
           "    **kwargs: Remeshing options (hmax, hmin, verbose, etc.).\n"
           "              ls: Isovalue to discretize (default=0.0).\n"
-          "              iso: Enable level-set mode (default=1).");
+          "              iso: Enable level-set mode (default=1).")
+      .def("build_size_map", &MmgMesh::build_size_map,
+           "Build an isotropic size map from the mean edge length passing "
+           "through each vertex (wraps MMG3D_doSol).\n\n"
+           "Populates the mesh metric channel and returns the resulting "
+           "Nx1 array of per-vertex sizes.")
+      .def("clean_iso_surface", &MmgMesh::clean_iso_surface,
+           "Remove isolated triangles / edges left after a level-set "
+           "discretization (wraps MMG3D_Clean_isoSurf).");
 
   // Phase 4: MmgMesh2D class for 2D planar meshes
   py::class_<MmgMesh2D>(m, "MmgMesh2D")
@@ -374,7 +382,12 @@ PYBIND11_MODULE(_mmgpy, m) {
           "    levelset: Nx1 array of scalar level-set values per vertex.\n"
           "    **kwargs: Remeshing options (hmax, hmin, verbose, etc.).\n"
           "              ls: Isovalue to discretize (default=0.0).\n"
-          "              iso: Enable level-set mode (default=1).");
+          "              iso: Enable level-set mode (default=1).")
+      .def("build_size_map", &MmgMesh2D::build_size_map,
+           "Build an isotropic size map from the mean edge length passing "
+           "through each vertex (wraps MMG2D_doSol).\n\n"
+           "Populates the mesh metric channel and returns the resulting "
+           "Nx1 array of per-vertex sizes.");
 
   // Phase 4: MmgMeshS class for surface meshes
   py::class_<MmgMeshS>(m, "MmgMeshS")
@@ -520,7 +533,15 @@ PYBIND11_MODULE(_mmgpy, m) {
           "    levelset: Nx1 array of scalar level-set values per vertex.\n"
           "    **kwargs: Remeshing options (hmax, hmin, verbose, etc.).\n"
           "              ls: Isovalue to discretize (default=0.0).\n"
-          "              iso: Enable level-set mode (default=1).");
+          "              iso: Enable level-set mode (default=1).")
+      .def("build_size_map", &MmgMeshS::build_size_map,
+           "Build an isotropic size map from the mean edge length passing "
+           "through each vertex (wraps MMGS_doSol).\n\n"
+           "Populates the mesh metric channel and returns the resulting "
+           "Nx1 array of per-vertex sizes.")
+      .def("clean_iso_surface", &MmgMeshS::clean_iso_surface,
+           "Remove isolated triangles / edges left after a level-set "
+           "discretization (wraps MMGS_Clean_isoSurf).");
 
   py::class_<mmg3d>(m, "mmg3d")
       .def_static("remesh", remesh_3d, py::arg("input_mesh"),

--- a/src/bindings/mmg_mesh.cpp
+++ b/src/bindings/mmg_mesh.cpp
@@ -1533,3 +1533,40 @@ py::dict MmgMesh::remesh_levelset(const py::array_t<double> &levelset,
 
   return build_remesh_result(before, after, duration, ret, warnings);
 }
+
+py::array_t<double> MmgMesh::build_size_map() {
+  check_not_corrupted("build_size_map");
+
+  // MMG3D_doSol is a function pointer initialized by MMG3D_setfunc. The
+  // selector reads mesh->info.ani and met->size to pick the iso or aniso
+  // implementation.
+  MMG3D_setfunc(mesh, met);
+  if (MMG3D_doSol == nullptr) {
+    throw std::runtime_error(
+        "MMG3D_doSol is null after MMG3D_setfunc; cannot build size map");
+  }
+
+  int ret;
+  {
+    py::gil_scoped_release release;
+    ret = MMG3D_doSol(mesh, met);
+  }
+  if (ret != 1) {
+    throw std::runtime_error("MMG3D_doSol failed to build size map");
+  }
+
+  return get_field("metric");
+}
+
+void MmgMesh::clean_iso_surface() {
+  check_not_corrupted("clean_iso_surface");
+
+  int ret;
+  {
+    py::gil_scoped_release release;
+    ret = MMG3D_Clean_isoSurf(mesh);
+  }
+  if (ret != 1) {
+    throw std::runtime_error("MMG3D_Clean_isoSurf failed");
+  }
+}

--- a/src/bindings/mmg_mesh.hpp
+++ b/src/bindings/mmg_mesh.hpp
@@ -150,6 +150,10 @@ public:
   py::dict remesh_levelset(const py::array_t<double> &levelset,
                            const py::dict &options = py::dict());
 
+  // Sizemap and level-set utilities
+  py::array_t<double> build_size_map();
+  void clean_iso_surface();
+
   bool is_corrupted() const { return corrupted_; }
 
   // Delete copy constructor and assignment operator

--- a/src/bindings/mmg_mesh_2d.cpp
+++ b/src/bindings/mmg_mesh_2d.cpp
@@ -1117,3 +1117,27 @@ py::dict MmgMesh2D::remesh_levelset(const py::array_t<double> &levelset,
 
   return build_remesh_result(before, after, duration, ret, warnings);
 }
+
+py::array_t<double> MmgMesh2D::build_size_map() {
+  check_not_corrupted("build_size_map");
+
+  // MMG2D_doSol is a function pointer initialized by MMG2D_setfunc. The
+  // selector reads mesh->info.ani and met->size to pick the iso or aniso
+  // implementation.
+  MMG2D_setfunc(mesh, met);
+  if (MMG2D_doSol == nullptr) {
+    throw std::runtime_error(
+        "MMG2D_doSol is null after MMG2D_setfunc; cannot build size map");
+  }
+
+  int ret;
+  {
+    py::gil_scoped_release release;
+    ret = MMG2D_doSol(mesh, met);
+  }
+  if (ret != 1) {
+    throw std::runtime_error("MMG2D_doSol failed to build size map");
+  }
+
+  return get_field("metric");
+}

--- a/src/bindings/mmg_mesh_2d.hpp
+++ b/src/bindings/mmg_mesh_2d.hpp
@@ -118,6 +118,9 @@ public:
   py::dict remesh_levelset(const py::array_t<double> &levelset,
                            const py::dict &options = py::dict());
 
+  // Sizemap utility (MMG2D has no Clean_isoSurf equivalent)
+  py::array_t<double> build_size_map();
+
   bool is_corrupted() const { return corrupted_; }
 
   // Delete copy constructor and assignment operator

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -1094,3 +1094,40 @@ py::dict MmgMeshS::remesh_levelset(const py::array_t<double> &levelset,
 
   return build_remesh_result(before, after, duration, ret, warnings);
 }
+
+py::array_t<double> MmgMeshS::build_size_map() {
+  check_not_corrupted("build_size_map");
+
+  // MMGS_doSol is a function pointer initialized by MMGS_setfunc. The
+  // selector reads mesh->info.ani and met->size to pick the iso or aniso
+  // implementation.
+  MMGS_setfunc(mesh, met);
+  if (MMGS_doSol == nullptr) {
+    throw std::runtime_error(
+        "MMGS_doSol is null after MMGS_setfunc; cannot build size map");
+  }
+
+  int ret;
+  {
+    py::gil_scoped_release release;
+    ret = MMGS_doSol(mesh, met);
+  }
+  if (ret != 1) {
+    throw std::runtime_error("MMGS_doSol failed to build size map");
+  }
+
+  return get_field("metric");
+}
+
+void MmgMeshS::clean_iso_surface() {
+  check_not_corrupted("clean_iso_surface");
+
+  int ret;
+  {
+    py::gil_scoped_release release;
+    ret = MMGS_Clean_isoSurf(mesh);
+  }
+  if (ret != 1) {
+    throw std::runtime_error("MMGS_Clean_isoSurf failed");
+  }
+}

--- a/src/bindings/mmg_mesh_s.hpp
+++ b/src/bindings/mmg_mesh_s.hpp
@@ -114,6 +114,10 @@ public:
   py::dict remesh_levelset(const py::array_t<double> &levelset,
                            const py::dict &options = py::dict());
 
+  // Sizemap and level-set utilities
+  py::array_t<double> build_size_map();
+  void clean_iso_surface();
+
   bool is_corrupted() const { return corrupted_; }
 
   // Delete copy constructor and assignment operator

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -1935,6 +1935,42 @@ class Mesh:
             opts["verbose"] = verbose
         return self.remesh(progress=progress, **opts)
 
+    def build_size_map(self) -> NDArray[np.float64]:
+        """Build an isotropic size map from mean incident edge lengths.
+
+        Wraps MMG's ``doSol`` entry point on each mesh kind. The resulting
+        per-vertex sizes are stored on the underlying metric channel and
+        also returned for direct inspection.
+
+        Returns
+        -------
+        ndarray
+            ``(n_vertices, 1)`` array of per-vertex isotropic sizes.
+
+        """
+        return self._impl.build_size_map()
+
+    def clean_iso_surface(self) -> None:
+        """Remove isolated triangles / edges left after a level-set discretization.
+
+        Wraps ``MMG3D_Clean_isoSurf`` / ``MMGS_Clean_isoSurf``. Modifies
+        the mesh in place. Not available on 2D meshes — MMG2D has no
+        equivalent entry point.
+
+        Raises
+        ------
+        ValueError
+            If called on a ``TRIANGULAR_2D`` mesh.
+
+        """
+        if self._kind == MeshKind.TRIANGULAR_2D:
+            msg = (
+                "clean_iso_surface() is not available for TRIANGULAR_2D meshes; "
+                "MMG2D has no Clean_isoSurf entry point"
+            )
+            raise ValueError(msg)
+        cast("MmgMesh3D | MmgMeshS", self._impl).clean_iso_surface()
+
     # =========================================================================
     # Local sizing constraints
     # =========================================================================

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -1954,7 +1954,7 @@ class Mesh:
         """Remove isolated triangles / edges left after a level-set discretization.
 
         Wraps ``MMG3D_Clean_isoSurf`` / ``MMGS_Clean_isoSurf``. Modifies
-        the mesh in place. Not available on 2D meshes — MMG2D has no
+        the mesh in place. Not available on 2D meshes, MMG2D has no
         equivalent entry point.
 
         Raises

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -1249,6 +1249,19 @@ class MmgMesh3D:
 
         """
 
+    def build_size_map(self) -> NDArray[np.float64]:
+        """Build an isotropic size map from mean incident edge lengths.
+
+        Wraps ``MMG3D_doSol``. Populates the mesh metric channel and
+        returns a ``(n_vertices, 1)`` array of per-vertex sizes.
+        """
+
+    def clean_iso_surface(self) -> None:
+        """Remove isolated triangles / edges left after a level-set discretization.
+
+        Wraps ``MMG3D_Clean_isoSurf``. Modifies the mesh in place.
+        """
+
 class MmgMesh2D:
     """2D triangular mesh class for in-memory remeshing.
 
@@ -2048,6 +2061,13 @@ class MmgMesh2D:
 
         """
 
+    def build_size_map(self) -> NDArray[np.float64]:
+        """Build an isotropic size map from mean incident edge lengths.
+
+        Wraps ``MMG2D_doSol``. Populates the mesh metric channel and
+        returns a ``(n_vertices, 1)`` array of per-vertex sizes.
+        """
+
 class MmgMeshS:
     """Surface mesh class for in-memory remeshing.
 
@@ -2781,4 +2801,17 @@ class MmgMeshS:
         dict[str, Any]
             Statistics dictionary with before/after metrics.
 
+        """
+
+    def build_size_map(self) -> NDArray[np.float64]:
+        """Build an isotropic size map from mean incident edge lengths.
+
+        Wraps ``MMGS_doSol``. Populates the mesh metric channel and
+        returns a ``(n_vertices, 1)`` array of per-vertex sizes.
+        """
+
+    def clean_iso_surface(self) -> None:
+        """Remove isolated triangles / edges left after a level-set discretization.
+
+        Wraps ``MMGS_Clean_isoSurf``. Modifies the mesh in place.
         """

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -806,6 +806,36 @@ class MmgAccessor:
         )
         return _to_pyvista_with_user_fields(mesh)
 
+    def build_size_map(self) -> NDArray[np.float64]:
+        """Build an isotropic size map from mean incident edge lengths.
+
+        Wraps MMG's ``doSol`` entry point. The returned ``(n_points, 1)``
+        array is also stored on the dataset as
+        ``point_data["metric"]`` so subsequent ``remesh()`` calls pick it
+        up as the target sizemap.
+        """
+        mesh = _build_mesh_with_mmg_fields(self._dataset)
+        sizes = mesh.build_size_map()
+        self._dataset.point_data["metric"] = sizes.reshape(-1)
+        return sizes
+
+    def clean_iso_surface(self) -> pv.UnstructuredGrid | pv.PolyData:
+        """Remove isolated triangles / edges from a level-set discretization.
+
+        Wraps ``MMG3D_Clean_isoSurf`` / ``MMGS_Clean_isoSurf``. Returns a
+        fresh dataset; the input is not modified. Not available on 2D
+        meshes — MMG2D has no equivalent entry point.
+
+        Raises
+        ------
+        ValueError
+            If the dataset's mesh kind is ``TRIANGULAR_2D``.
+
+        """
+        mesh = _build_mesh_with_mmg_fields(self._dataset)
+        mesh.clean_iso_surface()
+        return _to_pyvista_with_user_fields(mesh)
+
     def load_sol(self, path: str | Path) -> None:
         """Load a Medit ``.sol`` file and attach its fields to the dataset.
 

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -824,7 +824,15 @@ class MmgAccessor:
 
         Wraps ``MMG3D_Clean_isoSurf`` / ``MMGS_Clean_isoSurf``. Returns a
         fresh dataset; the input is not modified. Not available on 2D
-        meshes — MMG2D has no equivalent entry point.
+        meshes, MMG2D has no equivalent entry point.
+
+        Notes
+        -----
+        The vertex set is preserved, so ``point_data`` flows through to the
+        returned dataset. ``cell_data`` is dropped: ``Clean_isoSurf`` removes
+        triangles/edges, so any positional cell array on the input would no
+        longer align with the cleaned topology. A warning is emitted when
+        the input carries ``cell_data`` so the loss is not silent.
 
         Raises
         ------
@@ -832,6 +840,15 @@ class MmgAccessor:
             If the dataset's mesh kind is ``TRIANGULAR_2D``.
 
         """
+        if len(self._dataset.cell_data) > 0:
+            warnings.warn(
+                "clean_iso_surface() drops cell_data: Clean_isoSurf removes "
+                "triangles/edges, so positional cell arrays would no longer "
+                f"align with the cleaned mesh. Lost keys: "
+                f"{sorted(self._dataset.cell_data.keys())}.",
+                UserWarning,
+                stacklevel=2,
+            )
         mesh = _build_mesh_with_mmg_fields(self._dataset)
         mesh.clean_iso_surface()
         return _to_pyvista_with_user_fields(mesh)

--- a/tests/dosol_test.py
+++ b/tests/dosol_test.py
@@ -1,0 +1,237 @@
+"""Tests for ``build_size_map`` and ``clean_iso_surface`` bindings.
+
+``build_size_map`` wraps MMG's ``doSol`` entry point (isotropic size map
+from mean incident edge length). ``clean_iso_surface`` wraps
+``MMG{3D,S}_Clean_isoSurf`` (no 2D equivalent).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+import mmgpy  # noqa: F401  -- registers the .mmg accessor
+from mmgpy._mesh import Mesh
+from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
+
+
+class TestBuildSizeMap3D:
+    """Tests for ``MmgMesh3D.build_size_map``."""
+
+    def test_returns_per_vertex_sizes(
+        self,
+        cube_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Returned array has one positive, finite size per vertex."""
+        vertices, elements = cube_mesh
+        mesh = MmgMesh3D(vertices, elements)
+
+        sizes = mesh.build_size_map()
+
+        assert sizes.shape == (len(vertices), 1)
+        assert sizes.dtype == np.float64
+        assert np.all(np.isfinite(sizes))
+        assert np.all(sizes > 0)
+
+    def test_sizes_match_average_edge_length(
+        self,
+        cube_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Sizes should be in the same ballpark as the mean incident edge."""
+        vertices, elements = cube_mesh
+        mesh = MmgMesh3D(vertices, elements)
+
+        sizes = mesh.build_size_map().ravel()
+
+        # Compute mean incident edge length per vertex for the same mesh.
+        edge_pairs: list[tuple[int, int]] = []
+        for tet in elements:
+            edge_pairs.extend(
+                (tet[i], tet[j]) for i in range(4) for j in range(i + 1, 4)
+            )
+        edges = np.array(edge_pairs)
+        lengths = np.linalg.norm(vertices[edges[:, 0]] - vertices[edges[:, 1]], axis=1)
+
+        expected = np.zeros(len(vertices))
+        counts = np.zeros(len(vertices))
+        for (a, b), length in zip(edges, lengths, strict=True):
+            expected[a] += length
+            expected[b] += length
+            counts[a] += 1
+            counts[b] += 1
+        expected /= np.maximum(counts, 1)
+
+        # MMG truncates / clamps with hmin / hmax bookkeeping, so we only
+        # assert the same order of magnitude rather than equality.
+        assert np.allclose(sizes, expected, rtol=0.5)
+
+    def test_populates_metric_channel(
+        self,
+        cube_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """The returned sizes are also written to the mesh metric channel."""
+        vertices, elements = cube_mesh
+        mesh = MmgMesh3D(vertices, elements)
+
+        sizes = mesh.build_size_map()
+        metric = mesh.get_field("metric")
+
+        np.testing.assert_array_equal(sizes, metric)
+
+
+class TestBuildSizeMap2D:
+    """Tests for ``MmgMesh2D.build_size_map``."""
+
+    def test_returns_per_vertex_sizes(
+        self,
+        square_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Returned array has one positive, finite size per vertex."""
+        vertices, triangles = square_mesh
+        mesh = MmgMesh2D(vertices, triangles)
+
+        sizes = mesh.build_size_map()
+
+        assert sizes.shape == (len(vertices), 1)
+        assert np.all(np.isfinite(sizes))
+        assert np.all(sizes > 0)
+
+
+class TestBuildSizeMapSurface:
+    """Tests for ``MmgMeshS.build_size_map``."""
+
+    def test_returns_per_vertex_sizes(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Returned array has one positive, finite size per vertex."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        sizes = mesh.build_size_map()
+
+        assert sizes.shape == (len(vertices), 1)
+        assert np.all(np.isfinite(sizes))
+        assert np.all(sizes > 0)
+
+
+class TestCleanIsoSurface3D:
+    """Tests for ``MmgMesh3D.clean_iso_surface``."""
+
+    def test_runs_on_clean_mesh(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """No-op on a mesh with no level-set artifacts — should just succeed."""
+        vertices, elements = dense_3d_mesh
+        mesh = MmgMesh3D(vertices, elements)
+
+        mesh.clean_iso_surface()
+
+        assert mesh.get_vertices().shape[0] > 0
+
+    def test_after_levelset_discretization(
+        self,
+        dense_3d_mesh_fine: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """After a level-set remesh, cleaning should leave a valid mesh."""
+        vertices, elements = dense_3d_mesh_fine
+        mesh = MmgMesh3D(vertices, elements)
+
+        center = np.array([0.5, 0.5, 0.5])
+        radius = 0.3
+        levelset = (np.linalg.norm(vertices - center, axis=1) - radius).reshape(-1, 1)
+        mesh.remesh_levelset(levelset, hmax=0.15, verbose=False)
+
+        n_tri_before = mesh.get_triangles().shape[0]
+        mesh.clean_iso_surface()
+        n_tri_after = mesh.get_triangles().shape[0]
+
+        # Clean_isoSurf may only drop triangles, never add them.
+        assert n_tri_after <= n_tri_before
+
+
+class TestCleanIsoSurfaceSurface:
+    """Tests for ``MmgMeshS.clean_iso_surface``."""
+
+    def test_runs_on_clean_mesh(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """No-op on a mesh with no level-set artifacts — should just succeed."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        mesh.clean_iso_surface()
+
+        assert mesh.get_vertices().shape[0] > 0
+
+
+class TestMeshWrapper:
+    """Tests for the high-level :class:`mmgpy.Mesh` shims."""
+
+    def test_build_size_map_3d(
+        self,
+        cube_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """High-level wrapper forwards ``build_size_map`` to the C++ impl."""
+        vertices, elements = cube_mesh
+        mesh = Mesh(vertices, elements)
+
+        sizes = mesh.build_size_map()
+
+        assert sizes.shape == (len(vertices), 1)
+        assert np.all(sizes > 0)
+
+    def test_clean_iso_surface_rejects_2d(
+        self,
+        square_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """MMG2D has no Clean_isoSurf entry point — the wrapper rejects 2D."""
+        vertices, triangles = square_mesh
+        mesh = Mesh(vertices, triangles)
+
+        with pytest.raises(ValueError, match="not available for TRIANGULAR_2D"):
+            mesh.clean_iso_surface()
+
+
+class TestPyVistaAccessor:
+    """Tests for the ``dataset.mmg`` accessor surface."""
+
+    def test_build_size_map_populates_point_data(
+        self,
+        cube_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Accessor variant stores the result on the dataset as ``metric``."""
+        vertices, elements = cube_mesh
+        ug = pv.UnstructuredGrid(
+            np.column_stack([np.full(len(elements), 4), elements]).ravel(),
+            np.full(len(elements), pv.CellType.TETRA, dtype=np.uint8),
+            vertices,
+        )
+
+        sizes = ug.mmg.build_size_map()
+
+        assert sizes.shape == (ug.n_points, 1)
+        np.testing.assert_allclose(
+            ug.point_data["metric"],
+            sizes.ravel(),
+        )
+
+    def test_clean_iso_surface_returns_fresh_dataset(
+        self,
+        cube_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Accessor returns a new dataset; the input is not modified."""
+        vertices, elements = cube_mesh
+        ug = pv.UnstructuredGrid(
+            np.column_stack([np.full(len(elements), 4), elements]).ravel(),
+            np.full(len(elements), pv.CellType.TETRA, dtype=np.uint8),
+            vertices,
+        )
+
+        cleaned = ug.mmg.clean_iso_surface()
+
+        assert cleaned is not ug
+        assert cleaned.n_points > 0

--- a/tests/dosol_test.py
+++ b/tests/dosol_test.py
@@ -38,7 +38,7 @@ class TestBuildSizeMap3D:
         self,
         cube_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
-        """Sizes should be in the same ballpark as the mean incident edge."""
+        """Sizes track the mean incident edge length in scale and ordering."""
         vertices, elements = cube_mesh
         mesh = MmgMesh3D(vertices, elements)
 
@@ -62,9 +62,17 @@ class TestBuildSizeMap3D:
             counts[b] += 1
         expected /= np.maximum(counts, 1)
 
-        # MMG truncates / clamps with hmin / hmax bookkeeping, so we only
-        # assert the same order of magnitude rather than equality.
-        assert np.allclose(sizes, expected, rtol=0.5)
+        # Same computation in principle; MMG dedupes shared edges and applies
+        # its own hmin/hmax bookkeeping, so check the median ratio sits near 1
+        # rather than asserting per-vertex equality.
+        ratio = sizes / expected
+        assert 0.8 <= np.median(ratio) <= 1.25, (
+            f"median size/expected ratio {np.median(ratio):.3f} out of [0.8, 1.25]"
+        )
+        # Extremes must line up: the vertex with the smallest mean incident
+        # edge should also get the smallest size, and likewise for the largest.
+        assert np.argmin(sizes) == np.argmin(expected)
+        assert np.argmax(sizes) == np.argmax(expected)
 
     def test_populates_metric_channel(
         self,
@@ -123,7 +131,7 @@ class TestCleanIsoSurface3D:
         self,
         dense_3d_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
-        """No-op on a mesh with no level-set artifacts — should just succeed."""
+        """No-op on a mesh with no level-set artifacts, should just succeed."""
         vertices, elements = dense_3d_mesh
         mesh = MmgMesh3D(vertices, elements)
 
@@ -159,7 +167,7 @@ class TestCleanIsoSurfaceSurface:
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
-        """No-op on a mesh with no level-set artifacts — should just succeed."""
+        """No-op on a mesh with no level-set artifacts, should just succeed."""
         vertices, triangles = tetrahedron_surface_mesh
         mesh = MmgMeshS(vertices, triangles)
 
@@ -188,12 +196,36 @@ class TestMeshWrapper:
         self,
         square_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
-        """MMG2D has no Clean_isoSurf entry point — the wrapper rejects 2D."""
+        """MMG2D has no Clean_isoSurf entry point, the wrapper rejects 2D."""
         vertices, triangles = square_mesh
         mesh = Mesh(vertices, triangles)
 
         with pytest.raises(ValueError, match="not available for TRIANGULAR_2D"):
             mesh.clean_iso_surface()
+
+    def test_clean_iso_surface_3d(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """High-level wrapper forwards ``clean_iso_surface`` for 3D meshes."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+
+        mesh.clean_iso_surface()
+
+        assert mesh.get_vertices().shape[0] == len(vertices)
+
+    def test_clean_iso_surface_surface(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """High-level wrapper forwards ``clean_iso_surface`` for surface meshes."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = Mesh(vertices, triangles)
+
+        mesh.clean_iso_surface()
+
+        assert mesh.get_vertices().shape[0] == len(vertices)
 
 
 class TestPyVistaAccessor:
@@ -235,3 +267,23 @@ class TestPyVistaAccessor:
 
         assert cleaned is not ug
         assert cleaned.n_points > 0
+
+    def test_clean_iso_surface_warns_on_cell_data(
+        self,
+        cube_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """``cell_data`` is dropped by Clean_isoSurf; the accessor warns."""
+        vertices, elements = cube_mesh
+        ug = pv.UnstructuredGrid(
+            np.column_stack([np.full(len(elements), 4), elements]).ravel(),
+            np.full(len(elements), pv.CellType.TETRA, dtype=np.uint8),
+            vertices,
+        )
+        ug.cell_data["region"] = np.arange(len(elements), dtype=np.float64)
+
+        with pytest.warns(UserWarning, match="drops cell_data"):
+            cleaned = ug.mmg.clean_iso_surface()
+
+        assert "region" not in cleaned.cell_data
+        # Original input is not mutated.
+        assert "region" in ug.cell_data


### PR DESCRIPTION
## Summary
Wires up two MMG utilities that previously had no Python entry point.

## Changes
- `MmgMesh{3D,2D,S}.build_size_map()` wraps `MMG*_doSol` (isotropic size map from mean incident edge length); writes to the metric channel and returns the `(n_vertices, 1)` array.
- `MmgMesh{3D,S}.clean_iso_surface()` wraps `MMG{3D,S}_Clean_isoSurf` (no 2D equivalent in MMG).
- `Mesh.build_size_map()` / `Mesh.clean_iso_surface()` high-level shims; the latter raises on `TRIANGULAR_2D`.
- `dataset.mmg.build_size_map()` populates `point_data["metric"]`; `dataset.mmg.clean_iso_surface()` returns a fresh dataset.

## Notes
- `MMG*_doSol` is a function pointer initialized by `MMG*_setfunc`; the bindings call `setfunc` first and null-check before dispatch.
- New `tests/dosol_test.py` covers the bindings, the `Mesh` shims, and the PyVista accessor across all three mesh kinds.