### PR TITLE
enable aniso build_size_map on surface meshes via MMGS_analys

### DIFF
--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -610,12 +610,17 @@ PYBIND11_MODULE(_mmgpy, m) {
            "Build a size map from the edges incident to each vertex (wraps "
            "MMGS_doSol).\n\n"
            "Populates the mesh metric channel and returns it as a NumPy "
-           "array of shape (N, 1).\n\n"
+           "array.\n\n"
            "Args:\n"
-           "    aniso: Not implemented for surface meshes "
-           "(``MMGS_doSol_ani`` requires a pre-analyzed mesh). Raises a "
-           "RuntimeError if True; use MmgMesh3D or MmgMesh2D for the "
-           "anisotropic mesh-implied metric.")
+           "    aniso: If False (default), build an isotropic size map "
+           "from the mean incident edge length (shape (N, 1)). If True, "
+           "build the anisotropic mesh-implied metric tensor (shape (N, 6), "
+           "components [m11, m12, m13, m22, m23, m33]). The aniso path "
+           "first runs MMGS_analys to populate ridges, normals and "
+           "manifold tags; any subsequent remesh would have run analys "
+           "anyway, so this only changes the timing of work that would "
+           "have happened. Not supported on Windows: the underlying "
+           "MMGS_analys symbol is not exported from libmmgs.dll.")
       .def("clean_iso_surface", &MmgMeshS::clean_iso_surface,
            "Remove isolated triangles / edges left after a level-set "
            "discretization (wraps MMGS_Clean_isoSurf).");

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -9,6 +9,18 @@
 #include <cmath>
 #endif
 
+#ifndef _WIN32
+// MMGS_analys is declared in libmmgs_private.h, which is not in the installed
+// public headers, but the symbol has default visibility in the .so on Linux
+// and macOS (verified via nm). Forward-declare here so we can call it without
+// pulling in the private header. Required for surface anisotropic doSol,
+// which dispatches through MMGS_setfunc and needs the mesh to be analyzed
+// (ridges, normals, manifold tags) first. On Windows the symbol lacks
+// __declspec(dllexport) in MMG's build, so the aniso surface path stays
+// disabled there.
+extern "C" int MMGS_analys(MMG5_pMesh mesh);
+#endif
+
 namespace {
 
 // Wrapper for MMGS_Get_triangleQuality.
@@ -1127,31 +1139,57 @@ py::dict MmgMeshS::remesh_levelset(const py::array_t<double> &levelset,
 py::array_t<double> MmgMeshS::build_size_map(bool aniso) {
   check_not_corrupted("build_size_map");
 
+#ifdef _WIN32
   if (aniso) {
-    // MMGS_doSol_ani needs the surface mesh to have been analyzed
-    // (ridges, normals, manifold tags), which MMGS_analys does as part
-    // of remeshing entry points. We do not run analys from here because
-    // it mutates the mesh state in ways callers may not expect. Use the
-    // volumetric or 2D variants for now, or run a full remesh.
+    // MMGS_analys is not exported from libmmgs.dll (missing
+    // __declspec(dllexport) on MMG's side), so we cannot prepare the surface
+    // for the aniso dispatch on Windows. Same family of issue as the
+    // get_triangle_quality workaround above. Keep the explicit failure here
+    // so users get a clear message rather than a link-time crash.
     throw std::runtime_error(
         "build_size_map(aniso=True) is not implemented for surface meshes "
-        "(MMGS_doSol_ani requires a pre-analyzed mesh).");
+        "on Windows (MMGS_analys is not exported from libmmgs.dll).");
   }
+#endif
 
   // MMGS_doSol is a function pointer initialized by MMGS_setfunc, which
-  // dispatches on mesh->info.ani and met->size. Clear info.ani so a prior
-  // anisosize toggle elsewhere does not cause MMGS_setfunc to pick the aniso
-  // entry point against a scalar buffer.
-  if (!MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_anisosize, 0)) {
+  // dispatches on mesh->info.ani and met->size. Set info.ani to the
+  // requested mode and resize the metric buffer to match before letting
+  // setfunc pick the iso or aniso entry point.
+  if (!MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_anisosize, aniso ? 1 : 0)) {
     throw std::runtime_error(
-        "Failed to clear MMGS_IPARAM_anisosize for build_size_map");
+        "Failed to set MMGS_IPARAM_anisosize for build_size_map");
   }
   // Set_solSize frees and re-allocates the buffer, so skip it on the fast
-  // path where the channel is already scalar.
-  if (met->size != 1 &&
-      !MMGS_Set_solSize(mesh, met, MMG5_Vertex, mesh->np, MMG5_Scalar)) {
+  // path where the channel already matches the requested mode.
+  const int target_size = aniso ? 6 : 1;
+  if (met->size != target_size &&
+      !MMGS_Set_solSize(mesh, met, MMG5_Vertex, mesh->np,
+                        aniso ? MMG5_Tensor : MMG5_Scalar)) {
     throw std::runtime_error("Failed to resize metric for build_size_map");
   }
+
+#ifndef _WIN32
+  if (aniso) {
+    // MMGS_doSol_ani reads ridge tags, normals and manifold flags off the
+    // mesh, all of which are populated by MMGS_analys. The expensive part
+    // (vertex normal computation in norver) is guarded by !mesh->xp inside
+    // MMG, so calling analys again on an already-analyzed mesh short-
+    // circuits the heavy work. Any later remesh would also call analys
+    // internally, so running it here only changes the timing of work that
+    // would have happened anyway.
+    int ret_analys;
+    {
+      py::gil_scoped_release release;
+      ret_analys = MMGS_analys(mesh);
+    }
+    if (ret_analys != 1) {
+      throw std::runtime_error(
+          "MMGS_analys failed; cannot build anisotropic size map");
+    }
+  }
+#endif
+
   MMGS_setfunc(mesh, met);
   if (MMGS_doSol == nullptr) {
     throw std::runtime_error(

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -2895,14 +2895,20 @@ class MmgMeshS:
         """Build a size map from edges incident to each vertex.
 
         Wraps ``MMGS_doSol``. Populates the mesh metric channel and
-        returns the result as a NumPy array of shape ``(n_vertices, 1)``.
+        returns the result as a NumPy array.
 
         Args:
-            aniso: Not implemented for surface meshes
-                (``MMGS_doSol_ani`` requires a pre-analyzed mesh).
-                Raises ``RuntimeError`` if True. Use :class:`MmgMesh3D`
-                or :class:`MmgMesh2D` for the anisotropic mesh-implied
-                metric.
+            aniso: If ``False`` (default), build an isotropic size map
+                from the mean incident edge length (shape
+                ``(n_vertices, 1)``). If ``True``, build the anisotropic
+                mesh-implied metric tensor (shape ``(n_vertices, 6)``,
+                components ``[m11, m12, m13, m22, m23, m33]``). The
+                aniso path runs ``MMGS_analys`` first to populate
+                ridges, normals and manifold tags; any later remesh
+                would have run analys anyway, so this only changes
+                timing. Raises ``RuntimeError`` on Windows: the
+                underlying ``MMGS_analys`` symbol is not exported from
+                ``libmmgs.dll``.
 
         """
 

--- a/tests/dosol_test.py
+++ b/tests/dosol_test.py
@@ -9,6 +9,8 @@ equivalent).
 
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import pytest
 import pyvista as pv
@@ -17,6 +19,14 @@ import mmgpy  # noqa: F401  -- registers the .mmg accessor
 from mmgpy._mesh import Mesh
 from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 from mmgpy.metrics import validate_metric_tensor
+
+# MMGS_analys is not exported from libmmgs.dll on Windows, so the surface
+# aniso path stays disabled there. Skip those tests instead of running them.
+_SURFACE_ANISO_UNSUPPORTED = sys.platform == "win32"
+_skip_if_no_surface_aniso = pytest.mark.skipif(
+    _SURFACE_ANISO_UNSUPPORTED,
+    reason="MMGS_analys is not exported from libmmgs.dll on Windows",
+)
 
 
 class TestBuildSizeMap3D:
@@ -191,18 +201,84 @@ class TestBuildSizeMapAniso2D:
         assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
 
 
+@_skip_if_no_surface_aniso
 class TestBuildSizeMapAnisoSurface:
-    """``aniso=True`` raises on surface meshes.
+    """Tests for ``MmgMeshS.build_size_map(aniso=True)``.
 
-    ``MMGS_doSol_ani`` needs an analyzed mesh, which is not part of the
-    lightweight ``build_size_map`` contract.
+    The surface aniso path runs ``MMGS_analys`` to populate ridges,
+    normals and manifold tags before invoking ``MMGS_doSol_ani``. The
+    expensive part (vertex normals) is cached on ``mesh->xp`` inside
+    MMG, so a later remesh would not redo it.
     """
 
-    def test_aniso_raises_on_surface(
+    def test_returns_spd_tensor_per_vertex(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
-        """Surface ``build_size_map(aniso=True)`` is not implemented yet."""
+        """Anisotropic ``doSol`` returns ``(N, 6)`` SPD tensors on surfaces."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        metric = mesh.build_size_map(aniso=True)
+
+        assert metric.shape == (len(vertices), 6)
+        assert metric.dtype == np.float64
+        assert np.all(np.isfinite(metric))
+        assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
+
+    def test_populates_tensor_channel(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """The returned tensor is also written to the mesh tensor channel."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        metric = mesh.build_size_map(aniso=True)
+        stored = mesh.get_field("tensor")
+
+        np.testing.assert_array_equal(metric, stored)
+
+    def test_repeat_call_is_idempotent(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Calling aniso twice should yield the same tensor and not corrupt state."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        first = mesh.build_size_map(aniso=True)
+        second = mesh.build_size_map(aniso=True)
+
+        np.testing.assert_array_equal(first, second)
+
+    def test_scaling_metric_refines_mesh(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Multiplying the metric by c > 1 should refine the surface on remesh."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        metric = mesh.build_size_map(aniso=True)
+        mesh.set_field("tensor", metric * 4.0)  # halve target edge length
+        mesh.remesh(verbose=-1)
+
+        assert mesh.get_vertices().shape[0] > len(vertices)
+
+
+@pytest.mark.skipif(
+    not _SURFACE_ANISO_UNSUPPORTED,
+    reason="Windows-only: verifies the explicit RuntimeError stays in place",
+)
+class TestBuildSizeMapAnisoSurfaceWindows:
+    """On Windows, the surface aniso path still raises with a clear message."""
+
+    def test_aniso_raises_on_windows(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """``aniso=True`` raises until MMG exports ``MMGS_analys`` on Windows."""
         vertices, triangles = tetrahedron_surface_mesh
         mesh = MmgMeshS(vertices, triangles)
 
@@ -234,6 +310,36 @@ class TestBuildSizeMapAnisoToggle:
         """Calling ``aniso=True`` then ``aniso=False`` shrinks the channel."""
         vertices, elements = dense_3d_mesh
         mesh = MmgMesh3D(vertices, elements)
+
+        aniso = mesh.build_size_map(aniso=True)
+        assert aniso.shape == (len(vertices), 6)
+
+        iso = mesh.build_size_map(aniso=False)
+        assert iso.shape == (len(vertices), 1)
+
+    @_skip_if_no_surface_aniso
+    def test_iso_then_aniso_surface(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Surface: iso then aniso resizes the channel without state leaks."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        iso = mesh.build_size_map(aniso=False)
+        assert iso.shape == (len(vertices), 1)
+
+        aniso = mesh.build_size_map(aniso=True)
+        assert aniso.shape == (len(vertices), 6)
+
+    @_skip_if_no_surface_aniso
+    def test_aniso_then_iso_surface(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Surface: aniso then iso shrinks the channel back."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
 
         aniso = mesh.build_size_map(aniso=True)
         assert aniso.shape == (len(vertices), 6)
@@ -323,6 +429,20 @@ class TestMeshWrapper:
         assert metric.shape == (len(vertices), 6)
         assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
 
+    @_skip_if_no_surface_aniso
+    def test_build_size_map_surface_aniso(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """High-level wrapper forwards ``aniso`` for surface meshes too."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = Mesh(vertices, triangles)
+
+        metric = mesh.build_size_map(aniso=True)
+
+        assert metric.shape == (len(vertices), 6)
+        assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
+
     def test_clean_iso_surface_rejects_2d(
         self,
         square_mesh: tuple[np.ndarray, np.ndarray],
@@ -381,6 +501,22 @@ class TestPyVistaAccessor:
             ug.point_data["metric"],
             sizes.ravel(),
         )
+
+    @_skip_if_no_surface_aniso
+    def test_build_size_map_surface_aniso_via_polydata(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Accessor routes a triangular ``PolyData`` to ``MmgMeshS`` aniso."""
+        vertices, triangles = tetrahedron_surface_mesh
+        poly = pv.PolyData.from_regular_faces(vertices, triangles)
+
+        metric = poly.mmg.build_size_map(aniso=True)
+
+        assert metric.shape == (poly.n_points, 6)
+        assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
+        # Aniso result is stored as a 2D array on point_data, not flattened.
+        np.testing.assert_array_equal(poly.point_data["metric"], metric)
 
     def test_clean_iso_surface_returns_fresh_dataset(
         self,


### PR DESCRIPTION
## Summary
- Surface `MmgMeshS.build_size_map(aniso=True)` now returns `(N, 6)` SPD tensors instead of raising
- Runs `MMGS_analys` before `MMGS_doSol_ani` to populate ridges, normals and manifold tags
- Windows path still raises (MMGS_analys missing `LIBMMGS_EXPORT` in libmmgs.dll)

## Changes
- `src/bindings/mmg_mesh_s.cpp`: forward-declare `MMGS_analys`; call it on POSIX before the aniso `doSol` dispatch; mirror the iso/aniso resize logic from the 3D version
- `src/bindings/bindings.cpp`, `src/mmgpy/_mmgpy.pyi`: docstrings reflect the new aniso surface contract
- `tests/dosol_test.py`: replace the "aniso raises" test with shape/SPD/idempotency/round-trip coverage; mirror the toggle and high-level/accessor tests for surfaces; Windows path keeps the explicit RuntimeError check

## Notes
- `MMGS_analys` is in `libmmgs_private.h` but has default visibility in the `.so`; forward-declared to avoid pulling in the private header
- Idempotent: MMG's `norver` is guarded by `!mesh->xp`, so repeat calls and any later remesh short-circuit the expensive part