### PR TITLE
drop windows fallbacks for MMGS_analys and MMGS_Get_triangleQuality

### DIFF
--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -517,13 +517,13 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 ### Triangle Operations
 
-| Function                   | Status   | Notes                                                                                                                                                                  |
-| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MMGS_Set_triangle`        | Bound    | `MmgMeshS.set_triangle()` and loops in `set_triangles()`                                                                                                               |
-| `MMGS_Set_triangles`       | Indirect | `set_triangles()` loops over `Set_triangle` instead                                                                                                                    |
-| `MMGS_Get_triangle`        | Bound    | `MmgMeshS.get_triangle()`                                                                                                                                              |
-| `MMGS_Get_triangles`       | Indirect | `get_triangles()` accesses struct directly                                                                                                                             |
-| `MMGS_Get_triangleQuality` | Bound    | `MmgMeshS.get_element_quality()` / `get_element_qualities()`. Public header drops `LIBMMGS_EXPORT` in MMG v5.8.0; reached on Windows via `WINDOWS_EXPORT_ALL_SYMBOLS`. |
+| Function                   | Status   | Notes                                                                                                                                                                                                         |
+| -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MMGS_Set_triangle`        | Bound    | `MmgMeshS.set_triangle()` and loops in `set_triangles()`                                                                                                                                                      |
+| `MMGS_Set_triangles`       | Indirect | `set_triangles()` loops over `Set_triangle` instead                                                                                                                                                           |
+| `MMGS_Get_triangle`        | Bound    | `MmgMeshS.get_triangle()`                                                                                                                                                                                     |
+| `MMGS_Get_triangles`       | Indirect | `get_triangles()` accesses struct directly                                                                                                                                                                    |
+| `MMGS_Get_triangleQuality` | Bound    | `MmgMeshS.get_element_quality()` / `get_element_qualities()`. Public header drops `LIBMMGS_EXPORT` in MMG v5.8.0; wheel builds export via `WINDOWS_EXPORT_ALL_SYMBOLS`, conda Windows uses a manual fallback. |
 
 ### Edge Operations
 

--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -517,13 +517,13 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 ### Triangle Operations
 
-| Function                   | Status   | Notes                                                                                                                             |
-| -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `MMGS_Set_triangle`        | Bound    | `MmgMeshS.set_triangle()` and loops in `set_triangles()`                                                                          |
-| `MMGS_Set_triangles`       | Indirect | `set_triangles()` loops over `Set_triangle` instead                                                                               |
-| `MMGS_Get_triangle`        | Bound    | `MmgMeshS.get_triangle()`                                                                                                         |
-| `MMGS_Get_triangles`       | Indirect | `get_triangles()` accesses struct directly                                                                                        |
-| `MMGS_Get_triangleQuality` | Bound    | `MmgMeshS.get_element_quality()` / `get_element_qualities()`. Manual fallback on Windows due to missing DLL export in MMG v5.8.0. |
+| Function                   | Status   | Notes                                                                                                                                                                  |
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MMGS_Set_triangle`        | Bound    | `MmgMeshS.set_triangle()` and loops in `set_triangles()`                                                                                                               |
+| `MMGS_Set_triangles`       | Indirect | `set_triangles()` loops over `Set_triangle` instead                                                                                                                    |
+| `MMGS_Get_triangle`        | Bound    | `MmgMeshS.get_triangle()`                                                                                                                                              |
+| `MMGS_Get_triangles`       | Indirect | `get_triangles()` accesses struct directly                                                                                                                             |
+| `MMGS_Get_triangleQuality` | Bound    | `MmgMeshS.get_element_quality()` / `get_element_qualities()`. Public header drops `LIBMMGS_EXPORT` in MMG v5.8.0; reached on Windows via `WINDOWS_EXPORT_ALL_SYMBOLS`. |
 
 ### Edge Operations
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -44,10 +44,13 @@ set(USE_ELAS OFF CACHE BOOL "Do not use ELAS" FORCE)
 # Make MMG available
 FetchContent_MakeAvailable(mmg)
 
-# Work around missing LIBMMGS_EXPORT on MMGS_Get_triangleQuality in MMG v5.8.0.
-# On Windows, only __declspec(dllexport) symbols are exported from DLLs.
-# This generates a .def file that exports all symbols, including the one
-# missing the export macro in the upstream header.
+# Work around two missing exports in MMG v5.8.0 on Windows:
+#   - MMGS_Get_triangleQuality: public header drops LIBMMGS_EXPORT.
+#   - MMGS_analys: declared only in libmmgs_private.h, no export macro.
+# On POSIX both have default ELF visibility; on Windows only
+# __declspec(dllexport) symbols escape the DLL. WINDOWS_EXPORT_ALL_SYMBOLS
+# generates a .def file listing every extern symbol from the object files,
+# so both become callable from mmgpy. See issue #218.
 # https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html
 if(WIN32)
     set_target_properties(libmmgs_so PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,16 @@ target_link_libraries(${PROJECT_NAME}
         ${MMG_LIBRARIES}
 )
 
+# MMG v5.8.0 ships two MMGS symbols without LIBMMGS_EXPORT:
+# MMGS_Get_triangleQuality (public header drops the macro) and MMGS_analys
+# (only in the private header). On wheel builds, extern/CMakeLists.txt
+# enables WINDOWS_EXPORT_ALL_SYMBOLS on libmmgs_so to surface both. Conda
+# links against the prebuilt mmgsuite package, where neither workaround is
+# available, so the bindings need a manual fallback on that path only.
+if(WIN32 AND MMGPY_CONDA_BUILD)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE MMGPY_MMGS_PRIVATE_SYMBOLS_HIDDEN)
+endif()
+
 # Handle compiler warnings
 if(MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE /W4)

--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -619,7 +619,9 @@ PYBIND11_MODULE(_mmgpy, m) {
            "first runs MMGS_analys to populate ridges, normals and "
            "manifold tags; any subsequent remesh would have run analys "
            "anyway, so this only changes the timing of work that would "
-           "have happened.")
+           "have happened. Conda Windows builds link against the prebuilt "
+           "mmgsuite package, which does not export MMGS_analys, so "
+           "aniso=True raises there.")
       .def("clean_iso_surface", &MmgMeshS::clean_iso_surface,
            "Remove isolated triangles / edges left after a level-set "
            "discretization (wraps MMGS_Clean_isoSurf).");

--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -619,8 +619,7 @@ PYBIND11_MODULE(_mmgpy, m) {
            "first runs MMGS_analys to populate ridges, normals and "
            "manifold tags; any subsequent remesh would have run analys "
            "anyway, so this only changes the timing of work that would "
-           "have happened. Not supported on Windows: the underlying "
-           "MMGS_analys symbol is not exported from libmmgs.dll.")
+           "have happened.")
       .def("clean_iso_surface", &MmgMeshS::clean_iso_surface,
            "Remove isolated triangles / edges left after a level-set "
            "discretization (wraps MMGS_Clean_isoSurf).");

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -5,16 +5,61 @@
 #include <set>
 #include <stdexcept>
 
-// MMGS_analys is declared in libmmgs_private.h (not in the installed public
-// headers). The public declaration of MMGS_Get_triangleQuality in libmmgs.h
-// is also missing LIBMMGS_EXPORT in MMG v5.8.0. On Linux/macOS the symbols
-// have default visibility in the .so; on Windows the build enables
-// WINDOWS_EXPORT_ALL_SYMBOLS on libmmgs_so (see extern/CMakeLists.txt) so
-// the DLL exports them too. Forward-declare MMGS_analys here so we can call
-// it without pulling in the private header.
+// MMG v5.8.0 ships two MMGS symbols without LIBMMGS_EXPORT:
+//   - MMGS_Get_triangleQuality (public header drops the macro)
+//   - MMGS_analys (only in libmmgs_private.h)
+// On Linux/macOS both have default ELF visibility. Wheel builds on Windows
+// enable WINDOWS_EXPORT_ALL_SYMBOLS on libmmgs_so (see extern/CMakeLists.txt)
+// so the DLL exports them too. Conda links against the prebuilt mmgsuite
+// package, where the symbols stay hidden; src/CMakeLists.txt sets
+// MMGPY_MMGS_PRIVATE_SYMBOLS_HIDDEN on that path so we fall back to a manual
+// triangle-quality formula and refuse the aniso-surface path.
+#ifdef MMGPY_MMGS_PRIVATE_SYMBOLS_HIDDEN
+#include <cmath>
+#else
 extern "C" int MMGS_analys(MMG5_pMesh mesh);
+#endif
 
 namespace {
+
+double get_triangle_quality([[maybe_unused]] MMG5_pMesh mesh,
+                            [[maybe_unused]] MMG5_pSol met, MMG5_int k) {
+#ifdef MMGPY_MMGS_PRIVATE_SYMBOLS_HIDDEN
+  MMG5_pTria pt = &mesh->tria[k];
+  MMG5_pPoint p0 = &mesh->point[pt->v[0]];
+  MMG5_pPoint p1 = &mesh->point[pt->v[1]];
+  MMG5_pPoint p2 = &mesh->point[pt->v[2]];
+
+  double ax = p1->c[0] - p0->c[0], ay = p1->c[1] - p0->c[1],
+         az = p1->c[2] - p0->c[2];
+  double bx = p2->c[0] - p0->c[0], by = p2->c[1] - p0->c[1],
+         bz = p2->c[2] - p0->c[2];
+  double cx = p2->c[0] - p1->c[0], cy = p2->c[1] - p1->c[1],
+         cz = p2->c[2] - p1->c[2];
+
+  double a2 = ax * ax + ay * ay + az * az;
+  double b2 = bx * bx + by * by + bz * bz;
+  double c2 = cx * cx + cy * cy + cz * cz;
+
+  double nx = ay * bz - az * by;
+  double ny = az * bx - ax * bz;
+  double nz = ax * by - ay * bx;
+  double area2 = nx * nx + ny * ny + nz * nz;
+
+  if (area2 < 1e-30)
+    return 0.0;
+
+  double sum_edges = a2 + b2 + c2;
+  if (sum_edges < 1e-30)
+    return 0.0;
+
+  // Quality = 4 * sqrt(3) * area / (2 * (a^2 + b^2 + c^2))
+  // Equivalent to MMGS_ALPHAD * sqrt(area2) / sum_edges for isotropic meshes.
+  return 4.0 * std::sqrt(3.0) * std::sqrt(area2) / (2.0 * sum_edges);
+#else
+  return MMGS_Get_triangleQuality(mesh, met, k);
+#endif
+}
 
 // Collect mesh statistics for surface mesh
 RemeshStats collect_mesh_stats_surface(MMG5_pMesh mesh, MMG5_pSol met) {
@@ -28,7 +73,7 @@ RemeshStats collect_mesh_stats_surface(MMG5_pMesh mesh, MMG5_pSol met) {
   double quality_sum = 0.0;
   if (stats.triangles > 0) {
     for (MMG5_int i = 1; i <= stats.triangles; i++) {
-      double q = MMGS_Get_triangleQuality(mesh, met, i);
+      double q = get_triangle_quality(mesh, met, i);
       quality_sum += q;
       if (q < stats.quality_min)
         stats.quality_min = q;
@@ -777,7 +822,7 @@ double MmgMeshS::get_element_quality(MMG5_int idx) const {
                              std::to_string(idx));
   }
 
-  return MMGS_Get_triangleQuality(mesh, met, mmg_idx);
+  return get_triangle_quality(mesh, met, mmg_idx);
 }
 
 py::array_t<double> MmgMeshS::get_element_qualities() const {
@@ -787,7 +832,7 @@ py::array_t<double> MmgMeshS::get_element_qualities() const {
   double *ptr = static_cast<double *>(buf.ptr);
 
   for (MMG5_int i = 0; i < nt; i++) {
-    ptr[i] = MMGS_Get_triangleQuality(mesh, met, i + 1);
+    ptr[i] = get_triangle_quality(mesh, met, i + 1);
   }
 
   return result;
@@ -1089,6 +1134,18 @@ py::dict MmgMeshS::remesh_levelset(const py::array_t<double> &levelset,
 py::array_t<double> MmgMeshS::build_size_map(bool aniso) {
   check_not_corrupted("build_size_map");
 
+#ifdef MMGPY_MMGS_PRIVATE_SYMBOLS_HIDDEN
+  if (aniso) {
+    // MMGS_analys is not callable from this build (conda mmgsuite hides
+    // the symbol). The surface aniso path needs the analyzed mesh state,
+    // so refuse with a clear message rather than producing zero metrics.
+    throw std::runtime_error(
+        "build_size_map(aniso=True) is not implemented for surface meshes "
+        "in conda Windows builds (MMGS_analys is not exported from the "
+        "mmgsuite mmgs.dll).");
+  }
+#endif
+
   // MMGS_doSol is a function pointer initialized by MMGS_setfunc, which
   // dispatches on mesh->info.ani and met->size. Set info.ani to the
   // requested mode and resize the metric buffer to match before letting
@@ -1106,6 +1163,7 @@ py::array_t<double> MmgMeshS::build_size_map(bool aniso) {
     throw std::runtime_error("Failed to resize metric for build_size_map");
   }
 
+#ifndef MMGPY_MMGS_PRIVATE_SYMBOLS_HIDDEN
   if (aniso) {
     // MMGS_doSol_ani reads ridge tags, normals and manifold flags off the
     // mesh, all of which are populated by MMGS_analys. The expensive part
@@ -1124,6 +1182,7 @@ py::array_t<double> MmgMeshS::build_size_map(bool aniso) {
           "MMGS_analys failed; cannot build anisotropic size map");
     }
   }
+#endif
 
   MMGS_setfunc(mesh, met);
   if (MMGS_doSol == nullptr) {

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -5,66 +5,16 @@
 #include <set>
 #include <stdexcept>
 
-#ifdef _WIN32
-#include <cmath>
-#endif
-
-#ifndef _WIN32
-// MMGS_analys is declared in libmmgs_private.h, which is not in the installed
-// public headers, but the symbol has default visibility in the .so on Linux
-// and macOS (verified via nm). Forward-declare here so we can call it without
-// pulling in the private header. Required for surface anisotropic doSol,
-// which dispatches through MMGS_setfunc and needs the mesh to be analyzed
-// (ridges, normals, manifold tags) first. On Windows the symbol lacks
-// __declspec(dllexport) in MMG's build, so the aniso surface path stays
-// disabled there.
+// MMGS_analys is declared in libmmgs_private.h (not in the installed public
+// headers). The public declaration of MMGS_Get_triangleQuality in libmmgs.h
+// is also missing LIBMMGS_EXPORT in MMG v5.8.0. On Linux/macOS the symbols
+// have default visibility in the .so; on Windows the build enables
+// WINDOWS_EXPORT_ALL_SYMBOLS on libmmgs_so (see extern/CMakeLists.txt) so
+// the DLL exports them too. Forward-declare MMGS_analys here so we can call
+// it without pulling in the private header.
 extern "C" int MMGS_analys(MMG5_pMesh mesh);
-#endif
 
 namespace {
-
-// Wrapper for MMGS_Get_triangleQuality.
-// On Windows, the symbol is not exported from the MMG DLL (missing
-// LIBMMGS_EXPORT in MMG v5.8.0 header), so we compute the quality manually.
-// On other platforms we call the C API directly.
-double get_triangle_quality([[maybe_unused]] MMG5_pMesh mesh,
-                            [[maybe_unused]] MMG5_pSol met, MMG5_int k) {
-#ifdef _WIN32
-  MMG5_pTria pt = &mesh->tria[k];
-  MMG5_pPoint p0 = &mesh->point[pt->v[0]];
-  MMG5_pPoint p1 = &mesh->point[pt->v[1]];
-  MMG5_pPoint p2 = &mesh->point[pt->v[2]];
-
-  double ax = p1->c[0] - p0->c[0], ay = p1->c[1] - p0->c[1],
-         az = p1->c[2] - p0->c[2];
-  double bx = p2->c[0] - p0->c[0], by = p2->c[1] - p0->c[1],
-         bz = p2->c[2] - p0->c[2];
-  double cx = p2->c[0] - p1->c[0], cy = p2->c[1] - p1->c[1],
-         cz = p2->c[2] - p1->c[2];
-
-  double a2 = ax * ax + ay * ay + az * az;
-  double b2 = bx * bx + by * by + bz * bz;
-  double c2 = cx * cx + cy * cy + cz * cz;
-
-  double nx = ay * bz - az * by;
-  double ny = az * bx - ax * bz;
-  double nz = ax * by - ay * bx;
-  double area2 = nx * nx + ny * ny + nz * nz;
-
-  if (area2 < 1e-30)
-    return 0.0;
-
-  double sum_edges = a2 + b2 + c2;
-  if (sum_edges < 1e-30)
-    return 0.0;
-
-  // Quality = 4 * sqrt(3) * area / (2 * (a^2 + b^2 + c^2))
-  // Equivalent to MMGS_ALPHAD * sqrt(area2) / sum_edges for isotropic meshes.
-  return 4.0 * std::sqrt(3.0) * std::sqrt(area2) / (2.0 * sum_edges);
-#else
-  return MMGS_Get_triangleQuality(mesh, met, k);
-#endif
-}
 
 // Collect mesh statistics for surface mesh
 RemeshStats collect_mesh_stats_surface(MMG5_pMesh mesh, MMG5_pSol met) {
@@ -78,7 +28,7 @@ RemeshStats collect_mesh_stats_surface(MMG5_pMesh mesh, MMG5_pSol met) {
   double quality_sum = 0.0;
   if (stats.triangles > 0) {
     for (MMG5_int i = 1; i <= stats.triangles; i++) {
-      double q = get_triangle_quality(mesh, met, i);
+      double q = MMGS_Get_triangleQuality(mesh, met, i);
       quality_sum += q;
       if (q < stats.quality_min)
         stats.quality_min = q;
@@ -827,7 +777,7 @@ double MmgMeshS::get_element_quality(MMG5_int idx) const {
                              std::to_string(idx));
   }
 
-  return get_triangle_quality(mesh, met, mmg_idx);
+  return MMGS_Get_triangleQuality(mesh, met, mmg_idx);
 }
 
 py::array_t<double> MmgMeshS::get_element_qualities() const {
@@ -837,7 +787,7 @@ py::array_t<double> MmgMeshS::get_element_qualities() const {
   double *ptr = static_cast<double *>(buf.ptr);
 
   for (MMG5_int i = 0; i < nt; i++) {
-    ptr[i] = get_triangle_quality(mesh, met, i + 1);
+    ptr[i] = MMGS_Get_triangleQuality(mesh, met, i + 1);
   }
 
   return result;
@@ -1139,19 +1089,6 @@ py::dict MmgMeshS::remesh_levelset(const py::array_t<double> &levelset,
 py::array_t<double> MmgMeshS::build_size_map(bool aniso) {
   check_not_corrupted("build_size_map");
 
-#ifdef _WIN32
-  if (aniso) {
-    // MMGS_analys is not exported from libmmgs.dll (missing
-    // __declspec(dllexport) on MMG's side), so we cannot prepare the surface
-    // for the aniso dispatch on Windows. Same family of issue as the
-    // get_triangle_quality workaround above. Keep the explicit failure here
-    // so users get a clear message rather than a link-time crash.
-    throw std::runtime_error(
-        "build_size_map(aniso=True) is not implemented for surface meshes "
-        "on Windows (MMGS_analys is not exported from libmmgs.dll).");
-  }
-#endif
-
   // MMGS_doSol is a function pointer initialized by MMGS_setfunc, which
   // dispatches on mesh->info.ani and met->size. Set info.ani to the
   // requested mode and resize the metric buffer to match before letting
@@ -1169,7 +1106,6 @@ py::array_t<double> MmgMeshS::build_size_map(bool aniso) {
     throw std::runtime_error("Failed to resize metric for build_size_map");
   }
 
-#ifndef _WIN32
   if (aniso) {
     // MMGS_doSol_ani reads ridge tags, normals and manifold flags off the
     // mesh, all of which are populated by MMGS_analys. The expensive part
@@ -1188,7 +1124,6 @@ py::array_t<double> MmgMeshS::build_size_map(bool aniso) {
           "MMGS_analys failed; cannot build anisotropic size map");
     }
   }
-#endif
 
   MMGS_setfunc(mesh, met);
   if (MMGS_doSol == nullptr) {

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -2906,7 +2906,9 @@ class MmgMeshS:
                 aniso path runs ``MMGS_analys`` first to populate
                 ridges, normals and manifold tags; any later remesh
                 would have run analys anyway, so this only changes
-                timing.
+                timing. Conda Windows builds link the prebuilt
+                ``mmgsuite`` package, which does not export
+                ``MMGS_analys``, so ``aniso=True`` raises there.
 
         """
 

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -2906,9 +2906,7 @@ class MmgMeshS:
                 aniso path runs ``MMGS_analys`` first to populate
                 ridges, normals and manifold tags; any later remesh
                 would have run analys anyway, so this only changes
-                timing. Raises ``RuntimeError`` on Windows: the
-                underlying ``MMGS_analys`` symbol is not exported from
-                ``libmmgs.dll``.
+                timing.
 
         """
 

--- a/tests/dosol_test.py
+++ b/tests/dosol_test.py
@@ -36,9 +36,14 @@ def _surface_aniso_available() -> bool:
     return True
 
 
+_SURFACE_ANISO_AVAILABLE = _surface_aniso_available()
 _skip_if_no_surface_aniso = pytest.mark.skipif(
-    not _surface_aniso_available(),
+    not _SURFACE_ANISO_AVAILABLE,
     reason="MMGS_analys not exported in this build (conda Windows)",
+)
+_skip_if_surface_aniso_available = pytest.mark.skipif(
+    _SURFACE_ANISO_AVAILABLE,
+    reason="surface aniso works in this build; RuntimeError path is conda-Windows only",
 )
 
 
@@ -278,6 +283,25 @@ class TestBuildSizeMapAnisoSurface:
         mesh.remesh(verbose=-1)
 
         assert mesh.get_vertices().shape[0] > len(vertices)
+
+
+@_skip_if_surface_aniso_available
+class TestBuildSizeMapAnisoSurfaceUnsupported:
+    """Builds where ``MMGS_analys`` is hidden must raise with a clear message."""
+
+    def test_aniso_raises_with_clear_message(
+        self,
+        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """``aniso=True`` raises mentioning ``MMGS_analys`` on conda Windows."""
+        vertices, triangles = tetrahedron_surface_mesh
+        mesh = MmgMeshS(vertices, triangles)
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"not implemented for surface.*MMGS_analys",
+        ):
+            mesh.build_size_map(aniso=True)
 
 
 class TestBuildSizeMapAnisoToggle:

--- a/tests/dosol_test.py
+++ b/tests/dosol_test.py
@@ -9,8 +9,6 @@ equivalent).
 
 from __future__ import annotations
 
-import sys
-
 import numpy as np
 import pytest
 import pyvista as pv
@@ -19,14 +17,6 @@ import mmgpy  # noqa: F401  -- registers the .mmg accessor
 from mmgpy._mesh import Mesh
 from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 from mmgpy.metrics import validate_metric_tensor
-
-# MMGS_analys is not exported from libmmgs.dll on Windows, so the surface
-# aniso path stays disabled there. Skip those tests instead of running them.
-_SURFACE_ANISO_UNSUPPORTED = sys.platform == "win32"
-_skip_if_no_surface_aniso = pytest.mark.skipif(
-    _SURFACE_ANISO_UNSUPPORTED,
-    reason="MMGS_analys is not exported from libmmgs.dll on Windows",
-)
 
 
 class TestBuildSizeMap3D:
@@ -201,7 +191,6 @@ class TestBuildSizeMapAniso2D:
         assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
 
 
-@_skip_if_no_surface_aniso
 class TestBuildSizeMapAnisoSurface:
     """Tests for ``MmgMeshS.build_size_map(aniso=True)``.
 
@@ -267,25 +256,6 @@ class TestBuildSizeMapAnisoSurface:
         assert mesh.get_vertices().shape[0] > len(vertices)
 
 
-@pytest.mark.skipif(
-    not _SURFACE_ANISO_UNSUPPORTED,
-    reason="Windows-only: verifies the explicit RuntimeError stays in place",
-)
-class TestBuildSizeMapAnisoSurfaceWindows:
-    """On Windows, the surface aniso path still raises with a clear message."""
-
-    def test_aniso_raises_on_windows(
-        self,
-        tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
-    ) -> None:
-        """``aniso=True`` raises until MMG exports ``MMGS_analys`` on Windows."""
-        vertices, triangles = tetrahedron_surface_mesh
-        mesh = MmgMeshS(vertices, triangles)
-
-        with pytest.raises(RuntimeError, match="not implemented for surface"):
-            mesh.build_size_map(aniso=True)
-
-
 class TestBuildSizeMapAnisoToggle:
     """``aniso`` should be toggleable on the same mesh without leaking state."""
 
@@ -317,7 +287,6 @@ class TestBuildSizeMapAnisoToggle:
         iso = mesh.build_size_map(aniso=False)
         assert iso.shape == (len(vertices), 1)
 
-    @_skip_if_no_surface_aniso
     def test_iso_then_aniso_surface(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
@@ -332,7 +301,6 @@ class TestBuildSizeMapAnisoToggle:
         aniso = mesh.build_size_map(aniso=True)
         assert aniso.shape == (len(vertices), 6)
 
-    @_skip_if_no_surface_aniso
     def test_aniso_then_iso_surface(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
@@ -429,7 +397,6 @@ class TestMeshWrapper:
         assert metric.shape == (len(vertices), 6)
         assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
 
-    @_skip_if_no_surface_aniso
     def test_build_size_map_surface_aniso(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
@@ -502,7 +469,6 @@ class TestPyVistaAccessor:
             sizes.ravel(),
         )
 
-    @_skip_if_no_surface_aniso
     def test_build_size_map_surface_aniso_via_polydata(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],

--- a/tests/dosol_test.py
+++ b/tests/dosol_test.py
@@ -19,6 +19,29 @@ from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 from mmgpy.metrics import validate_metric_tensor
 
 
+def _surface_aniso_available() -> bool:
+    """Return False on builds where MMGS_analys is not callable (conda Windows)."""
+    try:
+        mesh = MmgMeshS(
+            np.array(
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            ),
+            np.array([[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]),
+        )
+        mesh.build_size_map(aniso=True)
+    except RuntimeError as exc:
+        if "MMGS_analys" in str(exc):
+            return False
+        raise
+    return True
+
+
+_skip_if_no_surface_aniso = pytest.mark.skipif(
+    not _surface_aniso_available(),
+    reason="MMGS_analys not exported in this build (conda Windows)",
+)
+
+
 class TestBuildSizeMap3D:
     """Tests for ``MmgMesh3D.build_size_map``."""
 
@@ -191,6 +214,7 @@ class TestBuildSizeMapAniso2D:
         assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
 
 
+@_skip_if_no_surface_aniso
 class TestBuildSizeMapAnisoSurface:
     """Tests for ``MmgMeshS.build_size_map(aniso=True)``.
 
@@ -287,6 +311,7 @@ class TestBuildSizeMapAnisoToggle:
         iso = mesh.build_size_map(aniso=False)
         assert iso.shape == (len(vertices), 1)
 
+    @_skip_if_no_surface_aniso
     def test_iso_then_aniso_surface(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
@@ -301,6 +326,7 @@ class TestBuildSizeMapAnisoToggle:
         aniso = mesh.build_size_map(aniso=True)
         assert aniso.shape == (len(vertices), 6)
 
+    @_skip_if_no_surface_aniso
     def test_aniso_then_iso_surface(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
@@ -397,6 +423,7 @@ class TestMeshWrapper:
         assert metric.shape == (len(vertices), 6)
         assert validate_metric_tensor(metric, raise_on_invalid=False)[0]
 
+    @_skip_if_no_surface_aniso
     def test_build_size_map_surface_aniso(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],
@@ -469,6 +496,7 @@ class TestPyVistaAccessor:
             sizes.ravel(),
         )
 
+    @_skip_if_no_surface_aniso
     def test_build_size_map_surface_aniso_via_polydata(
         self,
         tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray],


### PR DESCRIPTION
## Summary

Remove the unconditional `#ifdef _WIN32` fallback for two MMG v5.8.0 export gaps (`MMGS_analys`, `MMGS_Get_triangleQuality`), and replace it with a build-kind guard so the wheel path gets the full functionality while the conda path keeps the fallback.

- **Wheel builds** (all platforms): symbols reached via `WINDOWS_EXPORT_ALL_SYMBOLS` on `libmmgs_so` in `extern/CMakeLists.txt`. Surface aniso `build_size_map` now works on Windows too.
- **Conda builds** (Windows only): the prebuilt `mmgsuite` package's `mmgs.dll` does not export either symbol and is not under our build control. Bindings fall back to a manual triangle-quality formula and `build_size_map(aniso=True)` raises a clear `RuntimeError` on `MmgMeshS`.

## Changes

- `src/CMakeLists.txt`: define `MMGPY_MMGS_PRIVATE_SYMBOLS_HIDDEN` when `WIN32 AND MMGPY_CONDA_BUILD`.
- `src/bindings/mmg_mesh_s.cpp`: `get_triangle_quality()` helper switches between the C API and the manual formula on the macro; `build_size_map(aniso=True)` refuses on the conda-Windows path.
- `extern/CMakeLists.txt`: comment now covers both symbols.
- `tests/dosol_test.py`: runtime probe `_surface_aniso_available()` catches the specific `RuntimeError`; surface-aniso tests gated on it.
- `bindings.cpp`, `_mmgpy.pyi`, `docs/reference/mmg-api-coverage.md`: docs describe the conda-Windows limitation.

## Notes

Refs #218. The longer-term fix is upstream in MMG: add `LIBMMGS_EXPORT` to `MMGS_Get_triangleQuality` (one-line regression from merge `29c196f4`) and promote `MMGS_analys` to the public API so surface aniso `doSol` is reachable without the private header.