### PR TITLE
fix(ci): allow PyPI for transitive deps in validate-release

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -214,7 +214,9 @@ jobs:
           # Let uv pick the matching wheel for the venv's Python from
           # wheelhouse/. We deliberately do NOT `uv sync` here, which would
           # build mmgpy from source and shadow the wheel under test.
-          uv pip install --python .venv/bin/python --no-index --find-links wheelhouse mmgpy
+          # --find-links makes the local wheel win for mmgpy; PyPI is still
+          # used for transitive deps (numpy, pyvista, ...).
+          uv pip install --python .venv/bin/python --find-links wheelhouse mmgpy
           # fedoo is needed for the elasticity_propagation example.
           uv pip install --python .venv/bin/python pytest pytest-codeblocks pytest-pyvista fedoo
       - name: Verify the installed mmgpy is the wheel


### PR DESCRIPTION
## Summary

The `validate-release` job (added in #247) used `uv pip install --no-index --find-links wheelhouse mmgpy`, which forbids PyPI for *all* packages including transitive deps. mmgpy resolves locally but `numpy>=2.0.2,<3` has no candidate, so the v0.13.0 release validation failed.

## Changes

- Drop `--no-index`; keep `--find-links wheelhouse` so the local mmgpy wheel still wins, while PyPI is used for transitive deps