### PR TITLE
Release v0.13.0

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.13.0"
+  version: "0.14.0.dev0"
 
 package:
   name: mmgpy

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.13.0.dev0"
+  version: "0.13.0"
 
 package:
   name: mmgpy
@@ -32,15 +32,14 @@ requirements:
     - numpy
     - mmgsuite
   run:
-    - python
-    - numpy >=2.0.2
-    - meshio >=5.3.5
-    - pyvista >=0.47.0
-    - rich >=13.0.0
+    - python >=3.10
+    - numpy >=2.0.2,<3
+    - pyvista >=0.48,<1
+    - rich >=13.0.0,<15
     - scipy >=1.11.0,<2
     - mmgsuite
     - if: python < '3.11'
-      then: typing-extensions >=4.0.0
+      then: typing-extensions >=4.0.0,<5
 
 tests:
   - python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.13.0.dev0"
+version = "0.13.0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.13.0"
+version = "0.14.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.13.0"
+    assert mmgpy.__version__ == "0.14.0.dev0"
 
 
 def test_mmg_version() -> None:

--- a/tests/mmgpy_test.py
+++ b/tests/mmgpy_test.py
@@ -5,7 +5,7 @@ import mmgpy
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert mmgpy.__version__ == "0.13.0.dev0"
+    assert mmgpy.__version__ == "0.13.0"
 
 
 def test_mmg_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.13.0"
+version = "0.14.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.13.0.dev0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Bump version to `0.13.0` in `pyproject.toml`, `conda/recipe.yaml`, `tests/mmgpy_test.py`, and `uv.lock`.

## Changes

- Version bump to `0.13.0`
- Conda recipe: drop `meshio` (no longer a runtime dep), align pins with `pyproject.toml` (`numpy<3`, `pyvista>=0.48,<1`, `rich<15`, `python>=3.10`, `typing-extensions<5`)