### PR TITLE
surface multiMat / localParameter / lsBaseReference on Mesh + .mmg accessor

### DIFF
--- a/examples/mmg3d/multi_material_levelset.py
+++ b/examples/mmg3d/multi_material_levelset.py
@@ -1,0 +1,147 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "mmgpy",
+#     "numpy",
+#     "pyvista",
+# ]
+#
+# [tool.uv.sources]
+# mmgpy = { path = "../.." }
+# ///
+"""Multi-material level-set discretization with custom output references.
+
+Demonstrates ``dataset.mmg.set_multi_materials(...)`` on the PyVista
+accessor: the level-set defines a sphere inside a unit cube, and the
+multi-material configuration assigns custom references on each side of
+the interface instead of MMG's default ``ref=2`` / ``ref=3``.
+
+Pipeline:
+
+1. Build a dense tetrahedral background mesh of the unit cube.
+2. Define a sphere signed distance field at every vertex.
+3. Configure multi-material output references via
+   ``dataset.mmg.set_multi_materials(...)``: ``ref_minus`` for elements
+   inside the sphere, ``ref_plus`` for elements outside.
+4. Run ``dataset.mmg.remesh_levelset(...)``.
+
+Run with::
+
+    uv run python examples/mmg3d/multi_material_levelset.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyvista as pv
+
+import mmgpy  # noqa: F401  -- registers the .mmg accessor
+
+# Custom output references picked far from MMG's defaults (2, 3) so the
+# effect of set_multi_materials() is unambiguous in the output.
+REF_INTERIOR = 42
+REF_EXTERIOR = 17
+
+
+def background_mesh(resolution: int = 8) -> pv.UnstructuredGrid:
+    """Dense tetrahedralization of the unit cube via Delaunay on a regular grid."""
+    x = np.linspace(0.0, 1.0, resolution)
+    grid = np.stack(np.meshgrid(x, x, x, indexing="ij"), axis=-1).reshape(-1, 3)
+    return pv.PolyData(grid).delaunay_3d()
+
+
+def sphere_sdf(
+    vertices: np.ndarray,
+    center: tuple[float, float, float],
+    radius: float,
+) -> np.ndarray:
+    """Signed-distance to a sphere; negative inside, positive outside."""
+    return (np.linalg.norm(vertices - np.asarray(center), axis=1) - radius).reshape(
+        -1,
+        1,
+    )
+
+
+def main() -> None:
+    """Run the multi-material level-set discretization demo."""
+    print("Building background mesh...")
+    dataset = background_mesh(resolution=10)
+    print(f"  {dataset.n_points} vertices, {dataset.n_cells} tetrahedra")
+
+    vertices = np.asarray(dataset.points, dtype=np.float64)
+    levelset = sphere_sdf(vertices, center=(0.5, 0.5, 0.5), radius=0.3)
+
+    # MMG's default behavior assigns ref=2 (exterior) and ref=3 (interior)
+    # to elements on either side of the zero isosurface. ``set_multi_materials``
+    # lets us pick the output references instead — useful when downstream
+    # code already encodes materials with specific reference numbers.
+    print(
+        "\nConfiguring multi-material output: "
+        f"ref_minus={REF_INTERIOR} (inside sphere), "
+        f"ref_plus={REF_EXTERIOR} (outside sphere)",
+    )
+    dataset.mmg.set_multi_materials(
+        [
+            {
+                "ref": 0,  # the input ref to split
+                "split": True,
+                "ref_minus": REF_INTERIOR,
+                "ref_plus": REF_EXTERIOR,
+            },
+        ],
+    )
+
+    print("\nRunning level-set discretization...")
+    result = dataset.mmg.remesh_levelset(
+        levelset,
+        ls=0.0,
+        hmax=0.08,
+        hausd=0.005,
+        hgrad=1.3,
+        verbose=False,
+    )
+
+    refs = np.asarray(result.cell_data["refs"])
+    unique, counts = np.unique(refs, return_counts=True)
+    counts_by_ref = dict(zip(unique.tolist(), counts.tolist(), strict=True))
+    print(f"\nOutput element refs: {counts_by_ref}")
+    if REF_INTERIOR not in unique or REF_EXTERIOR not in unique:
+        msg = (
+            f"expected custom refs {REF_INTERIOR}/{REF_EXTERIOR} in output, "
+            f"got {sorted(unique.tolist())}"
+        )
+        raise RuntimeError(msg)
+
+    pl = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
+
+    pl.subplot(0, 0)
+    interior = result.extract_cells(np.where(refs == REF_INTERIOR)[0])
+    pl.add_mesh(
+        interior,
+        show_edges=True,
+        color="coral",
+        edge_color="darkred",
+        line_width=0.4,
+    )
+    pl.add_title(f"Interior (ref={REF_INTERIOR})\n{interior.n_cells} tetrahedra")
+
+    pl.subplot(0, 1)
+    centers = result.cell_centers().points
+    half = result.extract_cells(np.where(centers[:, 0] < 0.5)[0])
+    pl.add_mesh(
+        half,
+        scalars="refs",
+        show_edges=True,
+        cmap=["coral", "steelblue"],
+        edge_color="black",
+        line_width=0.4,
+    )
+    pl.add_title(f"Cut view by ref\n{half.n_cells} tetrahedra")
+
+    pl.link_views()
+    pl.camera_position = [(2.5, 2.0, 1.6), (0.5, 0.5, 0.5), (0, 0, 1)]
+    pl.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -453,10 +453,21 @@ def _normalize_multi_materials(
         if missing:
             msg = f"materials[{i}] missing keys: {missing}"
             raise ValueError(msg)
+        split_raw = raw["split"]
+        if not isinstance(split_raw, (bool, int)) or isinstance(split_raw, float):
+            msg = (
+                f"materials[{i}]['split'] must be bool or int (0/1), "
+                f"got {type(split_raw).__name__}"
+            )
+            raise ValueError(msg)  # noqa: TRY004
+        split = int(split_raw)
+        if split not in (0, 1):
+            msg = f"materials[{i}]['split'] must be 0 or 1, got {split}"
+            raise ValueError(msg)
         normalized.append(
             {
                 "ref": int(raw["ref"]),
-                "split": int(bool(raw["split"])),
+                "split": split,
                 "ref_minus": int(raw["ref_minus"]),
                 "ref_plus": int(raw["ref_plus"]),
             },
@@ -2387,7 +2398,8 @@ class Mesh:
               level-set; ``False`` / ``0`` to leave it unsplit.
             - ``"ref_minus"`` / ``"ref_plus"``: output references for the
               negative and positive sides of the level-set inside this
-              material. Ignored when ``split`` is false.
+              material. Required keys (use ``0`` as a placeholder when
+              ``split`` is false; the values are then ignored by MMG).
 
         Raises
         ------

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -12,6 +12,7 @@ dataset instead.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Mapping
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
@@ -388,6 +389,91 @@ def _create_impl(  # noqa: PLR0913
     if edges_arr is not None:
         impl.set_edges(edges_arr, e_refs)
     return impl
+
+
+_LOCAL_PARAM_KEYS = ("type", "ref", "hmin", "hmax", "hausd")
+_VALID_ENTITY_TYPES_3D = frozenset({"vertex", "edge", "triangle", "tetrahedron"})
+_VALID_ENTITY_TYPES_2D_S = frozenset({"vertex", "edge", "triangle"})
+_MULTI_MATERIAL_KEYS = ("ref", "split", "ref_minus", "ref_plus")
+
+
+def _normalize_local_parameters(
+    parameters: Sequence[Mapping[str, Any]],
+    kind: MeshKind,
+) -> list[dict[str, Any]]:
+    """Validate local-parameter specs at the Python boundary.
+
+    The binding raises a generic ``RuntimeError`` deep in MMG for malformed
+    input; routing through this helper turns shape errors into a clear
+    ``ValueError`` before the C call.
+    """
+    valid_types = (
+        _VALID_ENTITY_TYPES_3D
+        if kind == MeshKind.TETRAHEDRAL
+        else _VALID_ENTITY_TYPES_2D_S
+    )
+    normalized: list[dict[str, Any]] = []
+    for i, raw in enumerate(parameters):
+        if not isinstance(raw, Mapping):
+            msg = f"parameters[{i}] must be a mapping, got {type(raw).__name__}"
+            raise ValueError(msg)  # noqa: TRY004
+        missing = [k for k in _LOCAL_PARAM_KEYS if k not in raw]
+        if missing:
+            msg = f"parameters[{i}] missing keys: {missing}"
+            raise ValueError(msg)
+        type_str = str(raw["type"])
+        if type_str not in valid_types:
+            msg = (
+                f"parameters[{i}]['type'] must be one of "
+                f"{sorted(valid_types)}, got {type_str!r}"
+            )
+            raise ValueError(msg)
+        normalized.append(
+            {
+                "type": type_str,
+                "ref": int(raw["ref"]),
+                "hmin": float(raw["hmin"]),
+                "hmax": float(raw["hmax"]),
+                "hausd": float(raw["hausd"]),
+            },
+        )
+    return normalized
+
+
+def _normalize_multi_materials(
+    materials: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Validate multi-material specs at the Python boundary."""
+    normalized: list[dict[str, Any]] = []
+    for i, raw in enumerate(materials):
+        if not isinstance(raw, Mapping):
+            msg = f"materials[{i}] must be a mapping, got {type(raw).__name__}"
+            raise ValueError(msg)  # noqa: TRY004
+        missing = [k for k in _MULTI_MATERIAL_KEYS if k not in raw]
+        if missing:
+            msg = f"materials[{i}] missing keys: {missing}"
+            raise ValueError(msg)
+        normalized.append(
+            {
+                "ref": int(raw["ref"]),
+                "split": int(bool(raw["split"])),
+                "ref_minus": int(raw["ref_minus"]),
+                "ref_plus": int(raw["ref_plus"]),
+            },
+        )
+    return normalized
+
+
+def _normalize_ls_base_references(references: Sequence[int]) -> list[int]:
+    """Validate LS base reference list at the Python boundary."""
+    normalized: list[int] = []
+    for i, raw in enumerate(references):
+        try:
+            normalized.append(int(raw))
+        except (TypeError, ValueError) as exc:  # noqa: PERF203
+            msg = f"references[{i}] is not an integer: {raw!r}"
+            raise ValueError(msg) from exc
+    return normalized
 
 
 class Mesh:
@@ -2240,6 +2326,101 @@ class Mesh:
 
         # apply_sizing_constraints expects a mesh object and sets the field directly
         apply_sizing_constraints(self._impl, self._sizing_constraints)
+
+    # =========================================================================
+    # Multi-material / local parameters / level-set base references
+    # =========================================================================
+
+    def set_local_parameters(
+        self,
+        parameters: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Set region-specific sizing parameters per reference.
+
+        Wraps ``MMG{3D,2D,S}_Set_localParameter``. Each entry overrides the
+        global ``hmin`` / ``hmax`` / ``hausd`` for entities carrying the
+        matching reference, so the next ``remesh()`` call refines or
+        coarsens that region differently from the rest of the mesh.
+
+        Parameters
+        ----------
+        parameters : sequence of dict
+            Each dict must carry:
+
+            - ``"type"``: ``"vertex"``, ``"edge"``, ``"triangle"``, or
+              ``"tetrahedron"`` (the latter only valid on 3D meshes).
+            - ``"ref"``: reference number to target.
+            - ``"hmin"`` / ``"hmax"``: local sizing bounds.
+            - ``"hausd"``: local Hausdorff distance.
+
+        Raises
+        ------
+        ValueError
+            If any entry is missing a required key, has the wrong type, or
+            uses an entity type incompatible with this mesh's kind.
+
+        """
+        normalized = _normalize_local_parameters(parameters, self._kind)
+        # The stub types this as list[LocalParameter] (a TypedDict); our
+        # normalized dicts satisfy the same shape, only with broader value
+        # types. Cast to silence mypy without losing the runtime check.
+        self._impl.set_local_parameters(cast("list[Any]", normalized))
+
+    def set_multi_materials(
+        self,
+        materials: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Configure multi-material discretization for level-set remeshing.
+
+        Wraps ``MMG{3D,2D,S}_Set_multiMat``. Used together with
+        ``remesh_levelset()`` to discretize an interface that separates more
+        than two materials: each material specifies which interior reference
+        gets assigned to its negative and positive sides.
+
+        Parameters
+        ----------
+        materials : sequence of dict
+            Each dict must carry:
+
+            - ``"ref"``: material reference number on the input mesh.
+            - ``"split"``: ``True`` / ``1`` to split this material along the
+              level-set; ``False`` / ``0`` to leave it unsplit.
+            - ``"ref_minus"`` / ``"ref_plus"``: output references for the
+              negative and positive sides of the level-set inside this
+              material. Ignored when ``split`` is false.
+
+        Raises
+        ------
+        ValueError
+            If any entry is missing a required key or has the wrong type.
+
+        """
+        normalized = _normalize_multi_materials(materials)
+        self._impl.set_multi_materials(normalized)
+
+    def set_ls_base_references(
+        self,
+        references: Sequence[int],
+    ) -> None:
+        """Restrict level-set discretization to a subset of references.
+
+        Wraps ``MMG{3D,2D,S}_Set_lsBaseReference``. Only the references in
+        the list are eligible for splitting along the level-set during the
+        next ``remesh_levelset()`` call; all others are preserved as-is.
+
+        Parameters
+        ----------
+        references : sequence of int
+            Reference numbers eligible for level-set splitting.
+
+        Raises
+        ------
+        ValueError
+            If any entry cannot be coerced to an integer.
+
+        """
+        normalized = _normalize_ls_base_references(references)
+        self._impl.set_ls_base_references(normalized)
 
     # =========================================================================
     # PyVista conversion

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -29,7 +29,7 @@ import numpy as np
 import pyvista as pv
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
     from typing import TypeGuard
 
     from numpy.typing import NDArray
@@ -425,6 +425,34 @@ def _apply_constraint_markers(
             )
             raise ValueError(msg)
         setter(idx)
+
+
+_MMG_CONFIG_KEY_MULTI_MATERIALS = "mmg_multi_materials"
+_MMG_CONFIG_KEY_LOCAL_PARAMETERS = "mmg_local_parameters"
+_MMG_CONFIG_KEY_LS_BASE_REFERENCES = "mmg_ls_base_references"
+
+
+def _apply_pending_mmg_config(
+    mesh: _Mesh,
+    dataset: pv.UnstructuredGrid | pv.PolyData,
+) -> None:
+    """Push multi-material / local-parameter / LS config from user_dict into MMG.
+
+    The accessor methods ``set_multi_materials`` / ``set_local_parameters`` /
+    ``set_ls_base_references`` stash their specs in ``dataset.user_dict`` so
+    the configuration survives the fresh ``Mesh`` built on every accessor
+    call. This helper transfers them into the C++ side before remeshing.
+    """
+    user_dict = dataset.user_dict
+    materials = user_dict.get(_MMG_CONFIG_KEY_MULTI_MATERIALS)
+    if materials:
+        mesh.set_multi_materials(list(materials))
+    parameters = user_dict.get(_MMG_CONFIG_KEY_LOCAL_PARAMETERS)
+    if parameters:
+        mesh.set_local_parameters(list(parameters))
+    references = user_dict.get(_MMG_CONFIG_KEY_LS_BASE_REFERENCES)
+    if references:
+        mesh.set_ls_base_references(list(references))
 
 
 def _apply_local_sizing_specs(
@@ -845,6 +873,7 @@ class MmgAccessor:
             )
         _apply_constraint_markers(mesh, self._dataset, constraints)
         _apply_local_sizing_specs(mesh, local_sizing)
+        _apply_pending_mmg_config(mesh, self._dataset)
         # ``renum`` is popped + handled inside ``Mesh.remesh`` (one-time
         # FutureWarning + in-place reverse Cuthill-McKee). Forwarding it
         # through here keeps the PyVista-side path single-pass.
@@ -907,6 +936,7 @@ class MmgAccessor:
         mesh = _build_mesh_with_mmg_fields(self._dataset)
         _apply_constraint_markers(mesh, self._dataset, constraints)
         _apply_local_sizing_specs(mesh, local_sizing)
+        _apply_pending_mmg_config(mesh, self._dataset)
         mesh.remesh_levelset(levelset, **options)
         return _to_pyvista_with_user_fields(mesh)
 
@@ -923,6 +953,7 @@ class MmgAccessor:
         constraints = _split_constraint_kwargs(options)
         mesh = _build_mesh_with_mmg_fields(self._dataset)
         _apply_constraint_markers(mesh, self._dataset, constraints)
+        _apply_pending_mmg_config(mesh, self._dataset)
         mesh.remesh_optimize(**options)
         return _to_pyvista_with_user_fields(mesh)
 
@@ -945,6 +976,7 @@ class MmgAccessor:
         constraints = _split_constraint_kwargs(options)
         mesh = _build_mesh_with_mmg_fields(self._dataset)
         _apply_constraint_markers(mesh, self._dataset, constraints)
+        _apply_pending_mmg_config(mesh, self._dataset)
         mesh.remesh_uniform(size, **options)
         return _to_pyvista_with_user_fields(mesh)
 
@@ -1006,6 +1038,61 @@ class MmgAccessor:
             **remesh_options,
         )
         return _to_pyvista_with_user_fields(mesh)
+
+    def set_local_parameters(
+        self,
+        parameters: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Stash region-specific sizing parameters for the next ``remesh()``.
+
+        Mirrors :meth:`mmgpy.Mesh.set_local_parameters`. The spec list is
+        stored in ``dataset.user_dict["mmg_local_parameters"]`` and applied
+        to the underlying ``MmgMesh`` at the start of every subsequent
+        ``remesh`` / ``remesh_levelset`` / ``remesh_optimize`` /
+        ``remesh_uniform`` call. Pass an empty list to clear.
+        """
+        from mmgpy._mesh import _normalize_local_parameters  # noqa: PLC0415
+
+        if parameters:
+            normalized = _normalize_local_parameters(parameters, self.kind)
+            self._dataset.user_dict[_MMG_CONFIG_KEY_LOCAL_PARAMETERS] = normalized
+        elif _MMG_CONFIG_KEY_LOCAL_PARAMETERS in self._dataset.user_dict:
+            del self._dataset.user_dict[_MMG_CONFIG_KEY_LOCAL_PARAMETERS]
+
+    def set_multi_materials(
+        self,
+        materials: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Stash multi-material configuration for the next ``remesh_levelset()``.
+
+        Mirrors :meth:`mmgpy.Mesh.set_multi_materials`. The spec list is
+        stored in ``dataset.user_dict["mmg_multi_materials"]`` and applied
+        to the underlying ``MmgMesh`` at the start of every subsequent
+        accessor remesh call. Pass an empty list to clear.
+        """
+        from mmgpy._mesh import _normalize_multi_materials  # noqa: PLC0415
+
+        if materials:
+            normalized = _normalize_multi_materials(materials)
+            self._dataset.user_dict[_MMG_CONFIG_KEY_MULTI_MATERIALS] = normalized
+        elif _MMG_CONFIG_KEY_MULTI_MATERIALS in self._dataset.user_dict:
+            del self._dataset.user_dict[_MMG_CONFIG_KEY_MULTI_MATERIALS]
+
+    def set_ls_base_references(self, references: Sequence[int]) -> None:
+        """Restrict level-set splitting to the given references on the next call.
+
+        Mirrors :meth:`mmgpy.Mesh.set_ls_base_references`. The list is
+        stored in ``dataset.user_dict["mmg_ls_base_references"]`` and applied
+        to the underlying ``MmgMesh`` at the start of every subsequent
+        accessor remesh call. Pass an empty list to clear.
+        """
+        from mmgpy._mesh import _normalize_ls_base_references  # noqa: PLC0415
+
+        if references:
+            normalized = _normalize_ls_base_references(references)
+            self._dataset.user_dict[_MMG_CONFIG_KEY_LS_BASE_REFERENCES] = normalized
+        elif _MMG_CONFIG_KEY_LS_BASE_REFERENCES in self._dataset.user_dict:
+            del self._dataset.user_dict[_MMG_CONFIG_KEY_LS_BASE_REFERENCES]
 
     def build_size_map(self, *, aniso: bool = False) -> NDArray[np.float64]:
         """Build a size map from edges incident to each vertex.

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -439,20 +439,21 @@ def _apply_pending_mmg_config(
     """Push multi-material / local-parameter / LS config from user_dict into MMG.
 
     The accessor methods ``set_multi_materials`` / ``set_local_parameters`` /
-    ``set_ls_base_references`` stash their specs in ``dataset.user_dict`` so
-    the configuration survives the fresh ``Mesh`` built on every accessor
-    call. This helper transfers them into the C++ side before remeshing.
+    ``set_ls_base_references`` stash their already-normalized specs in
+    ``dataset.user_dict`` so the configuration survives the fresh ``Mesh``
+    built on every accessor call. The data was validated when stashed, so we
+    forward directly to the C++ binding without re-normalizing.
     """
     user_dict = dataset.user_dict
     materials = user_dict.get(_MMG_CONFIG_KEY_MULTI_MATERIALS)
-    if materials:
-        mesh.set_multi_materials(list(materials))
+    if materials is not None:
+        mesh._impl.set_multi_materials(list(materials))  # noqa: SLF001
     parameters = user_dict.get(_MMG_CONFIG_KEY_LOCAL_PARAMETERS)
-    if parameters:
-        mesh.set_local_parameters(list(parameters))
+    if parameters is not None:
+        mesh._impl.set_local_parameters(list(parameters))  # noqa: SLF001
     references = user_dict.get(_MMG_CONFIG_KEY_LS_BASE_REFERENCES)
-    if references:
-        mesh.set_ls_base_references(list(references))
+    if references is not None:
+        mesh._impl.set_ls_base_references(list(references))  # noqa: SLF001
 
 
 def _apply_local_sizing_specs(

--- a/tests/multimat_test.py
+++ b/tests/multimat_test.py
@@ -71,7 +71,7 @@ class TestMeshLocalParameters:
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
-        """Configure triangle-level params on a surface mesh."""
+        """Configure triangle-level params on a surface mesh and remesh."""
         vertices, triangles = tetrahedron_surface_mesh
         mesh = Mesh(vertices, triangles)
         mesh.set_local_parameters(
@@ -85,6 +85,8 @@ class TestMeshLocalParameters:
                 },
             ],
         )
+        mesh.remesh(verbose=False)
+        assert mesh.get_vertices().shape[0] > 0
 
     def test_local_parameters_drives_refinement(
         self,
@@ -229,6 +231,26 @@ class TestMeshMultiMaterials:
         mesh = Mesh(vertices, elements)
         with pytest.raises(ValueError, match="must be a mapping"):
             mesh.set_multi_materials([(1, True, 10, 20)])  # type: ignore[list-item]
+
+    def test_invalid_split_type_raises_value_error(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Non-bool/int ``split`` values are rejected upfront."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        with pytest.raises(ValueError, match="must be bool or int"):
+            mesh.set_multi_materials(
+                [{"ref": 1, "split": "yes", "ref_minus": 10, "ref_plus": 20}],
+            )
+        with pytest.raises(ValueError, match="must be bool or int"):
+            mesh.set_multi_materials(
+                [{"ref": 1, "split": 1.5, "ref_minus": 10, "ref_plus": 20}],
+            )
+        with pytest.raises(ValueError, match="must be 0 or 1"):
+            mesh.set_multi_materials(
+                [{"ref": 1, "split": 2, "ref_minus": 10, "ref_plus": 20}],
+            )
 
 
 class TestMeshLsBaseReferences:

--- a/tests/multimat_test.py
+++ b/tests/multimat_test.py
@@ -1,0 +1,381 @@
+"""High-level multi-material / local-parameter / LS-base-references tests.
+
+These tests exercise the methods surfaced on :class:`mmgpy.Mesh` and the
+PyVista ``.mmg`` accessor. The C++ bindings on ``MmgMesh{3D,2D,S}``
+already cover the configuration plumbing (see ``tests/topology_test.py``);
+here we focus on input validation, integration with the existing remesh
+paths, and the accessor's ``user_dict``-based persistence across rebuilds
+of the underlying ``Mesh``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+import mmgpy  # noqa: F401  -- registers the .mmg accessor
+from mmgpy._mesh import Mesh
+
+# ---------------------------------------------------------------------------
+# High-level Mesh wiring
+# ---------------------------------------------------------------------------
+
+
+class TestMeshLocalParameters:
+    """``Mesh.set_local_parameters`` on each mesh kind."""
+
+    def test_3d_set_local_parameters(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Configure tet-level params and remesh end to end."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        mesh.set_local_parameters(
+            [
+                {
+                    "type": "tetrahedron",
+                    "ref": 0,
+                    "hmin": 0.02,
+                    "hmax": 0.05,
+                    "hausd": 0.01,
+                },
+            ],
+        )
+        mesh.remesh(verbose=False)
+        assert mesh.get_vertices().shape[0] > 0
+
+    def test_2d_set_local_parameters(
+        self,
+        dense_2d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Configure triangle-level params and remesh a 2D mesh end to end."""
+        vertices, triangles = dense_2d_mesh
+        mesh = Mesh(vertices, triangles)
+        mesh.set_local_parameters(
+            [
+                {
+                    "type": "triangle",
+                    "ref": 0,
+                    "hmin": 0.02,
+                    "hmax": 0.1,
+                    "hausd": 0.01,
+                },
+            ],
+        )
+        mesh.remesh(verbose=False)
+        assert mesh.get_vertices().shape[0] > 0
+
+    def test_surface_set_local_parameters(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Configure triangle-level params on a surface mesh."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = Mesh(vertices, triangles)
+        mesh.set_local_parameters(
+            [
+                {
+                    "type": "triangle",
+                    "ref": 0,
+                    "hmin": 0.05,
+                    "hmax": 0.2,
+                    "hausd": 0.01,
+                },
+            ],
+        )
+
+    def test_local_parameters_drives_refinement(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """A local ``hmax`` override yields strictly more elements than the baseline.
+
+        Same input mesh + global ``hmax=0.2``; the second pass also sets a
+        local override of ``hmax=0.05`` on ref 0 (the only ref present).
+        """
+        vertices, elements = dense_3d_mesh
+        baseline = Mesh(vertices.copy(), elements.copy())
+        baseline.remesh(hmax=0.2, verbose=False)
+        n_baseline = baseline.get_tetrahedra().shape[0]
+
+        refined = Mesh(vertices.copy(), elements.copy())
+        refined.set_local_parameters(
+            [
+                {
+                    "type": "tetrahedron",
+                    "ref": 0,
+                    "hmin": 0.01,
+                    "hmax": 0.05,
+                    "hausd": 0.01,
+                },
+            ],
+        )
+        refined.remesh(hmax=0.2, verbose=False)
+        n_refined = refined.get_tetrahedra().shape[0]
+
+        assert n_refined > n_baseline, (
+            f"local refinement should produce more elements: "
+            f"baseline={n_baseline}, refined={n_refined}"
+        )
+
+    def test_invalid_entity_type_raises_value_error(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Unknown entity types fail at the Python boundary, not deep in MMG."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        with pytest.raises(ValueError, match="must be one of"):
+            mesh.set_local_parameters(
+                [
+                    {
+                        "type": "pentagon",
+                        "ref": 1,
+                        "hmin": 0.01,
+                        "hmax": 0.1,
+                        "hausd": 0.01,
+                    },
+                ],
+            )
+
+    def test_missing_key_raises_value_error(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Missing required keys are reported by name."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        with pytest.raises(ValueError, match="missing keys"):
+            mesh.set_local_parameters([{"type": "triangle", "ref": 1}])
+
+    def test_2d_rejects_tetrahedron_entity(
+        self,
+        dense_2d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """2D meshes reject ``type='tetrahedron'`` upfront."""
+        vertices, triangles = dense_2d_mesh
+        mesh = Mesh(vertices, triangles)
+        with pytest.raises(ValueError, match="must be one of"):
+            mesh.set_local_parameters(
+                [
+                    {
+                        "type": "tetrahedron",
+                        "ref": 0,
+                        "hmin": 0.01,
+                        "hmax": 0.1,
+                        "hausd": 0.01,
+                    },
+                ],
+            )
+
+
+class TestMeshMultiMaterials:
+    """``Mesh.set_multi_materials`` configuration and validation."""
+
+    def test_3d_set_multi_materials_with_levelset(
+        self,
+        dense_3d_mesh_fine: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Configuring multi-mat before ls-remesh produces split refs in output."""
+        vertices, elements = dense_3d_mesh_fine
+        mesh = Mesh(vertices, elements)
+
+        center = np.array([0.5, 0.5, 0.5])
+        radius = 0.3
+        levelset = (np.linalg.norm(vertices - center, axis=1) - radius).reshape(-1, 1)
+
+        mesh.set_multi_materials(
+            [{"ref": 0, "split": True, "ref_minus": 10, "ref_plus": 20}],
+        )
+        mesh.remesh_levelset(levelset, hmax=0.15, verbose=False)
+
+        _, elem_refs = mesh.get_elements_with_refs()
+        unique_refs = set(np.unique(elem_refs).tolist())
+        assert 10 in unique_refs, f"expected ref_minus=10 in output, got {unique_refs}"
+        assert 20 in unique_refs, f"expected ref_plus=20 in output, got {unique_refs}"
+
+    def test_split_accepts_bool_and_int(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """``split`` accepts both ``True``/``False`` and ``1``/``0``."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        mesh.set_multi_materials(
+            [
+                {"ref": 1, "split": True, "ref_minus": 10, "ref_plus": 20},
+                {"ref": 2, "split": 0, "ref_minus": 0, "ref_plus": 0},
+            ],
+        )
+
+    def test_missing_key_raises_value_error(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Missing required keys are reported by name."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        with pytest.raises(ValueError, match="missing keys"):
+            mesh.set_multi_materials([{"ref": 1, "split": True}])
+
+    def test_non_mapping_raises_value_error(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Non-mapping entries fail at the Python boundary."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        with pytest.raises(ValueError, match="must be a mapping"):
+            mesh.set_multi_materials([(1, True, 10, 20)])  # type: ignore[list-item]
+
+
+class TestMeshLsBaseReferences:
+    """``Mesh.set_ls_base_references`` configuration and validation."""
+
+    def test_3d_set_ls_base_references(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Accept a plain list of ints."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        mesh.set_ls_base_references([1, 2, 3])
+
+    def test_empty_list_is_allowed(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """An empty list clears the configured references."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        mesh.set_ls_base_references([])
+
+    def test_non_integer_raises_value_error(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Non-integer entries fail at the Python boundary."""
+        vertices, elements = dense_3d_mesh
+        mesh = Mesh(vertices, elements)
+        with pytest.raises(ValueError, match="not an integer"):
+            mesh.set_ls_base_references(["hello"])  # type: ignore[list-item]
+
+
+# ---------------------------------------------------------------------------
+# PyVista accessor wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAccessorPersistence:
+    """The accessor stores its config in ``dataset.user_dict``."""
+
+    def test_stash_into_user_dict(self) -> None:
+        """The three setters land under stable user_dict keys."""
+        pts = np.random.RandomState(0).rand(20, 3)
+        dataset = pv.PolyData(pts).delaunay_3d()
+
+        dataset.mmg.set_local_parameters(
+            [
+                {
+                    "type": "tetrahedron",
+                    "ref": 0,
+                    "hmin": 0.01,
+                    "hmax": 0.1,
+                    "hausd": 0.01,
+                },
+            ],
+        )
+        dataset.mmg.set_multi_materials(
+            [{"ref": 1, "split": True, "ref_minus": 10, "ref_plus": 20}],
+        )
+        dataset.mmg.set_ls_base_references([1, 2])
+
+        assert "mmg_local_parameters" in dataset.user_dict
+        assert "mmg_multi_materials" in dataset.user_dict
+        assert "mmg_ls_base_references" in dataset.user_dict
+
+        materials = list(dataset.user_dict["mmg_multi_materials"])
+        assert materials[0]["split"] == 1
+
+    def test_empty_clears_user_dict_key(self) -> None:
+        """Passing an empty list removes the stash key."""
+        pts = np.random.RandomState(0).rand(20, 3)
+        dataset = pv.PolyData(pts).delaunay_3d()
+        dataset.mmg.set_ls_base_references([1, 2])
+        assert "mmg_ls_base_references" in dataset.user_dict
+        dataset.mmg.set_ls_base_references([])
+        assert "mmg_ls_base_references" not in dataset.user_dict
+
+
+class TestAccessorLocalParametersDrivesRefinement:
+    """Local parameters set via the accessor are picked up by ``remesh``."""
+
+    def test_local_hmax_produces_more_cells(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Configured local ``hmax`` yields more cells than the baseline."""
+        from pyvista import CellType
+
+        vertices, elements = dense_3d_mesh
+        cells_padded = np.column_stack(
+            [np.full(len(elements), 4, dtype=np.int32), elements.astype(np.int32)],
+        ).ravel()
+        cell_types = np.full(len(elements), CellType.TETRA, dtype=np.uint8)
+        dataset = pv.UnstructuredGrid(cells_padded, cell_types, vertices)
+
+        baseline_pv = dataset.copy()
+        baseline = baseline_pv.mmg.remesh(hmax=0.2, verbose=False)
+
+        refined_pv = dataset.copy()
+        refined_pv.mmg.set_local_parameters(
+            [
+                {
+                    "type": "tetrahedron",
+                    "ref": 0,
+                    "hmin": 0.01,
+                    "hmax": 0.05,
+                    "hausd": 0.01,
+                },
+            ],
+        )
+        refined = refined_pv.mmg.remesh(hmax=0.2, verbose=False)
+
+        assert refined.n_cells > baseline.n_cells, (
+            f"local refinement should produce more cells: "
+            f"baseline={baseline.n_cells}, refined={refined.n_cells}"
+        )
+
+
+class TestAccessorMultiMaterialsViaLevelset:
+    """Multi-material config flows through ``remesh_levelset`` on the accessor."""
+
+    def test_multi_materials_apply_during_remesh_levelset(
+        self,
+        dense_3d_mesh_fine: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Custom ``ref_minus``/``ref_plus`` appear in output ``cell_data["refs"]``."""
+        from pyvista import CellType
+
+        vertices, elements = dense_3d_mesh_fine
+        cells_padded = np.column_stack(
+            [np.full(len(elements), 4, dtype=np.int32), elements.astype(np.int32)],
+        ).ravel()
+        cell_types = np.full(len(elements), CellType.TETRA, dtype=np.uint8)
+        dataset = pv.UnstructuredGrid(cells_padded, cell_types, vertices)
+
+        center = np.array([0.5, 0.5, 0.5])
+        radius = 0.3
+        levelset = (np.linalg.norm(vertices - center, axis=1) - radius).reshape(-1, 1)
+        dataset.point_data["levelset"] = levelset
+
+        dataset.mmg.set_multi_materials(
+            [{"ref": 0, "split": True, "ref_minus": 10, "ref_plus": 20}],
+        )
+
+        out = dataset.mmg.remesh_levelset(levelset, hmax=0.15, verbose=False)
+        refs = np.unique(out.cell_data["refs"]).tolist()
+        assert 10 in refs, f"expected ref_minus=10 in output, got {refs}"
+        assert 20 in refs, f"expected ref_plus=20 in output, got {refs}"


### PR DESCRIPTION
## Summary

- Surfaces the existing pybind11 `set_multi_materials` / `set_local_parameters` / `set_ls_base_references` bindings on the high-level `Mesh` class and on the PyVista `.mmg` accessor.
- No new C++; pure Python wiring with input validation at the boundary.

## Changes

### `Mesh` (src/mmgpy/_mesh.py)
- `Mesh.set_local_parameters(parameters)` — validates entity type (`tetrahedron` rejected on 2D/surface), required keys, then forwards to `MmgMesh{3D,2D,S}.set_local_parameters`.
- `Mesh.set_multi_materials(materials)` — validates required keys (`ref`, `split`, `ref_minus`, `ref_plus`), normalizes `split` (accepts `bool` or `int`).
- `Mesh.set_ls_base_references(refs)` — validates integer coercibility.
- Shape errors raise `ValueError` at the Python boundary instead of a generic `RuntimeError` deep in MMG.

### `.mmg` accessor (src/mmgpy/_pv_plugin.py)
- Mirrors all three methods. Specs are stashed in `dataset.user_dict["mmg_*"]` so they survive the fresh `Mesh` built on every accessor call.
- A new `_apply_pending_mmg_config(mesh, dataset)` helper applies the stashed config inside `remesh` / `remesh_levelset` / `remesh_optimize` / `remesh_uniform`.
- Passing an empty list clears the stash.

### Tests (tests/multimat_test.py)
18 tests covering: end-to-end remeshing on all three mesh kinds, validation errors, `split` bool/int interchangeability, accessor `user_dict` persistence, and an end-to-end refinement assertion (local `hmax=0.05` produces strictly more cells than the global `hmax=0.2` baseline).

### Example (examples/mmg3d/multi_material_levelset.py)
Demonstrates `dataset.mmg.set_multi_materials(...)` reassigning the post-discretization references away from MMG's defaults (2 / 3) to custom values (42 / 17) via the accessor.

## Notes

- All 18 new tests pass; 145 related tests in `topology_test.py`, `levelset_test.py`, `pv_plugin_test.py`, `mesh_3d_test.py` also pass.
- mypy on the changed files has no new errors (pre-existing ones untouched).