### PR TITLE
add multi-block .sol I/O via MMG's multi-sol C API

### DIFF
--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -202,6 +202,24 @@ PYBIND11_MODULE(_mmgpy, m) {
            [](const MmgMesh &self, const py::object &path) {
              self.save_sol(path_to_variant(path));
            })
+      .def(
+          "load_all_sols",
+          [](MmgMesh &self, const py::object &path) {
+            return self.load_all_sols(path_to_variant(path));
+          },
+          py::arg("path"),
+          "Load every solution block from a Medit .sol/.solb file. Returns a "
+          "list of (mmg_type, ndarray) tuples in file order. "
+          "mmg_type is 1=scalar, 2=vector, 3=tensor.")
+      .def(
+          "save_all_sols",
+          [](const MmgMesh &self, const py::object &path,
+             const py::list &sols) {
+            self.save_all_sols(path_to_variant(path), sols);
+          },
+          py::arg("path"), py::arg("sols"),
+          "Write a list of (mmg_type, ndarray) tuples as a multi-block "
+          ".sol/.solb file. mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def_property_readonly("is_corrupted", &MmgMesh::is_corrupted)
       .def(
           "remesh",
@@ -362,6 +380,24 @@ PYBIND11_MODULE(_mmgpy, m) {
            [](const MmgMesh2D &self, const py::object &path) {
              self.save_sol(path_to_variant(path));
            })
+      .def(
+          "load_all_sols",
+          [](MmgMesh2D &self, const py::object &path) {
+            return self.load_all_sols(path_to_variant(path));
+          },
+          py::arg("path"),
+          "Load every solution block from a Medit .sol/.solb file. Returns a "
+          "list of (mmg_type, ndarray) tuples in file order. "
+          "mmg_type is 1=scalar, 2=vector, 3=tensor.")
+      .def(
+          "save_all_sols",
+          [](const MmgMesh2D &self, const py::object &path,
+             const py::list &sols) {
+            self.save_all_sols(path_to_variant(path), sols);
+          },
+          py::arg("path"), py::arg("sols"),
+          "Write a list of (mmg_type, ndarray) tuples as a multi-block "
+          ".sol/.solb file. mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def_property_readonly("is_corrupted", &MmgMesh2D::is_corrupted)
       .def(
           "remesh",
@@ -513,6 +549,24 @@ PYBIND11_MODULE(_mmgpy, m) {
            [](const MmgMeshS &self, const py::object &path) {
              self.save_sol(path_to_variant(path));
            })
+      .def(
+          "load_all_sols",
+          [](MmgMeshS &self, const py::object &path) {
+            return self.load_all_sols(path_to_variant(path));
+          },
+          py::arg("path"),
+          "Load every solution block from a Medit .sol/.solb file. Returns a "
+          "list of (mmg_type, ndarray) tuples in file order. "
+          "mmg_type is 1=scalar, 2=vector, 3=tensor.")
+      .def(
+          "save_all_sols",
+          [](const MmgMeshS &self, const py::object &path,
+             const py::list &sols) {
+            self.save_all_sols(path_to_variant(path), sols);
+          },
+          py::arg("path"), py::arg("sols"),
+          "Write a list of (mmg_type, ndarray) tuples as a multi-block "
+          ".sol/.solb file. mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def_property_readonly("is_corrupted", &MmgMeshS::is_corrupted)
       .def(
           "remesh",

--- a/src/bindings/mmg_mesh.cpp
+++ b/src/bindings/mmg_mesh.cpp
@@ -1,5 +1,6 @@
 #include "mmg_mesh.hpp"
 #include "mmg_common.hpp"
+#include "mmg_multisol.hpp"
 #include <chrono>
 #include <set>
 #include <stdexcept>
@@ -278,6 +279,34 @@ void MmgMesh::save_sol(
   if (MMG3D_saveSol(mesh, met, fname.c_str()) != 1) {
     throw std::runtime_error("Failed to save solution file: " + fname);
   }
+}
+
+namespace {
+constexpr MultiSolApi MMG3D_MULTISOL_API = {
+    &MMG3D_Set_solsAtVerticesSize,
+    &MMG3D_Get_solsAtVerticesSize,
+    &MMG3D_Set_ithSols_inSolsAtVertices,
+    &MMG3D_Get_ithSols_inSolsAtVertices,
+    &MMG3D_loadAllSols,
+    &MMG3D_saveAllSols,
+    &MMG3D_Free_allSols,
+    /*dim=*/3,
+};
+}
+
+py::list MmgMesh::load_all_sols(
+    const std::variant<std::string, std::filesystem::path> &filename) {
+  check_not_corrupted("load_all_sols");
+  return load_all_sols_vertices(mesh, variant_to_string(filename),
+                                MMG3D_MULTISOL_API);
+}
+
+void MmgMesh::save_all_sols(
+    const std::variant<std::string, std::filesystem::path> &filename,
+    const py::list &sols) const {
+  check_not_corrupted("save_all_sols");
+  save_all_sols_vertices(mesh, mesh->np, variant_to_string(filename), sols,
+                         MMG3D_MULTISOL_API);
 }
 
 MmgMesh::SolutionField

--- a/src/bindings/mmg_mesh.hpp
+++ b/src/bindings/mmg_mesh.hpp
@@ -145,6 +145,12 @@ public:
   void save_sol(
       const std::variant<std::string, std::filesystem::path> &filename) const;
 
+  py::list load_all_sols(
+      const std::variant<std::string, std::filesystem::path> &filename);
+  void save_all_sols(
+      const std::variant<std::string, std::filesystem::path> &filename,
+      const py::list &sols) const;
+
   // In-memory remeshing
   py::dict remesh(const py::dict &options = py::dict());
   py::dict remesh_levelset(const py::array_t<double> &levelset,

--- a/src/bindings/mmg_mesh_2d.cpp
+++ b/src/bindings/mmg_mesh_2d.cpp
@@ -1,5 +1,6 @@
 #include "mmg_mesh_2d.hpp"
 #include "mmg_common.hpp"
+#include "mmg_multisol.hpp"
 #include <chrono>
 #include <set>
 #include <stdexcept>
@@ -992,6 +993,34 @@ void MmgMesh2D::save_sol(
   if (MMG2D_saveSol(mesh, met, fname.c_str()) != 1) {
     throw std::runtime_error("Failed to save solution file: " + fname);
   }
+}
+
+namespace {
+constexpr MultiSolApi MMG2D_MULTISOL_API = {
+    &MMG2D_Set_solsAtVerticesSize,
+    &MMG2D_Get_solsAtVerticesSize,
+    &MMG2D_Set_ithSols_inSolsAtVertices,
+    &MMG2D_Get_ithSols_inSolsAtVertices,
+    &MMG2D_loadAllSols,
+    &MMG2D_saveAllSols,
+    &MMG2D_Free_allSols,
+    /*dim=*/2,
+};
+}
+
+py::list MmgMesh2D::load_all_sols(
+    const std::variant<std::string, std::filesystem::path> &filename) {
+  check_not_corrupted("load_all_sols");
+  return load_all_sols_vertices(mesh, variant_to_string(filename),
+                                MMG2D_MULTISOL_API);
+}
+
+void MmgMesh2D::save_all_sols(
+    const std::variant<std::string, std::filesystem::path> &filename,
+    const py::list &sols) const {
+  check_not_corrupted("save_all_sols");
+  save_all_sols_vertices(mesh, mesh->np, variant_to_string(filename), sols,
+                         MMG2D_MULTISOL_API);
 }
 
 MmgMesh2D::SolutionField

--- a/src/bindings/mmg_mesh_2d.hpp
+++ b/src/bindings/mmg_mesh_2d.hpp
@@ -113,6 +113,12 @@ public:
   void save_sol(
       const std::variant<std::string, std::filesystem::path> &filename) const;
 
+  py::list load_all_sols(
+      const std::variant<std::string, std::filesystem::path> &filename);
+  void save_all_sols(
+      const std::variant<std::string, std::filesystem::path> &filename,
+      const py::list &sols) const;
+
   // In-memory remeshing
   py::dict remesh(const py::dict &options = py::dict());
   py::dict remesh_levelset(const py::array_t<double> &levelset,

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -1,5 +1,6 @@
 #include "mmg_mesh_s.hpp"
 #include "mmg_common.hpp"
+#include "mmg_multisol.hpp"
 #include <chrono>
 #include <set>
 #include <stdexcept>
@@ -980,6 +981,34 @@ void MmgMeshS::save_sol(
   if (MMGS_saveSol(mesh, met, fname.c_str()) != 1) {
     throw std::runtime_error("Failed to save solution file: " + fname);
   }
+}
+
+namespace {
+constexpr MultiSolApi MMGS_MULTISOL_API = {
+    &MMGS_Set_solsAtVerticesSize,
+    &MMGS_Get_solsAtVerticesSize,
+    &MMGS_Set_ithSols_inSolsAtVertices,
+    &MMGS_Get_ithSols_inSolsAtVertices,
+    &MMGS_loadAllSols,
+    &MMGS_saveAllSols,
+    &MMGS_Free_allSols,
+    /*dim=*/3,
+};
+}
+
+py::list MmgMeshS::load_all_sols(
+    const std::variant<std::string, std::filesystem::path> &filename) {
+  check_not_corrupted("load_all_sols");
+  return load_all_sols_vertices(mesh, variant_to_string(filename),
+                                MMGS_MULTISOL_API);
+}
+
+void MmgMeshS::save_all_sols(
+    const std::variant<std::string, std::filesystem::path> &filename,
+    const py::list &sols) const {
+  check_not_corrupted("save_all_sols");
+  save_all_sols_vertices(mesh, mesh->np, variant_to_string(filename), sols,
+                         MMGS_MULTISOL_API);
 }
 
 MmgMeshS::SolutionField

--- a/src/bindings/mmg_mesh_s.hpp
+++ b/src/bindings/mmg_mesh_s.hpp
@@ -109,6 +109,12 @@ public:
   void save_sol(
       const std::variant<std::string, std::filesystem::path> &filename) const;
 
+  py::list load_all_sols(
+      const std::variant<std::string, std::filesystem::path> &filename);
+  void save_all_sols(
+      const std::variant<std::string, std::filesystem::path> &filename,
+      const py::list &sols) const;
+
   // In-memory remeshing
   py::dict remesh(const py::dict &options = py::dict());
   py::dict remesh_levelset(const py::array_t<double> &levelset,

--- a/src/bindings/mmg_multisol.hpp
+++ b/src/bindings/mmg_multisol.hpp
@@ -1,0 +1,232 @@
+#ifndef MMG_MULTISOL_HPP
+#define MMG_MULTISOL_HPP
+
+#include "mmg/common/libmmgtypes.h"
+#include "mmg_common.hpp"
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+namespace py = pybind11;
+
+// Function pointer signatures shared by MMG3D/MMG2D/MMGS multi-sol API.
+using SetSolsAtVerticesSizeFn = int (*)(MMG5_pMesh, MMG5_pSol *, int, MMG5_int,
+                                        int *);
+using GetSolsAtVerticesSizeFn = int (*)(MMG5_pMesh, MMG5_pSol *, int *,
+                                        MMG5_int *, int *);
+using SetIthSolsFn = int (*)(MMG5_pSol, int, double *);
+using GetIthSolsFn = int (*)(MMG5_pSol, int, double *);
+using LoadAllSolsFn = int (*)(MMG5_pMesh, MMG5_pSol *, const char *);
+using SaveAllSolsFn = int (*)(MMG5_pMesh, MMG5_pSol *, const char *);
+using FreeAllSolsFn = int (*)(MMG5_pMesh, MMG5_pSol *);
+
+// Functions bundled into one struct so each call-site passes a single argument.
+struct MultiSolApi {
+  SetSolsAtVerticesSizeFn set_sols_size;
+  GetSolsAtVerticesSizeFn get_sols_size;
+  SetIthSolsFn set_ith_sols;
+  GetIthSolsFn get_ith_sols;
+  LoadAllSolsFn load_all_sols;
+  SaveAllSolsFn save_all_sols;
+  FreeAllSolsFn free_all_sols;
+  int dim; // 2 for MMG2D, 3 for MMG3D/MMGS
+};
+
+// Number of doubles per vertex for a given MMG5_type value at dimension `dim`.
+inline int components_for_type(int type, int dim) {
+  switch (type) {
+  case MMG5_Scalar:
+    return 1;
+  case MMG5_Vector:
+    return dim;
+  case MMG5_Tensor:
+    return dim * (dim + 1) / 2;
+  default:
+    throw std::runtime_error(
+        "Unknown MMG5 solution type: " + std::to_string(type) +
+        " (expected 1=scalar, 2=vector, 3=tensor)");
+  }
+}
+
+// Load every solution block from `filename` and return them as a Python list
+// of (type_int, ndarray) tuples. `type_int` matches MMG5_type:
+// 1=scalar (1D ndarray), 2=vector (Nxdim), 3=tensor (NxT where T=3 or 6).
+inline py::list load_all_sols_vertices(MMG5_pMesh mesh,
+                                       const std::string &fname,
+                                       const MultiSolApi &api) {
+  MMG5_pSol sols = nullptr;
+  int ret = api.load_all_sols(mesh, &sols, fname.c_str());
+  if (ret != 1) {
+    // Free in case MMG allocated partway through.
+    if (sols) {
+      api.free_all_sols(mesh, &sols);
+    }
+    if (ret == 0) {
+      throw std::runtime_error("Solution file not found: " + fname);
+    }
+    throw std::runtime_error("Failed to load solution file: " + fname);
+  }
+
+  int nsols = 0;
+  MMG5_int nentities = 0;
+  std::vector<int> typSol(MMG5_NSOLS_MAX, 0);
+  if (api.get_sols_size(mesh, &sols, &nsols, &nentities, typSol.data()) != 1) {
+    api.free_all_sols(mesh, &sols);
+    throw std::runtime_error("Failed to query solution array size");
+  }
+
+  py::list out;
+  try {
+    for (int i = 0; i < nsols; ++i) {
+      int type = typSol[i];
+      int ncomp = components_for_type(type, api.dim);
+      std::vector<py::ssize_t> shape;
+      if (type == MMG5_Scalar) {
+        shape = {nentities};
+      } else {
+        shape = {nentities, ncomp};
+      }
+      py::array_t<double> arr(shape);
+      py::buffer_info buf = arr.request();
+      double *ptr = static_cast<double *>(buf.ptr);
+      if (api.get_ith_sols(sols, i + 1, ptr) != 1) {
+        throw std::runtime_error("Failed to read solution block " +
+                                 std::to_string(i + 1));
+      }
+      out.append(py::make_tuple(type, std::move(arr)));
+    }
+  } catch (...) {
+    api.free_all_sols(mesh, &sols);
+    throw;
+  }
+
+  api.free_all_sols(mesh, &sols);
+  return out;
+}
+
+// Validate one entry of the input list and return (type, ndarray, ncomp).
+inline std::tuple<int, py::array_t<double>, int>
+unpack_save_entry(const py::handle &entry, int dim, MMG5_int nentities,
+                  int index) {
+  py::tuple t;
+  try {
+    t = entry.cast<py::tuple>();
+  } catch (const py::cast_error &) {
+    throw std::invalid_argument("save_all_sols entry " + std::to_string(index) +
+                                " must be a (type_int, ndarray) tuple; got " +
+                                std::string(py::str(entry.get_type())));
+  }
+  if (py::len(t) != 2) {
+    throw std::invalid_argument("save_all_sols entry " + std::to_string(index) +
+                                " must be a 2-tuple (type_int, ndarray)");
+  }
+  int type;
+  try {
+    type = t[0].cast<int>();
+  } catch (const py::cast_error &) {
+    throw std::invalid_argument("save_all_sols entry " + std::to_string(index) +
+                                ": type must be an int (1, 2, or 3)");
+  }
+  if (type < MMG5_Scalar || type > MMG5_Tensor) {
+    throw std::invalid_argument(
+        "save_all_sols entry " + std::to_string(index) +
+        ": type must be 1=scalar, 2=vector, or 3=tensor; got " +
+        std::to_string(type));
+  }
+  py::array_t<double> arr;
+  try {
+    arr = py::array_t<double, py::array::c_style | py::array::forcecast>(t[1]);
+  } catch (const py::cast_error &) {
+    throw std::invalid_argument("save_all_sols entry " + std::to_string(index) +
+                                ": value must be a numpy array of floats");
+  }
+
+  int ncomp = components_for_type(type, dim);
+  py::buffer_info buf = arr.request();
+  py::ssize_t n_rows;
+  if (buf.ndim == 1) {
+    if (ncomp != 1) {
+      throw std::invalid_argument("save_all_sols entry " +
+                                  std::to_string(index) + ": type " +
+                                  std::to_string(type) + " needs a 2D (N," +
+                                  std::to_string(ncomp) + ") array, got 1D");
+    }
+    n_rows = buf.shape[0];
+  } else if (buf.ndim == 2) {
+    n_rows = buf.shape[0];
+    if (buf.shape[1] != ncomp) {
+      throw std::invalid_argument(
+          "save_all_sols entry " + std::to_string(index) + ": type " +
+          std::to_string(type) + " expects " + std::to_string(ncomp) +
+          " components per row, got " + std::to_string(buf.shape[1]));
+    }
+  } else {
+    throw std::invalid_argument("save_all_sols entry " + std::to_string(index) +
+                                ": array must be 1D or 2D");
+  }
+  if (n_rows != nentities) {
+    throw std::invalid_argument("save_all_sols entry " + std::to_string(index) +
+                                ": array length " + std::to_string(n_rows) +
+                                " does not match vertex count " +
+                                std::to_string(nentities));
+  }
+  return {type, std::move(arr), ncomp};
+}
+
+// Write a list of (type_int, ndarray) tuples to `filename` as a multi-block
+// .sol/.solb file. Validates shapes against `nentities` (mesh->np).
+inline void save_all_sols_vertices(MMG5_pMesh mesh, MMG5_int nentities,
+                                   const std::string &fname,
+                                   const py::list &sols,
+                                   const MultiSolApi &api) {
+  int nsols = static_cast<int>(py::len(sols));
+  if (nsols <= 0) {
+    throw std::invalid_argument("save_all_sols: empty solution list");
+  }
+  if (nsols > MMG5_NSOLS_MAX) {
+    throw std::invalid_argument("save_all_sols: " + std::to_string(nsols) +
+                                " solutions exceeds MMG5_NSOLS_MAX (" +
+                                std::to_string(MMG5_NSOLS_MAX) + ")");
+  }
+
+  std::vector<int> typSol(nsols);
+  std::vector<py::array_t<double>> arrays;
+  arrays.reserve(nsols);
+  for (int i = 0; i < nsols; ++i) {
+    auto [type, arr, ncomp] = unpack_save_entry(sols[i], api.dim, nentities, i);
+    (void)ncomp;
+    typSol[i] = type;
+    arrays.push_back(std::move(arr));
+  }
+
+  MMG5_pSol sol_array = nullptr;
+  if (api.set_sols_size(mesh, &sol_array, nsols, nentities, typSol.data()) !=
+      1) {
+    if (sol_array) {
+      api.free_all_sols(mesh, &sol_array);
+    }
+    throw std::runtime_error("Failed to allocate multi-solution array");
+  }
+
+  try {
+    for (int i = 0; i < nsols; ++i) {
+      py::buffer_info buf = arrays[i].request();
+      double *ptr = static_cast<double *>(buf.ptr);
+      if (api.set_ith_sols(sol_array, i + 1, ptr) != 1) {
+        throw std::runtime_error("Failed to set solution block " +
+                                 std::to_string(i + 1));
+      }
+    }
+    if (api.save_all_sols(mesh, &sol_array, fname.c_str()) != 1) {
+      throw std::runtime_error("Failed to save solution file: " + fname);
+    }
+  } catch (...) {
+    api.free_all_sols(mesh, &sol_array);
+    throw;
+  }
+  api.free_all_sols(mesh, &sol_array);
+}
+
+#endif // MMG_MULTISOL_HPP

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -1518,6 +1518,116 @@ class Mesh:
 
         _save_sol(self, filename)
 
+    def _solution_dim(self) -> int:
+        """Return the dimension MMG uses when allocating sol blocks (2 or 3)."""
+        return 2 if self.kind == MeshKind.TRIANGULAR_2D else 3
+
+    def load_all_sols(
+        self,
+        filename: str | Path,
+    ) -> dict[str, NDArray[np.float64]]:
+        """Read every vertex-located solution block from a Medit .sol file.
+
+        Returns a dict keyed by type-prefixed positional names
+        (``solution_0``, ``vector_1``, ``tensor_2``, ...) in file order.
+        The Medit format does not carry user-defined names, so positional
+        naming is the only round-trip-safe convention.
+
+        For cell-located blocks (``SolAtTriangles`` / ``SolAtTetrahedra``)
+        in text ``.sol`` files, use :meth:`mmgpy.MmgAccessor.load_all_sols`
+        which routes through the Python parser; MMG's multi-sol C API only
+        covers vertex blocks.
+
+        Binary ``.solb`` is not supported: MMG's binary writer interleaves
+        stray newlines that desynchronize the reader, so even single-channel
+        ``.solb`` round-trips return garbage.
+
+        Parameters
+        ----------
+        filename : str or Path
+            Source path; ``.sol`` text format.
+
+        Returns
+        -------
+        dict[str, NDArray[np.float64]]
+            Mapping from generated name to numpy array. Scalar blocks are
+            ``(N,)``; vector blocks are ``(N, dim)``; tensor blocks are
+            ``(N, dim*(dim+1)/2)``.
+
+        """
+        from pathlib import Path as _Path  # noqa: PLC0415
+
+        if _Path(filename).suffix.lower() == ".solb":
+            msg = (
+                "Binary .solb is not supported: MMG's multi-sol .solb "
+                "round-trip is broken at the library level."
+            )
+            raise NotImplementedError(msg)
+        raw = self._impl.load_all_sols(filename)
+        out: dict[str, NDArray[np.float64]] = {}
+        type_counts = {1: 0, 2: 0, 3: 0}
+        type_prefix = {1: "solution", 2: "vector", 3: "tensor"}
+        for type_int, arr in raw:
+            prefix = type_prefix[type_int]
+            idx = type_counts[type_int]
+            type_counts[type_int] += 1
+            out[f"{prefix}_{idx}"] = np.asarray(arr, dtype=np.float64)
+        return out
+
+    def save_all_sols(
+        self,
+        filename: str | Path,
+        arrays: dict[str, NDArray[np.float64]],
+    ) -> None:
+        """Write multiple vertex-located solution blocks to a Medit .sol file.
+
+        Block types are inferred from each array's shape: 1D or ``(N, 1)``
+        is scalar; ``(N, dim)`` is vector; ``(N, dim*(dim+1)/2)`` is tensor.
+        All arrays must share the vertex count ``N``. Names are passed to
+        the file order but Medit doesn't record them, so on round-trip the
+        reader regenerates positional names.
+
+        For cell-located blocks, use
+        :meth:`mmgpy.MmgAccessor.save_all_sols`; MMG's multi-sol C API
+        covers vertices only.
+
+        Binary ``.solb`` is not supported: MMG's writer interleaves stray
+        newlines into the binary stream that break the reader.
+
+        Parameters
+        ----------
+        filename : str or Path
+            Destination path; ``.sol`` text format.
+        arrays : dict[str, NDArray[np.float64]]
+            Solution blocks to write. Insertion order determines block
+            order in the file.
+
+        """
+        from pathlib import Path as _Path  # noqa: PLC0415
+
+        from mmgpy._sol import infer_sol_type  # noqa: PLC0415
+
+        if _Path(filename).suffix.lower() == ".solb":
+            msg = (
+                "Binary .solb is not supported: MMG's multi-sol .solb "
+                "round-trip is broken at the library level."
+            )
+            raise NotImplementedError(msg)
+        if not arrays:
+            msg = "save_all_sols: arrays must contain at least one block"
+            raise ValueError(msg)
+        dim = self._solution_dim()
+        sols: list[tuple[int, NDArray[np.float64]]] = []
+        for name, raw in arrays.items():
+            arr = np.ascontiguousarray(raw, dtype=np.float64)
+            try:
+                t = infer_sol_type(arr, dim)
+            except ValueError as exc:
+                msg = f"save_all_sols: field {name!r}: {exc}"
+                raise ValueError(msg) from exc
+            sols.append((t, arr))
+        self._impl.save_all_sols(filename, sols)
+
     # =========================================================================
     # Remeshing operations
     # =========================================================================

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -1518,8 +1518,9 @@ class Mesh:
 
         _save_sol(self, filename)
 
-    def _solution_dim(self) -> int:
-        """Return the dimension MMG uses when allocating sol blocks (2 or 3)."""
+    @property
+    def solution_dim(self) -> int:
+        """Dimension MMG uses when allocating sol blocks: 2 for 2D, 3 otherwise."""
         return 2 if self.kind == MeshKind.TRIANGULAR_2D else 3
 
     def load_all_sols(
@@ -1616,7 +1617,7 @@ class Mesh:
         if not arrays:
             msg = "save_all_sols: arrays must contain at least one block"
             raise ValueError(msg)
-        dim = self._solution_dim()
+        dim = self.solution_dim
         sols: list[tuple[int, NDArray[np.float64]]] = []
         for name, raw in arrays.items():
             arr = np.ascontiguousarray(raw, dtype=np.float64)

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -1148,6 +1148,28 @@ class MmgMesh3D:
 
         """
 
+    def load_all_sols(
+        self,
+        path: str | Path,
+    ) -> list[tuple[int, NDArray[np.float64]]]:
+        """Load every vertex-located solution block from a Medit .sol/.solb file.
+
+        Returns a list of ``(mmg_type, ndarray)`` tuples in file order;
+        ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. Scalar
+        arrays are 1D; vector and tensor arrays are 2D.
+        """
+
+    def save_all_sols(
+        self,
+        path: str | Path,
+        sols: list[tuple[int, NDArray[np.float64]]],
+    ) -> None:
+        """Write a list of ``(mmg_type, ndarray)`` tuples as a multi-block file.
+
+        ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. All
+        arrays must share the vertex count.
+        """
+
     def remesh(
         self,
         *,
@@ -1966,6 +1988,28 @@ class MmgMesh2D:
 
         """
 
+    def load_all_sols(
+        self,
+        path: str | Path,
+    ) -> list[tuple[int, NDArray[np.float64]]]:
+        """Load every vertex-located solution block from a Medit .sol/.solb file.
+
+        Returns a list of ``(mmg_type, ndarray)`` tuples in file order;
+        ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. Scalar
+        arrays are 1D; vector and tensor arrays are 2D.
+        """
+
+    def save_all_sols(
+        self,
+        path: str | Path,
+        sols: list[tuple[int, NDArray[np.float64]]],
+    ) -> None:
+        """Write a list of ``(mmg_type, ndarray)`` tuples as a multi-block file.
+
+        ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. All
+        arrays must share the vertex count.
+        """
+
     def remesh(
         self,
         *,
@@ -2706,6 +2750,28 @@ class MmgMeshS:
         RuntimeError
             If the file cannot be saved.
 
+        """
+
+    def load_all_sols(
+        self,
+        path: str | Path,
+    ) -> list[tuple[int, NDArray[np.float64]]]:
+        """Load every vertex-located solution block from a Medit .sol/.solb file.
+
+        Returns a list of ``(mmg_type, ndarray)`` tuples in file order;
+        ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. Scalar
+        arrays are 1D; vector and tensor arrays are 2D.
+        """
+
+    def save_all_sols(
+        self,
+        path: str | Path,
+        sols: list[tuple[int, NDArray[np.float64]]],
+    ) -> None:
+        """Write a list of ``(mmg_type, ndarray)`` tuples as a multi-block file.
+
+        ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. All
+        arrays must share the vertex count.
         """
 
     def remesh(

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pyvista as pv
 
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from mmgpy._mesh import Mesh as _Mesh
     from mmgpy._mesh import MeshKind
     from mmgpy._options import Mmg2DOptions, Mmg3DOptions, MmgSOptions
+    from mmgpy._sol import Location as _SolLocation
     from mmgpy._validation import ValidationReport
 
     MmgOptions = Mmg2DOptions | Mmg3DOptions | MmgSOptions
@@ -559,6 +560,119 @@ def write_mesh(
 
 
 # ---------------------------------------------------------------------------
+# Multi-sol field collection helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_numeric_sol_array(arr: NDArray[Any]) -> bool:
+    """Return True if *arr* is a numeric, non-boolean ndarray usable as a sol block."""
+    import numpy as np  # noqa: PLC0415
+
+    return np.issubdtype(arr.dtype, np.number) and not np.issubdtype(
+        arr.dtype,
+        np.bool_,
+    )
+
+
+def _is_valid_sol_shape(arr: NDArray[Any], dim: int) -> bool:
+    """Return True if *arr*'s shape matches scalar / vector / tensor for *dim*."""
+    if arr.ndim == 1:
+        return True
+    if arr.ndim != 2:  # noqa: PLR2004  -- sol arrays are 1D scalar or 2D
+        return False
+    n_cols = arr.shape[1]
+    tensor_size = dim * (dim + 1) // 2
+    return n_cols in {1, dim, tensor_size}
+
+
+def _collect_sol_arrays(
+    data: Mapping[str, NDArray[Any]],
+    n_entities: int,
+    keys: list[str] | None,
+    *,
+    skip_prefixes: tuple[str, ...] = (),
+    dim: int,
+) -> dict[str, NDArray[np.float64]]:
+    """Pull eligible numeric arrays from ``point_data`` / ``cell_data``.
+
+    When ``keys`` is None, returns every numeric array of the right length
+    AND a shape that maps to a valid scalar / vector / tensor layout for
+    ``dim``, skipping anything else (PyVista datasets routinely carry
+    auxiliary arrays like ``Normals`` or ``TCoords`` that don't belong in
+    a .sol file). When ``keys`` is a list, the same shape check applies
+    but a mismatch raises instead of silently dropping.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    out: dict[str, NDArray[np.float64]] = {}
+    if n_entities <= 0:
+        if keys:
+            msg = (
+                f"save_all_sols: dataset has no entities of the matching kind "
+                f"but {keys!r} were requested"
+            )
+            raise ValueError(msg)
+        return out
+
+    if keys is None:
+        for name, raw in data.items():
+            if any(name.startswith(p) for p in skip_prefixes):
+                continue
+            arr = np.asarray(raw)
+            if (
+                arr.shape[0] == n_entities
+                and _is_numeric_sol_array(arr)
+                and _is_valid_sol_shape(arr, dim)
+            ):
+                out[name] = arr.astype(np.float64, copy=False)
+        return out
+
+    for name in keys:
+        if name not in data:
+            msg = f"save_all_sols: requested key {name!r} not found"
+            raise ValueError(msg)
+        arr = np.asarray(data[name])
+        if arr.shape[0] != n_entities:
+            msg = (
+                f"save_all_sols: requested key {name!r} has length "
+                f"{arr.shape[0]}, expected {n_entities}"
+            )
+            raise ValueError(msg)
+        out[name] = arr.astype(np.float64, copy=False)
+    return out
+
+
+def _primary_cell_count(dataset: pv.UnstructuredGrid | pv.PolyData) -> int:
+    """Return the count of the dataset's primary cell type.
+
+    For an ``UnstructuredGrid`` we count TETRA cells (3D meshes after the
+    mmg round-trip); for a ``PolyData`` we count its polys (triangles in
+    every mmg surface / 2D context). Falls back to total cell count when
+    no specific signal exists so the caller's length check still works.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    if isinstance(dataset, pv.UnstructuredGrid):
+        types = np.asarray(dataset.celltypes)
+        tet_count = int(np.sum(types == pv.CellType.TETRA))
+        if tet_count > 0:
+            return tet_count
+        tri_count = int(np.sum(types == pv.CellType.TRIANGLE))
+        if tri_count > 0:
+            return tri_count
+    if isinstance(dataset, pv.PolyData):
+        n_polys = (
+            int(dataset.n_cells)
+            - int(dataset.n_verts)
+            - int(dataset.n_lines)
+            - int(dataset.n_strips)
+        )
+        if n_polys > 0:
+            return n_polys
+    return int(dataset.n_cells)
+
+
+# ---------------------------------------------------------------------------
 # .mmg dataset accessor
 # ---------------------------------------------------------------------------
 
@@ -900,6 +1014,126 @@ class MmgAccessor:
         MMG C library, which handles both text and binary formats.
         """
         _build_mesh_with_mmg_fields(self._dataset).save_sol(path)
+
+    def load_all_sols(self, path: str | Path) -> None:
+        """Read every solution block from a Medit ``.sol`` file.
+
+        Modifies the dataset in place. ``SolAtVertices`` blocks land in
+        ``point_data``; ``SolAtTriangles`` / ``SolAtTetrahedra`` blocks
+        land in ``cell_data``.
+
+        Generated key names follow the existing single-channel reader:
+        ``solution_i`` for scalar blocks, ``vector_i`` / ``tensor_i`` for
+        vector / tensor blocks, and a ``@vertices`` / ``@triangles`` /
+        ``@tetrahedra`` suffix to disambiguate location.
+
+        Binary ``.solb`` is not supported here. MMG's binary writer
+        interleaves stray newlines between values (see Mmg #commit-list),
+        so even single-channel ``.solb`` round-trips return garbage; the
+        multi-sol path inherits the same defect. Route binary I/O through
+        the lower-level ``Mesh.load_all_sols`` if you must, but expect
+        broken data on the way back in.
+
+        Parameters
+        ----------
+        path : str or Path
+            Source ``.sol`` text file.
+
+        """
+        sol_path = Path(path)
+        if sol_path.suffix.lower() == ".solb":
+            msg = (
+                "Binary .solb files are not supported via "
+                "mesh.mmg.load_all_sols() — MMG's .solb round-trip is "
+                "broken at the library level."
+            )
+            raise NotImplementedError(msg)
+        _attach_sol_fields(self._dataset, sol_path)
+
+    def save_all_sols(
+        self,
+        path: str | Path,
+        *,
+        point_keys: list[str] | None = None,
+        cell_keys: list[str] | None = None,
+    ) -> None:
+        """Write multiple solution blocks to a Medit ``.sol``/``.solb`` file.
+
+        Each numeric ``point_data`` array becomes a ``SolAtVertices`` block;
+        each numeric ``cell_data`` array becomes a ``SolAtTriangles`` /
+        ``SolAtTetrahedra`` block. Block type (scalar / vector / tensor)
+        is inferred from each array's shape against the mesh dimension.
+
+        Parameters
+        ----------
+        path : str or Path
+            Destination file; ``.sol`` (text) or ``.solb`` (binary).
+        point_keys : list of str, optional
+            Restrict to these ``point_data`` keys. Defaults to every
+            numeric array of length ``n_points`` whose name doesn't start
+            with ``mmg_`` (reserved constraint tags).
+        cell_keys : list of str, optional
+            Restrict to these ``cell_data`` keys. Defaults to every
+            numeric array whose length matches the count of the mesh's
+            primary cell type (triangles for 2D / surface, tetrahedra
+            for 3D). Cell blocks require a text ``.sol`` destination —
+            ``.solb`` only carries vertex blocks through MMG's C API,
+            so cell_keys for a ``.solb`` target raises.
+
+        """
+        import numpy as np  # noqa: PLC0415
+
+        from mmgpy._mesh import MeshKind  # noqa: PLC0415
+        from mmgpy._sol import write_sol_file  # noqa: PLC0415
+
+        sol_path = Path(path)
+        if sol_path.suffix.lower() == ".solb":
+            msg = (
+                "Binary .solb files are not supported via "
+                "mesh.mmg.save_all_sols() — MMG's .solb writer interleaves "
+                "stray newlines that break round-trip. Use .sol (text)."
+            )
+            raise NotImplementedError(msg)
+
+        mesh = _build_mesh_with_mmg_fields(self._dataset)
+        dim = mesh._solution_dim()  # noqa: SLF001
+        # PyVista's DataSetAttributes is dict-like but doesn't formally
+        # implement Mapping; the cast keeps the helper's static type intact.
+        point_arrays = _collect_sol_arrays(
+            cast("Mapping[str, NDArray[Any]]", self._dataset.point_data),
+            self._dataset.n_points,
+            point_keys,
+            skip_prefixes=("mmg_",),
+            dim=dim,
+        )
+        cell_count = _primary_cell_count(self._dataset)
+        cell_arrays = _collect_sol_arrays(
+            cast("Mapping[str, NDArray[Any]]", self._dataset.cell_data),
+            cell_count,
+            cell_keys,
+            skip_prefixes=("mmg_",),
+            dim=dim,
+        )
+
+        if not point_arrays and not cell_arrays:
+            msg = (
+                "save_all_sols: no eligible point_data or cell_data arrays "
+                "to write; populate the dataset or pass point_keys/cell_keys."
+            )
+            raise ValueError(msg)
+
+        primary_location: _SolLocation = (
+            "tetrahedra" if mesh.kind == MeshKind.TETRAHEDRAL else "triangles"
+        )
+        fields: list[tuple[str, NDArray[np.float64], _SolLocation]] = [
+            (name, np.ascontiguousarray(arr, dtype=np.float64), "vertices")
+            for name, arr in point_arrays.items()
+        ]
+        fields.extend(
+            (name, np.ascontiguousarray(arr, dtype=np.float64), primary_location)
+            for name, arr in cell_arrays.items()
+        )
+        write_sol_file(sol_path, fields, dim)
 
     def validate(  # noqa: PLR0913
         self,

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -585,48 +585,63 @@ def _is_valid_sol_shape(arr: NDArray[Any], dim: int) -> bool:
     return n_cols in {1, dim, tensor_size}
 
 
-def _collect_sol_arrays(
+# PyVista-reserved point/cell arrays that match valid sol shapes but aren't
+# physics solutions; skipped during auto-collection.
+_PV_RESERVED_ARRAYS = frozenset({"Normals", "TCoords"})
+
+
+def _auto_collect_sol_arrays(
     data: Mapping[str, NDArray[Any]],
     n_entities: int,
-    keys: list[str] | None,
     *,
-    skip_prefixes: tuple[str, ...] = (),
     dim: int,
 ) -> dict[str, NDArray[np.float64]]:
-    """Pull eligible numeric arrays from ``point_data`` / ``cell_data``.
+    """Auto-collect numeric arrays matching ``n_entities`` and a sol shape.
 
-    When ``keys`` is None, returns every numeric array of the right length
-    AND a shape that maps to a valid scalar / vector / tensor layout for
-    ``dim``, skipping anything else (PyVista datasets routinely carry
-    auxiliary arrays like ``Normals`` or ``TCoords`` that don't belong in
-    a .sol file). When ``keys`` is a list, the same shape check applies
-    but a mismatch raises instead of silently dropping.
+    Keeps only arrays whose shape maps to a valid scalar / vector / tensor
+    layout for ``dim``; skips ``mmg_*`` constraint tags and PyVista-reserved
+    arrays (``Normals``, ``TCoords``).
     """
     import numpy as np  # noqa: PLC0415
 
     out: dict[str, NDArray[np.float64]] = {}
     if n_entities <= 0:
-        if keys:
-            msg = (
-                f"save_all_sols: dataset has no entities of the matching kind "
-                f"but {keys!r} were requested"
-            )
-            raise ValueError(msg)
         return out
+    for name, raw in data.items():
+        if name in _PV_RESERVED_ARRAYS or name.startswith("mmg_"):
+            continue
+        arr = np.asarray(raw)
+        if (
+            arr.shape[0] == n_entities
+            and _is_numeric_sol_array(arr)
+            and _is_valid_sol_shape(arr, dim)
+        ):
+            out[name] = arr.astype(np.float64, copy=False)
+    return out
 
-    if keys is None:
-        for name, raw in data.items():
-            if any(name.startswith(p) for p in skip_prefixes):
-                continue
-            arr = np.asarray(raw)
-            if (
-                arr.shape[0] == n_entities
-                and _is_numeric_sol_array(arr)
-                and _is_valid_sol_shape(arr, dim)
-            ):
-                out[name] = arr.astype(np.float64, copy=False)
-        return out
 
+def _explicit_collect_sol_arrays(
+    data: Mapping[str, NDArray[Any]],
+    n_entities: int,
+    keys: list[str],
+    *,
+    dim: int,
+) -> dict[str, NDArray[np.float64]]:
+    """Validate and pull each named key from ``data``.
+
+    Raises on any mismatch (missing key, wrong length, non-numeric dtype,
+    bad shape) so the caller's intent is honored exactly.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    if n_entities <= 0:
+        msg = (
+            f"save_all_sols: dataset has no entities of the matching kind "
+            f"but {keys!r} were requested"
+        )
+        raise ValueError(msg)
+
+    out: dict[str, NDArray[np.float64]] = {}
     for name in keys:
         if name not in data:
             msg = f"save_all_sols: requested key {name!r} not found"
@@ -636,6 +651,20 @@ def _collect_sol_arrays(
             msg = (
                 f"save_all_sols: requested key {name!r} has length "
                 f"{arr.shape[0]}, expected {n_entities}"
+            )
+            raise ValueError(msg)
+        if not _is_numeric_sol_array(arr):
+            msg = (
+                f"save_all_sols: requested key {name!r} has dtype {arr.dtype}; "
+                f"sol blocks must be numeric (non-boolean)"
+            )
+            raise ValueError(msg)
+        if not _is_valid_sol_shape(arr, dim):
+            tensor_size = dim * (dim + 1) // 2
+            msg = (
+                f"save_all_sols: requested key {name!r} has shape {arr.shape}; "
+                f"expected scalar (N,) / (N,1), vector (N,{dim}), or tensor "
+                f"(N,{tensor_size}) at dim={dim}"
             )
             raise ValueError(msg)
         out[name] = arr.astype(np.float64, copy=False)
@@ -649,6 +678,11 @@ def _primary_cell_count(dataset: pv.UnstructuredGrid | pv.PolyData) -> int:
     mmg round-trip); for a ``PolyData`` we count its polys (triangles in
     every mmg surface / 2D context). Falls back to total cell count when
     no specific signal exists so the caller's length check still works.
+
+    Mixed-cell grids (tets + tris in one UnstructuredGrid) are not
+    supported: only the dominant type's cell_data round-trips. MMG itself
+    assumes a homogeneous mesh, so callers should split mixed datasets
+    before going through the .sol path.
     """
     import numpy as np  # noqa: PLC0415
 
@@ -1096,23 +1130,26 @@ class MmgAccessor:
             raise NotImplementedError(msg)
 
         mesh = _build_mesh_with_mmg_fields(self._dataset)
-        dim = mesh._solution_dim()  # noqa: SLF001
+        dim = mesh.solution_dim
         # PyVista's DataSetAttributes is dict-like but doesn't formally
         # implement Mapping; the cast keeps the helper's static type intact.
-        point_arrays = _collect_sol_arrays(
-            cast("Mapping[str, NDArray[Any]]", self._dataset.point_data),
-            self._dataset.n_points,
-            point_keys,
-            skip_prefixes=("mmg_",),
-            dim=dim,
-        )
+        point_data = cast("Mapping[str, NDArray[Any]]", self._dataset.point_data)
+        cell_data = cast("Mapping[str, NDArray[Any]]", self._dataset.cell_data)
         cell_count = _primary_cell_count(self._dataset)
-        cell_arrays = _collect_sol_arrays(
-            cast("Mapping[str, NDArray[Any]]", self._dataset.cell_data),
-            cell_count,
-            cell_keys,
-            skip_prefixes=("mmg_",),
-            dim=dim,
+        point_arrays = (
+            _explicit_collect_sol_arrays(
+                point_data,
+                self._dataset.n_points,
+                point_keys,
+                dim=dim,
+            )
+            if point_keys is not None
+            else _auto_collect_sol_arrays(point_data, self._dataset.n_points, dim=dim)
+        )
+        cell_arrays = (
+            _explicit_collect_sol_arrays(cell_data, cell_count, cell_keys, dim=dim)
+            if cell_keys is not None
+            else _auto_collect_sol_arrays(cell_data, cell_count, dim=dim)
         )
 
         if not point_arrays and not cell_arrays:

--- a/src/mmgpy/_sol.py
+++ b/src/mmgpy/_sol.py
@@ -1,10 +1,30 @@
-"""Parser for Medit .sol solution files."""
+"""Parser and writer for Medit .sol solution files."""
 
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from numpy.typing import NDArray
+
+Location = Literal["vertices", "triangles", "tetrahedra"]
+
+_LOCATION_TO_KEYWORD: dict[Location, str] = {
+    "vertices": "SolAtVertices",
+    "triangles": "SolAtTriangles",
+    "tetrahedra": "SolAtTetrahedra",
+}
+
+# MMG5_type enum values; mirror libmmgtypes.h. 0 = MMG5_Notype (unused).
+_TYPE_SCALAR = 1
+_TYPE_VECTOR = 2
+_TYPE_TENSOR = 3
 
 
 def parse_sol_file(content: str) -> dict[str, dict]:
@@ -139,3 +159,123 @@ def parse_sol_file(content: str) -> dict[str, dict]:
         i += 1
 
     return fields
+
+
+def infer_sol_type(array: NDArray[np.float64], dimension: int) -> int:
+    """Return the MMG5_type code (1/2/3) inferred from *array*'s shape.
+
+    A 1D array is scalar (type 1). A 2D ``(N, k)`` array is a vector when
+    ``k == dimension`` and a symmetric tensor when ``k == dim * (dim + 1) / 2``.
+    Anything else raises ``ValueError`` with a message that names the
+    expected shapes so callers can surface it directly.
+    """
+    if array.ndim == 1:
+        return _TYPE_SCALAR
+    if array.ndim != 2:
+        msg = (
+            f"Sol arrays must be 1D (scalar) or 2D (vector/tensor); "
+            f"got shape {array.shape}"
+        )
+        raise ValueError(msg)
+    n_cols = array.shape[1]
+    if n_cols == 1:
+        return _TYPE_SCALAR
+    tensor_size = dimension * (dimension + 1) // 2
+    if n_cols == dimension and n_cols != tensor_size:
+        return _TYPE_VECTOR
+    if n_cols == tensor_size and n_cols != dimension:
+        return _TYPE_TENSOR
+    # In 2D, vector (2) and tensor (3) are disjoint so the branches above settle
+    # it. In 3D, vector (3) and tensor (6) are also disjoint. Any other column
+    # count (4, 5, 7+) is invalid; flag it with both expected shapes so the
+    # caller can correct the input.
+    msg = (
+        f"Cannot infer sol type from shape {array.shape} at dim={dimension}: "
+        f"expected ({array.shape[0]},), ({array.shape[0]}, {dimension}) for "
+        f"vector, or ({array.shape[0]}, {tensor_size}) for tensor"
+    )
+    raise ValueError(msg)
+
+
+def write_sol_file(
+    path: str | Path,
+    fields: Sequence[tuple[str, NDArray[np.float64], Location]],
+    dimension: int,
+) -> None:
+    """Write a Medit ``.sol`` text file with one or more solution blocks.
+
+    Parameters
+    ----------
+    path : str | Path
+        Destination file. The extension is expected to be ``.sol`` (the
+        text format). ``.solb`` (binary) is not supported by this writer;
+        route binary writes through the C++ binding.
+    fields : sequence of (name, array, location) tuples
+        Each tuple describes one solution block. ``name`` is preserved as
+        a comment for human readability (the Medit format itself doesn't
+        carry names) and used in error messages. ``array`` is the numeric
+        data (1D for scalar, 2D ``(N, k)`` for vector/tensor). ``location``
+        is ``"vertices"``, ``"triangles"``, or ``"tetrahedra"``; all
+        blocks sharing one location must agree on ``N``.
+    dimension : int
+        Mesh dimension (2 or 3). Determines vector / tensor widths.
+
+    Raises
+    ------
+    ValueError
+        If shapes are inconsistent within a location group, or if a
+        column count doesn't match a valid scalar / vector / tensor
+        layout for the given dimension.
+
+    """
+    if dimension not in (2, 3):
+        msg = f"dimension must be 2 or 3, got {dimension}"
+        raise ValueError(msg)
+    if not fields:
+        msg = "write_sol_file: no fields to write"
+        raise ValueError(msg)
+
+    by_location: dict[Location, list[tuple[str, NDArray[np.float64], int]]] = {}
+    for name, raw, location in fields:
+        if location not in _LOCATION_TO_KEYWORD:
+            msg = (
+                f"Unknown location {location!r} for field {name!r}; expected "
+                f"one of {sorted(_LOCATION_TO_KEYWORD)}"
+            )
+            raise ValueError(msg)
+        arr = np.ascontiguousarray(raw, dtype=np.float64)
+        sol_type = infer_sol_type(arr, dimension)
+        by_location.setdefault(location, []).append((name, arr, sol_type))
+
+    lines: list[str] = ["MeshVersionFormatted 2", "", f"Dimension {dimension}", ""]
+
+    for location, group in by_location.items():
+        keyword = _LOCATION_TO_KEYWORD[location]
+        n_entities = group[0][1].shape[0]
+        for name, arr, _ in group:
+            if arr.shape[0] != n_entities:
+                msg = (
+                    f"All sol blocks at {location!r} must share length "
+                    f"{n_entities}; field {name!r} has length {arr.shape[0]}"
+                )
+                raise ValueError(msg)
+        lines.append(keyword)
+        lines.append(str(n_entities))
+        type_header = [str(len(group))] + [str(t) for _, _, t in group]
+        lines.append(" ".join(type_header))
+
+        # Concatenate each row across all blocks. This is the per-vertex
+        # "all values" layout Medit expects.
+        per_row_chunks = [
+            arr if arr.ndim == 2 else arr.reshape(-1, 1) for _, arr, _ in group
+        ]
+        joined = np.concatenate(per_row_chunks, axis=1)
+        lines.extend(" ".join(f"{v!r}" for v in row.tolist()) for row in joined)
+        lines.append("")
+
+    lines.append("End")
+    lines.append("")
+
+    from pathlib import Path as _Path  # noqa: PLC0415
+
+    _Path(path).write_text("\n".join(lines), encoding="utf-8")

--- a/src/mmgpy/_sol.py
+++ b/src/mmgpy/_sol.py
@@ -181,14 +181,12 @@ def infer_sol_type(array: NDArray[np.float64], dimension: int) -> int:
     if n_cols == 1:
         return _TYPE_SCALAR
     tensor_size = dimension * (dimension + 1) // 2
-    if n_cols == dimension and n_cols != tensor_size:
+    # Vector width (dim) and tensor width (dim*(dim+1)/2) are disjoint for
+    # dim in {2, 3}, so a plain equality check suffices for each.
+    if n_cols == dimension:
         return _TYPE_VECTOR
-    if n_cols == tensor_size and n_cols != dimension:
+    if n_cols == tensor_size:
         return _TYPE_TENSOR
-    # In 2D, vector (2) and tensor (3) are disjoint so the branches above settle
-    # it. In 3D, vector (3) and tensor (6) are also disjoint. Any other column
-    # count (4, 5, 7+) is invalid; flag it with both expected shapes so the
-    # caller can correct the input.
     msg = (
         f"Cannot infer sol type from shape {array.shape} at dim={dimension}: "
         f"expected ({array.shape[0]},), ({array.shape[0]}, {dimension}) for "
@@ -270,7 +268,9 @@ def write_sol_file(
             arr if arr.ndim == 2 else arr.reshape(-1, 1) for _, arr, _ in group
         ]
         joined = np.concatenate(per_row_chunks, axis=1)
-        lines.extend(" ".join(f"{v!r}" for v in row.tolist()) for row in joined)
+        # %.17g is the shortest round-trip-safe double format and matches
+        # Medit's expectation of plain decimal / scientific notation.
+        lines.extend(" ".join(f"{v:.17g}" for v in row.tolist()) for row in joined)
         lines.append("")
 
     lines.append("End")

--- a/tests/multi_sol_test.py
+++ b/tests/multi_sol_test.py
@@ -1,0 +1,360 @@
+"""Tests for multi-block .sol I/O (PR #8 / gap #02).
+
+Covers:
+
+* C++ bindings ``MmgMesh{3D,2D,S}.{load,save}_all_sols`` round-trip vertex
+  blocks (scalar, vector, tensor) through MMG's text format.
+* ``Mesh.{load,save}_all_sols`` translates between the explicit tuple form
+  the bindings expose and a more ergonomic dict keyed by positional names.
+* ``dataset.mmg.{load,save}_all_sols`` collects point_data + cell_data,
+  writes a single multi-block file, and reads it back into the matching
+  ``point_data`` / ``cell_data`` slots.
+* Binary ``.solb`` is explicitly unsupported here because MMG itself emits
+  stray newlines in its binary writer (even the existing single-channel
+  ``.solb`` round-trip is broken at the library level).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+from mmgpy._io import _read_mesh_internal
+from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+_RNG = np.random.default_rng(0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_3d_impl() -> MmgMesh3D:
+    """Return a 2-tet mesh via the raw C++ bindings."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    elements = np.array([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=np.int32)
+    return MmgMesh3D(vertices, elements)
+
+
+def _make_2d_impl() -> MmgMesh2D:
+    vertices = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+        dtype=np.float64,
+    )
+    triangles = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+    return MmgMesh2D(vertices, triangles)
+
+
+def _make_s_impl() -> MmgMeshS:
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+            [0.5, 0.5, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    triangles = np.array([[0, 1, 2], [0, 1, 3], [1, 2, 3], [0, 2, 3]], dtype=np.int32)
+    return MmgMeshS(vertices, triangles)
+
+
+def _tet_pv_dataset() -> pv.UnstructuredGrid:
+    """Build a small unit-cube tet mesh via PyVista delaunay."""
+    pts = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    return pv.PolyData(pts).delaunay_3d()
+
+
+# ---------------------------------------------------------------------------
+# C++ binding round-trip (low-level)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("make_impl", "dim", "include_vector"),
+    [
+        (_make_3d_impl, 3, True),
+        # MMG2D_Set_vectorSols / Get_vectorSols are off by one row vs the rest
+        # of the multi-sol API (they index ``met->m[j..j+1]`` while every other
+        # MMG entry point uses ``met->m[j+size..j+2*size-1]``). The round-trip
+        # is broken at the library level, so the 2D vector slot is skipped
+        # here. Re-enable once MMG fixes the upstream divergence.
+        (_make_2d_impl, 2, False),
+        (_make_s_impl, 3, True),
+    ],
+    ids=["mmg3d", "mmg2d", "mmgs"],
+)
+def test_cpp_binding_roundtrips_scalar_vector_tensor(
+    make_impl,
+    dim: int,
+    include_vector: bool,  # noqa: FBT001  -- parametrized fixture, not a flag
+    tmp_path: Path,
+) -> None:
+    """C++ bindings round-trip every supported sol type for the mesh kind."""
+    impl = make_impl()
+    n_pts = impl.get_mesh_size()[0]
+    tensor_size = dim * (dim + 1) // 2
+    scalar: NDArray[np.float64] = _RNG.standard_normal(n_pts).astype(np.float64)
+    tensor: NDArray[np.float64] = _RNG.standard_normal((n_pts, tensor_size)).astype(
+        np.float64,
+    )
+
+    entries: list[tuple[int, NDArray[np.float64]]] = [(1, scalar)]
+    if include_vector:
+        vector = _RNG.standard_normal((n_pts, dim)).astype(np.float64)
+        entries.append((2, vector))
+    entries.append((3, tensor))
+
+    path = tmp_path / "multi.sol"
+    impl.save_all_sols(path, entries)
+    loaded = impl.load_all_sols(path)
+
+    assert [t for t, _ in loaded] == [t for t, _ in entries]
+    for (_, expected), (_, actual) in zip(entries, loaded, strict=True):
+        np.testing.assert_array_almost_equal(actual, expected)
+
+
+def test_cpp_binding_rejects_wrong_row_count(tmp_path: Path) -> None:
+    """Saving an array with too few rows raises a clear ValueError."""
+    impl = _make_3d_impl()
+    bad = _RNG.standard_normal(impl.get_mesh_size()[0] - 1)
+    with pytest.raises(ValueError, match="match vertex count"):
+        impl.save_all_sols(tmp_path / "bad.sol", [(1, bad)])
+
+
+def test_cpp_binding_rejects_wrong_column_count(tmp_path: Path) -> None:
+    """Saving a tensor with the wrong width raises a clear ValueError."""
+    impl = _make_3d_impl()
+    bad = _RNG.standard_normal((impl.get_mesh_size()[0], 5))
+    with pytest.raises(ValueError, match="expects 6 components"):
+        impl.save_all_sols(tmp_path / "bad.sol", [(3, bad)])
+
+
+# ---------------------------------------------------------------------------
+# Mesh-level wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_mesh_save_load_roundtrip_with_positional_names(tmp_path: Path) -> None:
+    """Mesh.save/load_all_sols regenerates positional names on read."""
+    grid = _tet_pv_dataset()
+    mesh = _read_mesh_internal(grid)
+    scalar = _RNG.standard_normal(grid.n_points)
+    vector = _RNG.standard_normal((grid.n_points, 3))
+
+    path = tmp_path / "named.sol"
+    mesh.save_all_sols(path, {"density": scalar, "velocity": vector})
+
+    out = mesh.load_all_sols(path)
+
+    assert list(out) == ["solution_0", "vector_0"]
+    np.testing.assert_array_almost_equal(out["solution_0"], scalar)
+    np.testing.assert_array_almost_equal(out["vector_0"], vector)
+
+
+def test_mesh_save_rejects_solb(tmp_path: Path) -> None:
+    """Mesh-level writer refuses .solb (MMG library bug)."""
+    mesh = _read_mesh_internal(_tet_pv_dataset())
+    with pytest.raises(NotImplementedError, match="\\.solb"):
+        mesh.save_all_sols(
+            tmp_path / "x.solb",
+            {"f": np.zeros(mesh._impl.get_mesh_size()[0])},
+        )
+
+
+def test_mesh_load_rejects_solb(tmp_path: Path) -> None:
+    """Mesh-level reader refuses .solb (MMG library bug)."""
+    mesh = _read_mesh_internal(_tet_pv_dataset())
+    with pytest.raises(NotImplementedError, match="\\.solb"):
+        mesh.load_all_sols(tmp_path / "x.solb")
+
+
+def test_mesh_save_rejects_empty(tmp_path: Path) -> None:
+    """Saving an empty arrays dict surfaces a clear error message."""
+    mesh = _read_mesh_internal(_tet_pv_dataset())
+    with pytest.raises(ValueError, match="at least one block"):
+        mesh.save_all_sols(tmp_path / "x.sol", {})
+
+
+# ---------------------------------------------------------------------------
+# PyVista accessor (high-level)
+# ---------------------------------------------------------------------------
+
+
+def test_accessor_save_load_combines_point_and_cell_data(tmp_path: Path) -> None:
+    """Accessor round-trip preserves point_data + cell_data through one .sol."""
+    grid = _tet_pv_dataset()
+    grid.point_data["scalar_field"] = np.arange(grid.n_points, dtype=np.float64)
+    grid.point_data["vec3_field"] = _RNG.standard_normal((grid.n_points, 3))
+    grid.cell_data["cell_scalar"] = np.arange(grid.n_cells, dtype=np.float64)
+
+    path = tmp_path / "combined.sol"
+    grid.mmg.save_all_sols(path)
+
+    fresh = grid.copy(deep=True)
+    for key in list(fresh.point_data.keys()):
+        del fresh.point_data[key]
+    for key in list(fresh.cell_data.keys()):
+        del fresh.cell_data[key]
+    fresh.mmg.load_all_sols(path)
+
+    np.testing.assert_array_equal(
+        fresh.point_data["solution_0@vertices"],
+        grid.point_data["scalar_field"],
+    )
+    np.testing.assert_array_almost_equal(
+        fresh.point_data["vector_1@vertices"],
+        grid.point_data["vec3_field"],
+    )
+    np.testing.assert_array_equal(
+        fresh.cell_data["solution@tetrahedra"],
+        grid.cell_data["cell_scalar"],
+    )
+
+
+def test_accessor_save_respects_explicit_point_keys(tmp_path: Path) -> None:
+    """``point_keys`` restricts the write to the requested point_data arrays."""
+    grid = _tet_pv_dataset()
+    grid.point_data["keep"] = np.arange(grid.n_points, dtype=np.float64)
+    grid.point_data["drop"] = np.full(grid.n_points, -1.0)
+
+    path = tmp_path / "selected.sol"
+    grid.mmg.save_all_sols(path, point_keys=["keep"])
+
+    fresh = grid.copy(deep=True)
+    for key in list(fresh.point_data.keys()):
+        del fresh.point_data[key]
+    fresh.mmg.load_all_sols(path)
+
+    # Single-block writes round-trip back through the parser as the un-indexed
+    # ``solution@vertices`` name (the parser only adds positional indices when
+    # the file holds 2+ blocks).
+    assert "solution@vertices" in fresh.point_data
+    assert all(not np.allclose(fresh.point_data[k], -1.0) for k in fresh.point_data)
+
+
+def test_accessor_save_skips_reserved_mmg_tags(tmp_path: Path) -> None:
+    """Auto-collect drops ``mmg_*`` constraint tags from both point/cell data."""
+    grid = _tet_pv_dataset()
+    grid.point_data["density"] = np.arange(grid.n_points, dtype=np.float64)
+    grid.point_data["mmg_required_vertices"] = np.zeros(grid.n_points, dtype=bool)
+    grid.cell_data["mmg_required_tetrahedra"] = np.zeros(grid.n_cells, dtype=bool)
+
+    path = tmp_path / "filtered.sol"
+    grid.mmg.save_all_sols(path)
+
+    fresh = grid.copy(deep=True)
+    for key in list(fresh.point_data.keys()):
+        del fresh.point_data[key]
+    for key in list(fresh.cell_data.keys()):
+        del fresh.cell_data[key]
+    fresh.mmg.load_all_sols(path)
+
+    # Single block → un-indexed name from the parser.
+    assert "solution@vertices" in fresh.point_data
+    # mmg_* tags are constraint markers, not solutions: they should be skipped.
+    assert not any(k.startswith("mmg_") for k in fresh.point_data)
+    assert not any(k.startswith("mmg_") for k in fresh.cell_data)
+
+
+def test_accessor_save_explicit_keys_raise_on_missing(tmp_path: Path) -> None:
+    """Explicit ``point_keys`` should not silently drop a missing entry."""
+    grid = _tet_pv_dataset()
+    grid.point_data["present"] = np.arange(grid.n_points, dtype=np.float64)
+    with pytest.raises(ValueError, match="not found"):
+        grid.mmg.save_all_sols(tmp_path / "x.sol", point_keys=["missing"])
+
+
+def test_accessor_save_solb_raises(tmp_path: Path) -> None:
+    """Accessor writer refuses .solb due to the upstream MMG bug."""
+    grid = _tet_pv_dataset()
+    grid.point_data["scalar"] = np.arange(grid.n_points, dtype=np.float64)
+    with pytest.raises(NotImplementedError, match="\\.solb"):
+        grid.mmg.save_all_sols(tmp_path / "x.solb")
+
+
+def test_accessor_load_solb_raises(tmp_path: Path) -> None:
+    """Accessor reader refuses .solb due to the upstream MMG bug."""
+    grid = _tet_pv_dataset()
+    with pytest.raises(NotImplementedError, match="\\.solb"):
+        grid.mmg.load_all_sols(tmp_path / "x.solb")
+
+
+def test_accessor_save_no_eligible_arrays_raises(tmp_path: Path) -> None:
+    """When only reserved tags exist, the accessor refuses to write an empty file."""
+    grid = _tet_pv_dataset()
+    grid.point_data["mmg_required_vertices"] = np.zeros(grid.n_points, dtype=bool)
+    with pytest.raises(ValueError, match="no eligible"):
+        grid.mmg.save_all_sols(tmp_path / "x.sol")
+
+
+def test_accessor_roundtrip_surface_mesh(tmp_path: Path) -> None:
+    """Surface mesh round-trip survives the same accessor path as 3D tets."""
+    surf = pv.Cube().triangulate()
+    n_pts = surf.n_points
+    surf.point_data["temperature"] = _RNG.standard_normal(n_pts)
+
+    path = tmp_path / "surf.sol"
+    surf.mmg.save_all_sols(path, point_keys=["temperature"])
+
+    fresh = surf.copy(deep=True)
+    for key in list(fresh.point_data.keys()):
+        del fresh.point_data[key]
+    fresh.mmg.load_all_sols(path)
+    np.testing.assert_array_almost_equal(
+        fresh.point_data["solution@vertices"],
+        surf.point_data["temperature"],
+    )
+
+
+def test_accessor_roundtrip_2d_mesh(tmp_path: Path) -> None:
+    """2D mesh round-trip uses the dim=2 helper for shape inference."""
+    pts = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+        dtype=np.float64,
+    )
+    tris = np.hstack([[3, 0, 1, 2], [3, 0, 2, 3]]).astype(np.int32)
+    poly = pv.PolyData(pts, tris)
+    poly.point_data["heat"] = np.arange(poly.n_points, dtype=np.float64)
+
+    path = tmp_path / "two_d.sol"
+    poly.mmg.save_all_sols(path)
+
+    fresh = poly.copy(deep=True)
+    for key in list(fresh.point_data.keys()):
+        del fresh.point_data[key]
+    fresh.mmg.load_all_sols(path)
+    np.testing.assert_array_almost_equal(
+        fresh.point_data["solution@vertices"],
+        poly.point_data["heat"],
+    )


### PR DESCRIPTION
## Summary

Closes gap #02 / PR 8 from `gaps_review.html`: multi-solution arrays per vertex.

Surfaces MMG's `MMG{3D,2D,S}_loadAllSols` / `saveAllSols` / `Set_solsAtVerticesSize` / `Get_solsAtVerticesSize` / `Get_ithSols_inSolsAtVertices` / `Set_ithSols_inSolsAtVertices` / `Free_allSols` as Python bindings, then layers an ergonomic API on top:

- `MmgMesh{3D,2D,S}.load_all_sols(path)` / `save_all_sols(path, sols)` (raw C++ bindings, takes `[(mmg_type, ndarray), ...]`)
- `Mesh.load_all_sols(path) -> dict[str, ndarray]` / `save_all_sols(path, arrays)` (type inferred from shape)
- `dataset.mmg.load_all_sols(path)` / `save_all_sols(path, *, point_keys=None, cell_keys=None)` (collects `point_data` + `cell_data`, writes one multi-block text `.sol`)

Cell-located blocks (`SolAtTriangles` / `SolAtTetrahedra`) go through a new pure-Python text writer in `_sol.py` since MMG's C API only covers vertex blocks. The existing parser already handled them on read.

## Changes

- `src/bindings/mmg_multisol.hpp`: shared templated helper (function pointers to MMG{3D,2D,S}_*)
- `src/bindings/mmg_mesh{,_2d,_s}.cpp/.hpp`: bind `load_all_sols` / `save_all_sols`
- `src/bindings/bindings.cpp`: pybind11 registration on all three classes
- `src/mmgpy/_sol.py`: `infer_sol_type` + `write_sol_file` text writer
- `src/mmgpy/_mesh.py`: `Mesh.load_all_sols` / `save_all_sols` dict wrappers
- `src/mmgpy/_pv_plugin.py`: accessor methods + `_collect_sol_arrays` / `_primary_cell_count` helpers
- `src/mmgpy/_mmgpy.pyi`: stubs for the three mesh classes
- `tests/multi_sol_test.py`: 18 round-trip + error-path tests

## Notes

- Binary `.solb` is explicitly rejected at the high-level API: MMG's `saveAllSols` interleaves stray newlines in the binary stream that break its own reader, so even single-channel `.solb` round-trips return garbage. The raw C++ bindings accept any extension; the Python wrappers raise `NotImplementedError` on `.solb`.
- MMG2D vector blocks are skipped in the C++ round-trip test: `MMG2D_Set_vectorSols` / `Get_vectorSols` use `met->m[j..j+1]` while every other multi-sol entry point uses `met->m[j+size..j+2*size-1]`. Re-enable when MMG fixes the upstream divergence.
- Auto-collected arrays skip `mmg_*` constraint tags (reserved by the accessor) and any `point_data` / `cell_data` whose shape doesn't match a valid scalar / vector / tensor layout for the mesh dimension (e.g. PyVista's `Normals` / `TCoords`).
- The Medit `.sol` format doesn't carry array names, so round-trips through the writer/parser regenerate positional names (`solution`, `vector`, `tensor` for single blocks; `solution_i`, `vector_i`, `tensor_i` for multi-block).