### PR TITLE
docs: switch README and lagging docs to pv.read + .mmg accessor

### DIFF
--- a/.github/workflows/redeploy-docs.yml
+++ b/.github/workflows/redeploy-docs.yml
@@ -1,8 +1,16 @@
 name: Redeploy docs
 
 # Manually rebuild a versioned doc slot (e.g. `0.13`) from any ref.
-# Use for doc-only fixes on already-released versions, when cutting a
+# Intended for doc-only fixes on already-released versions when cutting a
 # new tag is overkill.
+#
+# Typical workflow for a doc fix on an already-shipped release:
+#   1. Branch from the release tag:    git switch -c docs-backport/0.13 v0.13.0
+#   2. Cherry-pick the doc commits:    git cherry-pick <sha>...
+#   3. Push, then run this workflow with version=0.13, ref=docs-backport/0.13.
+#
+# Do NOT run with ref=main against an older version slot: main may describe
+# newer API that did not exist in that release.
 
 on:
   workflow_dispatch:
@@ -11,11 +19,10 @@ on:
         description: 'Mike version slot to write (e.g. "0.13"). Use the minor version, not the patch.'
         required: true
       ref:
-        description: "Git ref to build from (branch, tag, or SHA). Defaults to main."
+        description: "Git ref to build from. Typically a backport branch off the release tag, NOT main."
         required: true
-        default: main
       set_latest:
-        description: "Also update the `latest` alias to this version. Leave off when redeploying an older release."
+        description: "Also update the `latest` alias. Enable only if redeploying the currently-latest release."
         required: true
         default: false
         type: boolean

--- a/.github/workflows/redeploy-docs.yml
+++ b/.github/workflows/redeploy-docs.yml
@@ -1,0 +1,71 @@
+name: Redeploy docs
+
+# Manually rebuild a versioned doc slot (e.g. `0.13`) from any ref.
+# Use for doc-only fixes on already-released versions, when cutting a
+# new tag is overkill.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Mike version slot to write (e.g. "0.13"). Use the minor version, not the patch.'
+        required: true
+      ref:
+        description: "Git ref to build from (branch, tag, or SHA). Defaults to main."
+        required: true
+        default: main
+      set_latest:
+        description: "Also update the `latest` alias to this version. Leave off when redeploying an older release."
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - run: uv python install 3.12
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libvtk9-dev qtbase5-dev qt5-qmake libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev
+          version: 1.0
+
+      - run: uv sync --group docs
+
+      - name: Configure Git for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate version input
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version input must be MAJOR.MINOR (e.g. '0.13'), got '${{ inputs.version }}'"
+            exit 1
+          fi
+
+      - name: Deploy with mike
+        run: |
+          if [[ "${{ inputs.set_latest }}" == "true" ]]; then
+            uv run mike deploy "${{ inputs.version }}" latest --update-aliases --push
+            uv run mike set-default latest --push
+          else
+            uv run mike deploy "${{ inputs.version }}" --push
+          fi

--- a/README.md
+++ b/README.md
@@ -7,24 +7,25 @@
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://kmarchais.github.io/mmgpy)
 [![codecov](https://codecov.io/gh/kmarchais/mmgpy/graph/badge.svg)](https://codecov.io/gh/kmarchais/mmgpy)
 
-**mmgpy** brings the power of [MMG](https://www.mmgtools.org) mesh adaptation to Python. Generate, optimize, and refine 2D, 3D, and surface meshes with a clean API.
+**mmgpy** brings the power of [MMG](https://www.mmgtools.org) mesh adaptation to Python. Generate, optimize, and refine 2D, 3D, and surface meshes through a native PyVista accessor.
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers the .mmg accessor + Medit reader/writer
 
-mesh = mmgpy.read("input.vtk")
-mesh.remesh(hmax=0.1)
-mesh.save("output.vtk")
+mesh = pv.read("input.mesh")
+remeshed = mesh.mmg.remesh(hmax=0.1)
+remeshed.save("output.vtk")
 ```
 
 ![Mechanical piece remeshing](assets/mechanical_piece_remeshing.png)
 
 ## Try It
 
-No installation needed — run directly with [uvx](https://docs.astral.sh/uv/):
+No installation needed, run directly with [uvx](https://docs.astral.sh/uv/):
 
 ```bash
-# Remesh a mesh file
+# Remesh a mesh file from the command line
 uvx mmgpy input.stl -o output.mesh -hmax 0.1
 
 # Launch the interactive UI
@@ -39,7 +40,7 @@ The recommended way to install mmgpy:
 uv pip install mmgpy
 ```
 
-This uses pre-built wheels from PyPI that bundle all native libraries (MMG, VTK) — no compiler needed.
+This uses pre-built wheels from PyPI that bundle all native libraries (MMG, VTK), no compiler needed.
 
 ### Other install methods
 
@@ -52,6 +53,9 @@ conda install -c conda-forge mmgpy
 
 # With UI support
 uv pip install "mmgpy[ui]"
+
+# With elasticity-based displacement propagation
+uv pip install "mmgpy[fem]"
 ```
 
 ### Using uv for project management
@@ -73,73 +77,159 @@ uv tool install "mmgpy[ui]"  # install CLI tools + UI globally
 
 Use **PyPI** (`uv pip install`) for the fastest setup. Use **conda-forge** when you already have a conda environment with VTK, PyVista, or other scientific packages.
 
-Lagrangian motion (boundary-driven mesh displacement) is available on every channel via `mmgpy.move_mesh`, with a built-in Laplacian propagator and an optional elasticity propagator backed by [`fedoo`](https://github.com/3MAH/fedoo) (`uv pip install "mmgpy[fem]"`).
+## How it works
+
+Importing `mmgpy` registers a PyVista plugin that adds two things to every `pv.UnstructuredGrid` and `pv.PolyData`:
+
+- A **`.mmg` accessor** that exposes the full MMG API: `remesh`, `remesh_optimize`, `remesh_uniform`, `remesh_levelset`, `move`, `validate`, `element_qualities`, and more.
+- A **Medit reader/writer** for `.mesh` and `.meshb` files (with auto-loading of companion `.sol` files into `point_data` / `cell_data`).
+
+Every accessor call returns a fresh PyVista dataset, so the result composes with the rest of the PyVista API (slicing, plotting, IO).
 
 ## Features
 
-- **Multi-dimensional** — 2D triangular, 3D tetrahedral, and surface meshes
-- **Local refinement** — Control mesh density with spheres, boxes, cylinders
-- **Anisotropic adaptation** — Metric tensors for directional refinement, including least-squares Hessian recovery from a scalar field
-- **Level-set discretization** — Extract isosurfaces from implicit functions
-- **Lagrangian motion** — Move boundaries and remesh, with Laplacian or (optional) elasticity-based propagation
-- **PyVista integration** — Visualize and convert meshes seamlessly
-- **40+ file formats** — VTK, STL, OBJ, GMSH, and more
+- **Multi-dimensional**, 2D triangular, 3D tetrahedral, and surface meshes (auto-detected from cell types via `dataset.mmg.kind`).
+- **Local refinement**, sphere / box / cylinder / point-based sizing, passed as `local_sizing=[...]` on `remesh`.
+- **Anisotropic adaptation**, metric tensors in `point_data["metric"]`, including least-squares Hessian recovery from a scalar field.
+- **Level-set discretization**, extract isosurfaces from implicit functions via `mesh.mmg.remesh_levelset(...)`; multi-material splits via `set_multi_materials`.
+- **Lagrangian motion**, move boundaries and remesh through `mesh.mmg.move(displacement, ...)`, with a Laplacian propagator or an optional elasticity backend (`fedoo`).
+- **Required entities**, lock vertices, edges, triangles, or tetrahedra during remeshing via kwargs (`required_triangles=...`) or `mmg_*` data tags.
+- **Companion `.sol` I/O**, scalar / vector / tensor fields via `load_sol`, `save_sol`, `load_all_sols`, `save_all_sols`.
+- **Validation & quality**, `mesh.mmg.validate(detailed=True)` returns a `ValidationReport`; `mesh.mmg.element_qualities()` returns MMG's in-radius ratios.
+- **40+ file formats**, native Medit, plus everything PyVista supports (VTK, STL, OBJ, GMSH, MED, Abaqus, etc.; install `pyvista[io]` for meshio-backed formats).
 
 ## Usage
 
-### Basic Remeshing
+### Basic remeshing
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401
 
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh(hmax=0.1)
+mesh = pv.read("input.mesh")
+remeshed = mesh.mmg.remesh(hmax=0.1)
 
-print(f"Quality: {result.quality_mean_before:.2f} → {result.quality_mean_after:.2f}")
-mesh.save("output.vtk")
+q_before = mesh.mmg.element_qualities()
+q_after = remeshed.mmg.element_qualities()
+print(f"Quality: {q_before.mean():.2f} -> {q_after.mean():.2f}")
+
+remeshed.save("output.vtk")
 ```
 
-### Local Sizing
+### Local sizing
+
+Refine inside specific regions without touching the rest of the mesh:
 
 ```python
-mesh = mmgpy.read("input.mesh")
-
-# Fine mesh near a point
-mesh.set_size_sphere(center=[0.5, 0.5, 0.5], radius=0.2, size=0.01)
-
-# Fine mesh in a region
-mesh.set_size_box(bounds=[[0, 0, 0], [0.3, 0.3, 0.3]], size=0.02)
-
-mesh.remesh(hmax=0.1)
+remeshed = mesh.mmg.remesh(
+    hmax=0.1,
+    local_sizing=[
+        {"shape": "sphere", "center": [0.5, 0.5, 0.5], "radius": 0.2, "size": 0.01},
+        {"shape": "box", "bounds": [[0, 0, 0], [0.3, 0.3, 0.3]], "size": 0.02},
+        {"shape": "cylinder", "point1": [0, 0, 0], "point2": [0, 0, 1],
+         "radius": 0.1, "size": 0.01},
+        {"shape": "from_point", "point": [0.5, 0.5, 0.5],
+         "near_size": 0.01, "far_size": 0.1, "influence_radius": 0.3},
+    ],
+)
 ```
 
-### Typed Options
+### Typed options
 
 ```python
 from mmgpy import Mmg3DOptions
 
 opts = Mmg3DOptions(hmin=0.01, hmax=0.1, hausd=0.001)
-mesh.remesh(opts)
+remeshed = mesh.mmg.remesh(opts)
 
 # Or use presets
-mesh.remesh(Mmg3DOptions.fine())
+remeshed = mesh.mmg.remesh(Mmg3DOptions.fine(hmax=0.05))
+```
+
+### Anisotropic metrics
+
+Drop a per-vertex metric on `point_data["metric"]` and `remesh()` picks it up:
+
+```python
+import numpy as np
+import mmgpy.metrics as metrics
+
+sizes = np.full(mesh.n_points, 0.05)
+mesh.point_data["metric"] = metrics.create_isotropic_metric(sizes)
+
+remeshed = mesh.mmg.remesh()
+```
+
+For solution-adaptive remeshing, recover a Hessian and convert it to a metric:
+
+```python
+from mmgpy.metrics import compute_hessian, create_metric_from_hessian
+
+hessian = compute_hessian(vertices, triangles, field)
+mesh.point_data["metric"] = create_metric_from_hessian(
+    hessian, target_error=5e-3, hmin=3e-3, hmax=8e-2,
+)
+remeshed = mesh.mmg.remesh(hgrad=2.0)
+```
+
+### Level-set discretization
+
+```python
+import numpy as np
+
+levelset = (
+    np.linalg.norm(mesh.points - [0.5, 0.5, 0.5], axis=1) - 0.3
+).reshape(-1, 1)
+
+discretized = mesh.mmg.remesh_levelset(levelset)
+```
+
+### Lagrangian motion
+
+Apply a per-vertex displacement and remesh to maintain element quality:
+
+```python
+import numpy as np
+
+displacement = np.zeros((mesh.n_points, 3))
+displacement[:, 0] = 0.1
+
+moved = mesh.mmg.move(displacement, hmax=0.1)
+```
+
+Pass only boundary values plus `propagate=True` to fill the interior. The default is a Laplacian smoother; pass `propagation_method="elasticity"` to use the `fedoo`-backed linear-elasticity solver (`uv pip install "mmgpy[fem]"`).
+
+### Locking entities
+
+Keep specific vertices, edges, triangles, or tetrahedra fixed during remeshing:
+
+```python
+remeshed = mesh.mmg.remesh(
+    hmax=0.1,
+    required_triangles=np.array([3, 7, 11], dtype=np.int32),
+)
+```
+
+Or attach the constraint to the dataset (it travels through `save` / `copy`):
+
+```python
+mask = np.zeros(mesh.n_cells, dtype=bool)
+mask[[3, 7, 11]] = True
+mesh.cell_data["mmg_required_triangles"] = mask
+remeshed = mesh.mmg.remesh(hmax=0.1)
 ```
 
 ### Visualization
 
 ```python
-mesh.plot()  # Quick plot with edges
-
-# Or for custom plotting:
-import pyvista as pv
-plotter = pv.Plotter()
-plotter.add_mesh(mesh.vtk, show_edges=True, color="lightblue")
-plotter.show()
+remeshed.plot(show_edges=True)
 ```
+
+The accessor returns a regular PyVista dataset, so anything PyVista does (slicing, integration, custom plotters) works directly on the result.
 
 ## Command Line
 
-MMG executables are included and available after installation:
+MMG executables are bundled with the wheel:
 
 ```bash
 # Auto-detect mesh type
@@ -175,7 +265,7 @@ The `_O3` suffix variants (`mmg3d_O3`, etc.) are also available for compatibilit
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and the pull request process.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and the pull request process.
 
 ## License
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -38,12 +38,16 @@ This section provides detailed API documentation for all public classes and func
 
 ### I/O Functions
 
-| Function                                     | Description                                                      |
-| -------------------------------------------- | ---------------------------------------------------------------- |
-| `pv.read(...)` (PyVista)                     | Preferred: handles `.mesh` / `.meshb` via mmgpy's reader plugin  |
-| [`read()`](io.md#mmgpy.read)                 | **Deprecated in 0.13, removed in 0.14.** Use `pv.read()` instead |
-| [`from_pyvista()`](io.md#mmgpy.from_pyvista) | Create mesh from PyVista                                         |
-| [`to_pyvista()`](io.md#mmgpy.to_pyvista)     | Convert mesh to PyVista                                          |
+| Function                                     | Description                                                     |
+| -------------------------------------------- | --------------------------------------------------------------- |
+| `pv.read(...)` (PyVista)                     | Handles `.mesh` / `.meshb` via mmgpy's reader plugin            |
+| `dataset.save(...)` (PyVista)                | Handles `.mesh` / `.meshb` via mmgpy's writer plugin            |
+| [`from_pyvista()`](io.md#mmgpy.from_pyvista) | Low-level: convert PyVista dataset to an `MmgMesh*` impl        |
+| [`to_pyvista()`](io.md#mmgpy.to_pyvista)     | Low-level: convert an `MmgMesh*` impl back to a PyVista dataset |
+
+!!! warning "Deprecated: `mmgpy.read`"
+`mmgpy.read(...)` emits a `DeprecationWarning` since 0.13 and will be
+removed in 0.14. Use `pv.read(...)` and the `.mmg` accessor instead.
 
 ### Modules
 

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -6,11 +6,25 @@ mmgpy registers a Medit reader/writer plugin with PyVista on import, so `pv.read
 
 ## Reading Meshes
 
-::: mmgpy.read
-options:
-show_root_heading: true
+Use `pyvista.read` for everything. With `mmgpy` imported, the same call also reads MMG's native Medit format:
 
-`mmgpy.read` is **deprecated in 0.13 and will be removed in 0.14**. It still returns the same internal `Mesh` wrapper as in 0.12 (so existing `mesh = mmgpy.read(...); mesh.remesh(...)` code keeps running), but it emits a `DeprecationWarning`. New code should call `pv.read(...)` directly and use the `.mmg` accessor: `pv.read(...)` works for any PyVista-supported format, and with `mmgpy` installed it additionally handles `.mesh` / `.meshb` via the registered Medit reader plugin.
+```python
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers reader/writer + accessor
+
+mesh = pv.read("input.mesh")    # MMG native (via mmgpy's plugin)
+mesh = pv.read("input.meshb")   # MMG binary
+mesh = pv.read("input.vtu")     # VTK XML
+mesh = pv.read("input.stl")     # STL surface
+```
+
+The reader plugin auto-detects volumetric vs surface vs 2D meshes from the file's `Dimension` keyword and element population. A sibling `.sol` file (same stem, same directory) is auto-loaded into `point_data` / `cell_data`.
+
+!!! warning "Deprecated: `mmgpy.read`"
+`mmgpy.read(...)` is kept as a compatibility shim that returns the old
+internal `Mesh` wrapper. It emits a `DeprecationWarning` and will be
+removed in 0.14. New code should call `pv.read(...)` and use the `.mmg`
+accessor.
 
 ### Supported Formats
 

--- a/docs/api/lagrangian.md
+++ b/docs/api/lagrangian.md
@@ -118,24 +118,21 @@ print(f"Cells: {mesh.n_cells} -> {remeshed.n_cells}")
 
 ### Boundary-Only Displacement
 
-Move only boundary vertices:
+Move only boundary vertices and let `move()` propagate the displacement into the interior. PyVista's `extract_surface` gives the boundary vertex set for any mesh kind:
 
 <!-- pytest-codeblocks:skip -->
 
 ```python
 import numpy as np
 import pyvista as pv
-from mmgpy import detect_boundary_vertices
 import mmgpy  # noqa: F401
 
 mesh = pv.read("input.mesh")
-vertices = np.asarray(mesh.points)
+surface = mesh.extract_surface()
+boundary_mask = np.zeros(mesh.n_points, dtype=bool)
+boundary_mask[surface.point_data["vtkOriginalPointIds"]] = True
 
-# detect_boundary_vertices accepts the underlying impl; fetch via _io.read
-from mmgpy import read as mmgpy_read
-boundary_mask = detect_boundary_vertices(mmgpy_read(mesh)._impl_unwrap)
-
-displacement = np.zeros((len(vertices), 3))
+displacement = np.zeros((mesh.n_points, 3))
 displacement[boundary_mask, 2] = 0.05
 
 moved = mesh.mmg.move(

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -6,8 +6,10 @@ This page documents the metric tensor operations in the `mmgpy.metrics` module.
 
 Metric tensors control anisotropic mesh adaptation. A metric at each vertex specifies:
 
-- **Isotropic**: Target edge length (single scalar)
-- **Anisotropic**: Target lengths along different directions (tensor)
+- **Isotropic**, target edge length (single scalar or `(n,1)` array).
+- **Anisotropic**, target lengths along principal directions (a symmetric tensor in Voigt form).
+
+The metric is attached to the dataset as `point_data["metric"]`; `dataset.mmg.remesh(...)` automatically picks it up.
 
 ## Metric Creation
 
@@ -70,22 +72,17 @@ show_root_heading: true
 Create a metric for uniform element sizes:
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers reader/writer + accessor
 import mmgpy.metrics as metrics
 import numpy as np
 
-mesh = mmgpy.read("input.mesh")
-n_vertices = len(mesh.get_vertices())
+mesh = pv.read("input.mesh")
 
-# Uniform size everywhere
-sizes = np.ones(n_vertices) * 0.1
-metric = metrics.create_isotropic_metric(sizes)
+sizes = np.ones(mesh.n_points) * 0.1
+mesh.point_data["metric"] = metrics.create_isotropic_metric(sizes)
 
-# Apply to mesh (auto-detects tensor from shape)
-mesh["metric"] = metric
-
-# Remesh using the metric
-result = mesh.remesh()
+remeshed = mesh.mmg.remesh()
 ```
 
 ### Variable Size Metric
@@ -97,14 +94,14 @@ Size varying with position:
 ```python
 import numpy as np
 
-vertices = mesh.get_vertices()
+vertices = np.asarray(mesh.points)
 
 # Size increases with distance from origin
 distances = np.linalg.norm(vertices, axis=1)
 sizes = 0.01 + 0.1 * distances
 
-metric = metrics.create_isotropic_metric(sizes)
-mesh["metric"] = metric
+mesh.point_data["metric"] = metrics.create_isotropic_metric(sizes)
+remeshed = mesh.mmg.remesh()
 ```
 
 ### Anisotropic Metric
@@ -116,16 +113,13 @@ Different sizes in different directions:
 ```python
 import numpy as np
 
-n_vertices = len(mesh.get_vertices())
-
-# Create anisotropic metric for a single vertex, then tile
 # sizes: desired element sizes along each principal direction
 sizes = np.array([0.1, 0.1, 0.05])  # Smaller in z
 
 single_tensor = metrics.create_anisotropic_metric(sizes)
-metric = np.tile(single_tensor, (n_vertices, 1))
+mesh.point_data["metric"] = np.tile(single_tensor, (mesh.n_points, 1))
 
-mesh["metric"] = metric
+remeshed = mesh.mmg.remesh()
 ```
 
 ### Metric from Hessian
@@ -135,20 +129,19 @@ Adapt mesh to solution curvature:
 <!-- pytest-codeblocks:skip -->
 
 ```python
-# Solution field (e.g., temperature)
+from mmgpy.metrics import compute_hessian, create_metric_from_hessian
+
 solution = np.sin(vertices[:, 0] * 2 * np.pi)
+hessian = compute_hessian(vertices, triangles, solution)
 
-# Compute Hessian (second derivatives) - requires additional computation
-# hessian shape: (n_vertices, 6) for symmetric 3x3 tensor
-hessian = compute_hessian(solution, mesh)  # Implementation needed
-
-# Create metric from Hessian
-metric = metrics.create_metric_from_hessian(
+mesh.point_data["metric"] = create_metric_from_hessian(
     hessian,
-    target_error=0.01,  # Target interpolation error
+    target_error=0.01,
+    hmin=1e-3,
+    hmax=1e-1,
 )
 
-mesh["metric"] = metric
+adapted = mesh.mmg.remesh(hgrad=2.0)
 ```
 
 ### Metric Intersection
@@ -158,16 +151,13 @@ Combine multiple metrics (minimum size wins):
 <!-- pytest-codeblocks:cont -->
 
 ```python
-# Two different metrics with different sizes
-n_vertices = len(mesh.get_vertices())
-sizes1 = np.ones(n_vertices) * 0.05
-sizes2 = np.ones(n_vertices) * 0.08
+sizes1 = np.ones(mesh.n_points) * 0.05
+sizes2 = np.ones(mesh.n_points) * 0.08
 metric1 = metrics.create_isotropic_metric(sizes1)
 metric2 = metrics.create_isotropic_metric(sizes2)
 
-# Intersect: take minimum size in all directions
 combined = metrics.intersect_metrics(metric1, metric2)
-mesh["metric"] = combined
+mesh.point_data["metric"] = combined
 ```
 
 ### Extracting Metric Information
@@ -175,14 +165,12 @@ mesh["metric"] = combined
 <!-- pytest-codeblocks:cont -->
 
 ```python
-# Get current metric
-metric = mesh["metric"]
+metric = np.asarray(mesh.point_data["metric"])
 
-# Extract principal sizes and directions
 sizes, directions = metrics.compute_metric_eigenpairs(metric)
 
-# sizes shape: (n_vertices, 3) - element sizes along each principal direction
-# directions shape: (n_vertices, 3, 3) - principal directions as columns
+# sizes shape: (n_vertices, dim) — element sizes along each principal direction
+# directions shape: (n_vertices, dim, dim) — principal directions as columns
 
 print(f"Size range: {sizes.min():.4f} to {sizes.max():.4f}")
 ```
@@ -200,12 +188,10 @@ MMG uses symmetric tensors in Voigt notation:
 # 2D: 3 components per vertex
 # [M11, M12, M22]
 
-# Convert tensor to full matrix
-tensor = mesh["metric"][0]  # First vertex
+tensor = np.asarray(mesh.point_data["metric"])[0]  # First vertex
 matrix = metrics.tensor_to_matrix(tensor)
 print(matrix.shape)  # (3, 3)
 
-# Convert matrix back to tensor
 tensor_back = metrics.matrix_to_tensor(matrix)
 ```
 
@@ -216,9 +202,8 @@ Check metric tensor validity:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-metric = mesh["metric"]
+metric = np.asarray(mesh.point_data["metric"])
 
-# Validate: must be symmetric positive definite
 is_valid = metrics.validate_metric_tensor(metric)
 if not is_valid:
     print("Warning: invalid metric tensor")
@@ -236,7 +221,7 @@ M = [M12  M22  M23]  -> [M11, M12, M13, M22, M23, M33]
     [M13  M23  M33]
 ```
 
-Metric field shape: `(n_vertices, 6)`
+Metric field shape: `(n_vertices, 6)`.
 
 ### 2D Metrics (TRIANGULAR_2D)
 
@@ -247,20 +232,16 @@ Symmetric 2x2 tensor stored as 3 components:
 M = [M12  M22]  -> [M11, M12, M22]
 ```
 
-Metric field shape: `(n_vertices, 3)`
+Metric field shape: `(n_vertices, 3)`.
 
 ### Surface Metrics (TRIANGULAR_SURFACE)
 
-Same as 3D: `(n_vertices, 6)`
+Same as 3D: `(n_vertices, 6)`.
 
 ## Tips
 
-1. **Isotropic first**: Start with isotropic metrics, add anisotropy only when needed
-
-2. **Size bounds**: Ensure metric sizes are within reasonable bounds relative to domain size
-
-3. **Gradation**: MMG's `hgrad` parameter controls size gradation regardless of metric
-
-4. **Validation**: Always validate metric tensors before remeshing
-
-5. **Combination**: Use `intersect_metrics` to combine sizing from different sources
+1. **Isotropic first**, start with isotropic metrics, add anisotropy only when needed.
+2. **Size bounds**, ensure metric sizes are within reasonable bounds relative to the domain.
+3. **Gradation**, MMG's `hgrad` parameter controls size gradation regardless of metric.
+4. **Validation**, always validate metric tensors before remeshing.
+5. **Combination**, use `intersect_metrics` to combine sizing from different sources.

--- a/docs/api/results-validation.md
+++ b/docs/api/results-validation.md
@@ -4,7 +4,7 @@ This page documents the result and validation classes returned by mmgpy operatio
 
 ## RemeshResult
 
-Every remeshing operation returns a `RemeshResult` dataclass with statistics:
+`RemeshResult` is a dataclass that captures the before/after statistics emitted by MMG. It is returned by the lower-level `mmgpy.mmg3d.remesh(...)` / `mmgpy.mmg2d.remesh(...)` / `mmgpy.mmgs.remesh(...)` functions; the `.mmg` accessor does the same work and returns a fresh PyVista dataset, with quality numbers accessible via `dataset.mmg.element_qualities()` and validation via `dataset.mmg.validate(...)`.
 
 ::: mmgpy.RemeshResult
 options:
@@ -13,30 +13,34 @@ show_root_heading: true
 ### Usage
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers reader/writer + accessor
 
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh(hmax=0.1)
+mesh = pv.read("input.mesh")
+remeshed = mesh.mmg.remesh(hmax=0.1)
 
-# Access statistics
-print(f"Vertices: {result.vertices_before} -> {result.vertices_after}")
-print(f"Elements: {result.elements_before} -> {result.elements_after}")
-print(f"Triangles: {result.triangles_before} -> {result.triangles_after}")
-print(f"Edges: {result.edges_before} -> {result.edges_after}")
+# Before/after sizes
+print(f"Vertices: {mesh.n_points} -> {remeshed.n_points}")
+print(f"Cells:    {mesh.n_cells} -> {remeshed.n_cells}")
 
-# Quality metrics
-print(f"Min quality: {result.quality_min_before:.3f} -> {result.quality_min_after:.3f}")
-print(f"Mean quality: {result.quality_mean_before:.3f} -> {result.quality_mean_after:.3f}")
+# MMG in-radius-ratio quality (1.0 = equilateral)
+q_before = mesh.mmg.element_qualities()
+q_after = remeshed.mmg.element_qualities()
+print(f"Min quality:  {q_before.min():.3f} -> {q_after.min():.3f}")
+print(f"Mean quality: {q_before.mean():.3f} -> {q_after.mean():.3f}")
+```
 
-# Timing
-print(f"Duration: {result.duration_seconds:.2f}s")
+If you need the structured `RemeshResult` (return code, MMG warnings, duration), reach for the underlying module-level entry points:
 
-# Warnings from MMG
+<!-- pytest-codeblocks:skip -->
+
+```python
+from mmgpy import mmg3d
+result = mmg3d.remesh("input.mesh", "output.mesh", hmax=0.1)
+print(f"Return code: {result.return_code}")
+print(f"Duration:    {result.duration_seconds:.2f}s")
 for warning in result.warnings:
     print(f"Warning: {warning}")
-
-# Return code
-print(f"Return code: {result.return_code}")
 ```
 
 ## Validation Classes
@@ -76,12 +80,13 @@ show_root_heading: true
 ### Quick Validation
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401
 
-mesh = mmgpy.read("input.mesh")
+mesh = pv.read("input.mesh")
 
 # Returns True/False
-if mesh.validate():
+if mesh.mmg.validate():
     print("Mesh is valid")
 else:
     print("Mesh has issues")
@@ -92,16 +97,14 @@ else:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-report = mesh.validate(detailed=True)
+report = mesh.mmg.validate(detailed=True)
 
 print(f"Valid: {report.is_valid}")
-# Quality statistics
-print(f"Quality min: {report.quality.min:.3f}")
-print(f"Quality max: {report.quality.max:.3f}")
+print(f"Quality min:  {report.quality.min:.3f}")
+print(f"Quality max:  {report.quality.max:.3f}")
 print(f"Quality mean: {report.quality.mean:.3f}")
-print(f"Quality std: {report.quality.std:.3f}")
+print(f"Quality std:  {report.quality.std:.3f}")
 
-# Issues
 for issue in report.issues:
     print(f"[{issue.severity.name}] {issue.message}")
 ```
@@ -114,7 +117,7 @@ for issue in report.issues:
 from mmgpy import ValidationError
 
 try:
-    mesh.validate(strict=True)
+    mesh.mmg.validate(strict=True)
     print("Mesh passed strict validation")
 except ValidationError as e:
     print(f"Validation failed: {e}")
@@ -128,52 +131,46 @@ except ValidationError as e:
 
 ```python
 # Only check geometry
-report = mesh.validate(
+report = mesh.mmg.validate(
     detailed=True,
     check_geometry=True,
     check_topology=False,
     check_quality=False,
 )
 
-# Only check quality with custom threshold
-report = mesh.validate(
+# Only check quality with a custom threshold
+report = mesh.mmg.validate(
     detailed=True,
     check_geometry=False,
     check_topology=False,
     check_quality=True,
-    min_quality=0.2,  # Custom threshold
+    min_quality=0.2,
 )
 ```
 
 ## Complete Example
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401
 from mmgpy import ValidationError
 
-# Load mesh
-mesh = mmgpy.read("input.mesh")
+mesh = pv.read("input.mesh")
 
-# Initial validation
-initial = mesh.validate(detailed=True)
+initial = mesh.mmg.validate(detailed=True)
 print(f"Initial quality: {initial.quality.mean:.3f}")
-
 if not initial.is_valid:
-    print("Initial mesh has issues:")
     for issue in initial.issues:
         print(f"  - {issue.message}")
 
-# Remesh
-result = mesh.remesh(hmax=0.1, verbose=-1)
+remeshed = mesh.mmg.remesh(hmax=0.1, verbose=-1)
 
-# Post-remesh validation
 try:
-    mesh.validate(strict=True)
+    remeshed.mmg.validate(strict=True)
     print("Remeshed mesh is valid")
 except ValidationError as e:
     print(f"Remeshed mesh has issues: {len(e.report.issues)}")
 
-# Final report
-final = mesh.validate(detailed=True)
-print(f"\nQuality improved: {initial.quality.mean:.3f} -> {final.quality.mean:.3f}")
+final = remeshed.mmg.validate(detailed=True)
+print(f"Quality improved: {initial.quality.mean:.3f} -> {final.quality.mean:.3f}")
 ```

--- a/docs/api/sizing.md
+++ b/docs/api/sizing.md
@@ -163,7 +163,7 @@ constraints = [
 
 # Convert directly to an isotropic metric and remesh through point_data
 vertices = np.asarray(mesh.points)
-sizes = compute_sizes_from_constraints(vertices, constraints, default_size=0.1)
+sizes = compute_sizes_from_constraints(vertices, constraints)
 mesh.point_data["metric"] = sizes_to_metric(sizes)
 remeshed = mesh.mmg.remesh()
 ```
@@ -216,7 +216,7 @@ constraints = [
     SphereSize(center=np.array([0.5, 0.5, 0.5]), radius=0.2, size=0.01),
     BoxSize(bounds=np.array([[0, 0, 0], [0.3, 0.3, 0.3]]), size=0.02),
 ]
-sizes = compute_sizes_from_constraints(vertices, constraints, default_size=0.1)
+sizes = compute_sizes_from_constraints(vertices, constraints)
 
 mesh.point_data["metric"] = metrics.create_isotropic_metric(sizes)
 remeshed = mesh.mmg.remesh()

--- a/docs/api/sizing.md
+++ b/docs/api/sizing.md
@@ -4,7 +4,9 @@ This page documents the sizing constraint classes for local mesh refinement.
 
 ## Overview
 
-Sizing constraints define regions where specific element sizes should be used. Multiple constraints can be combined - where they overlap, the minimum size wins.
+Sizing constraints define regions where specific element sizes should be used. Multiple constraints can be combined: where they overlap, the minimum size wins.
+
+The recommended way to apply sizing constraints is to pass them as a `local_sizing=[...]` list of dicts to `dataset.mmg.remesh(...)`. The corresponding dataclasses (`SphereSize`, `BoxSize`, ...) are also exported for callers that prefer typed objects.
 
 ## Sizing Classes
 
@@ -38,92 +40,47 @@ show_root_heading: true
 options:
 show_root_heading: true
 
-## Mesh Methods
+## Accessor Usage
 
-All mesh classes have convenience methods for adding sizing constraints:
-
-```python
-import mmgpy
-
-mesh = mmgpy.read("input.mesh")
-```
-
-### set_size_sphere
-
-<!-- pytest-codeblocks:cont -->
+Pass sizing specifications to `mesh.mmg.remesh(...)` via the `local_sizing` keyword. Each entry is a dict with a `"shape"` key (`"sphere"`, `"box"`, `"cylinder"`, or `"from_point"`) plus the matching parameters:
 
 ```python
-mesh.set_size_sphere(
-    center=[0.5, 0.5, 0.5],  # Center of sphere
-    radius=0.2,              # Sphere radius
-    size=0.01,               # Target edge size
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers reader/writer + accessor
+
+mesh = pv.read("input.mesh")
+
+remeshed = mesh.mmg.remesh(
+    hmax=0.1,
+    local_sizing=[
+        {"shape": "sphere", "center": [0.5, 0.5, 0.5], "radius": 0.2, "size": 0.01},
+        {"shape": "box", "bounds": [[0, 0, 0], [0.3, 0.3, 0.3]], "size": 0.02},
+        {
+            "shape": "cylinder",
+            "point1": [0, 0, 0],
+            "point2": [0, 0, 1],
+            "radius": 0.1,
+            "size": 0.01,
+        },
+        {
+            "shape": "from_point",
+            "point": [0.5, 0.5, 0.5],
+            "near_size": 0.01,
+            "far_size": 0.1,
+            "influence_radius": 0.5,
+        },
+    ],
 )
 ```
 
-### set_size_box
+### Available shapes
 
-<!-- pytest-codeblocks:cont -->
-
-```python
-mesh.set_size_box(
-    bounds=[[0, 0, 0], [0.3, 0.3, 0.3]],  # [[min], [max]]
-    size=0.01,
-)
-```
-
-### set_size_cylinder
-
-<!-- pytest-codeblocks:cont -->
-
-```python
-# 3D meshes only
-mesh.set_size_cylinder(
-    point1=[0, 0, 0],    # First axis endpoint
-    point2=[0, 0, 1],    # Second axis endpoint
-    radius=0.1,          # Cylinder radius
-    size=0.01,
-)
-```
-
-### set_size_from_point
-
-<!-- pytest-codeblocks:cont -->
-
-```python
-mesh.set_size_from_point(
-    point=[0.5, 0.5, 0.5],
-    near_size=0.01,       # Size at reference point
-    far_size=0.1,         # Size at influence_radius
-    influence_radius=0.5,
-)
-```
-
-### clear_local_sizing
-
-<!-- pytest-codeblocks:cont -->
-
-```python
-# Remove all sizing constraints
-mesh.clear_local_sizing()
-```
-
-### get_local_sizing_count
-
-<!-- pytest-codeblocks:cont -->
-
-```python
-# Check number of active constraints
-n = mesh.get_local_sizing_count()
-```
-
-### apply_local_sizing
-
-<!-- pytest-codeblocks:cont -->
-
-```python
-# Manually apply constraints to metric field
-mesh.apply_local_sizing()
-```
+| Shape        | Required parameters                                                  |
+| ------------ | -------------------------------------------------------------------- |
+| `sphere`     | `center`, `radius`, `size`                                           |
+| `box`        | `bounds` (a `[[xmin, ymin, zmin], [xmax, ymax, zmax]]` pair), `size` |
+| `cylinder`   | `point1`, `point2`, `radius`, `size` (3D only)                       |
+| `from_point` | `point`, `near_size`, `far_size`, `influence_radius`                 |
 
 ## Utility Functions
 
@@ -144,15 +101,17 @@ show_root_heading: true
 ### Basic Usage
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401
 
-mesh = mmgpy.read("input.mesh")
+mesh = pv.read("input.mesh")
 
-# Add refinement region
-mesh.set_size_sphere(center=[0.5, 0.5, 0.5], radius=0.2, size=0.01)
-
-# Remesh (sizing constraints applied automatically)
-result = mesh.remesh(hmax=0.1)
+remeshed = mesh.mmg.remesh(
+    hmax=0.1,
+    local_sizing=[
+        {"shape": "sphere", "center": [0.5, 0.5, 0.5], "radius": 0.2, "size": 0.01},
+    ],
+)
 ```
 
 ### Multiple Regions
@@ -160,32 +119,35 @@ result = mesh.remesh(hmax=0.1)
 <!-- pytest-codeblocks:cont -->
 
 ```python
-# Fine region
-mesh.set_size_sphere(center=[0.3, 0.5, 0.5], radius=0.1, size=0.005)
-
-# Medium region
-mesh.set_size_box(bounds=[[0.5, 0, 0], [1, 1, 1]], size=0.02)
-
-# Graded region
-mesh.set_size_from_point(
-    point=[0.8, 0.5, 0.5],
-    near_size=0.01,
-    far_size=0.05,
-    influence_radius=0.3,
+remeshed = mesh.mmg.remesh(
+    hmax=0.1,
+    local_sizing=[
+        # Fine region
+        {"shape": "sphere", "center": [0.3, 0.5, 0.5], "radius": 0.1, "size": 0.005},
+        # Medium region
+        {"shape": "box", "bounds": [[0.5, 0, 0], [1, 1, 1]], "size": 0.02},
+        # Graded region
+        {
+            "shape": "from_point",
+            "point": [0.8, 0.5, 0.5],
+            "near_size": 0.01,
+            "far_size": 0.05,
+            "influence_radius": 0.3,
+        },
+    ],
 )
-
-result = mesh.remesh(hmax=0.1)
 ```
 
-### Direct Class Usage
+### Using the Dataclasses Directly
 
 ```python
-import mmgpy
-from mmgpy import SphereSize, BoxSize
-from mmgpy.sizing import apply_sizing_constraints
 import numpy as np
+import pyvista as pv
+import mmgpy  # noqa: F401
+from mmgpy import SphereSize, BoxSize
+from mmgpy.sizing import compute_sizes_from_constraints, sizes_to_metric
 
-mesh = mmgpy.read("input.mesh")
+mesh = pv.read("input.mesh")
 
 constraints = [
     SphereSize(
@@ -199,72 +161,70 @@ constraints = [
     ),
 ]
 
-apply_sizing_constraints(mesh, constraints)
-result = mesh.remesh(hmax=0.1)
+# Convert directly to an isotropic metric and remesh through point_data
+vertices = np.asarray(mesh.points)
+sizes = compute_sizes_from_constraints(vertices, constraints, default_size=0.1)
+mesh.point_data["metric"] = sizes_to_metric(sizes)
+remeshed = mesh.mmg.remesh()
 ```
 
 ### Workflow with Validation
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401
 
-mesh = mmgpy.read("input.mesh")
+mesh = pv.read("input.mesh")
 
-# Add sizing constraints
-mesh.set_size_sphere(center=[0.5, 0.5, 0.5], radius=0.2, size=0.01)
+remeshed = mesh.mmg.remesh(
+    hmax=0.1,
+    verbose=-1,
+    local_sizing=[
+        {"shape": "sphere", "center": [0.5, 0.5, 0.5], "radius": 0.2, "size": 0.01},
+    ],
+)
 
-# Check constraint count
-print(f"Active constraints: {mesh.get_local_sizing_count()}")
+# Inspect the size map MMG used (also writes point_data["metric"] in place)
+sizes = remeshed.mmg.build_size_map()
+print(f"Metric sizes: {sizes.min():.4f} to {sizes.max():.4f}")
 
-# Preview metric field
-mesh.apply_local_sizing()
-metric = mesh["metric"]
-print(f"Metric sizes: {metric.min():.4f} to {metric.max():.4f}")
-
-# Remesh
-result = mesh.remesh(hmax=0.1, verbose=-1)
-
-# Clear for next iteration
-mesh.clear_local_sizing()
+assert remeshed.mmg.validate(), "remeshed mesh failed validation"
 ```
 
 ## How Sizing Works
 
-1. **Constraint Definition**: Each constraint defines a region and target size
-2. **Size Computation**: For each vertex, compute size from all constraints
-3. **Minimum Selection**: Where constraints overlap, minimum size wins
-4. **Metric Conversion**: Sizes are converted to isotropic metric tensors
-5. **Remeshing**: MMG uses the metric field to guide remeshing
+1. **Constraint Definition**, each constraint defines a region and a target size.
+2. **Size Computation**, for each vertex, MMG computes the size implied by every constraint.
+3. **Minimum Selection**, where constraints overlap, the smallest size wins.
+4. **Metric Conversion**, sizes are converted to isotropic metric tensors.
+5. **Remeshing**, MMG uses the metric field to guide remeshing.
+
+Constraints become the `point_data["metric"]` array on the remeshed dataset (an isotropic scalar). Build it manually if you want full control:
 
 ```python
-import mmgpy
+import numpy as np
+import pyvista as pv
+import mmgpy  # noqa: F401
 from mmgpy import SphereSize, BoxSize
 from mmgpy.sizing import compute_sizes_from_constraints
 import mmgpy.metrics as metrics
-import numpy as np
 
-mesh = mmgpy.read("input.mesh")
+mesh = pv.read("input.mesh")
+vertices = np.asarray(mesh.points)
 
-# Get vertex coordinates
-vertices = mesh.get_vertices()
-
-# Compute sizes from constraints
 constraints = [
     SphereSize(center=np.array([0.5, 0.5, 0.5]), radius=0.2, size=0.01),
     BoxSize(bounds=np.array([[0, 0, 0], [0.3, 0.3, 0.3]]), size=0.02),
 ]
-sizes = compute_sizes_from_constraints(vertices, constraints)
+sizes = compute_sizes_from_constraints(vertices, constraints, default_size=0.1)
 
-# Convert to metric tensor field
-metric = metrics.create_isotropic_metric(sizes)
-
-# Apply to mesh
-mesh["metric"] = metric
+mesh.point_data["metric"] = metrics.create_isotropic_metric(sizes)
+remeshed = mesh.mmg.remesh()
 ```
 
 ## Tips
 
-1. **Constraint Order**: Order doesn't matter - minimum size wins everywhere
-2. **Performance**: Many constraints have minimal overhead
-3. **Clearing**: Always clear constraints between different remeshing runs if needed
-4. **Debugging**: Use `apply_local_sizing()` to preview the metric field before remeshing
+1. **Constraint order does not matter**, the minimum size wins at every vertex.
+2. **Many constraints have minimal overhead**, fold them into one `remesh` call.
+3. **Combine with `hmax`**, `local_sizing` only tightens the metric inside its regions, the global `hmax` still applies elsewhere.
+4. **Debugging**, call `dataset.mmg.build_size_map()` to inspect the metric the accessor would feed to MMG.

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -1,6 +1,6 @@
 # File Formats
 
-mmgpy supports numerous file formats: the native Medit `.mesh`/`.meshb` reader is registered with PyVista at import; other formats are handled by PyVista directly. Formats not natively supported by VTK (e.g. `.msh`, `.med`, `.inp`) require `pip install pyvista[io]`, which pulls in meshio.
+mmgpy supports numerous file formats. The native Medit `.mesh`/`.meshb` reader and writer are registered with PyVista on import, so `pv.read("foo.mesh")` and `dataset.save("foo.mesh")` go through MMG's native I/O. Other formats are handled by PyVista directly. Formats not natively supported by VTK (e.g. `.msh`, `.med`, `.inp`) require `pip install pyvista[io]`, which pulls in meshio.
 
 ## Native MMG Format
 
@@ -70,9 +70,10 @@ End
 ## Format Selection Guide
 
 ```python
-import mmgpy
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers reader/writer + accessor
 
-mesh = mmgpy.read("input.mesh")
+mesh = pv.read("input.mesh")
 ```
 
 ### For MMG Processing
@@ -86,8 +87,8 @@ mesh.save("output.mesh")
 ```
 
 - Best compatibility with MMG
-- Supports all MMG-specific features
-- Can include solution/metric files
+- Supports all MMG-specific features (ridges, required entities, reference markers)
+- Companion `.sol` files are auto-loaded on read and round-trip via `mesh.mmg.save_sol(...)`
 
 ### For Visualization (ParaView)
 
@@ -104,11 +105,12 @@ mesh.save("output.vtu")   # XML (preferred)
 
 Use STL:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
+import pyvista as pv
+import mmgpy  # noqa: F401
+
 # Surface meshes only
-surface_mesh = mmgpy.read("model.stl")
+surface_mesh = pv.read("model.stl")
 surface_mesh.save("output.stl")
 ```
 
@@ -125,35 +127,47 @@ surface_mesh.save("output.stl")
 
 ## Solution Files
 
-MMG supports solution files (`.sol`) containing:
+MMG supports solution files (`.sol` / `.solb`) containing:
 
-- Scalar fields (temperature, pressure)
+- Scalar fields (temperature, pressure, level set, isotropic metric)
 - Vector fields (velocity, displacement)
-- Tensor fields (stress, metric)
+- Tensor fields (stress, anisotropic metric)
 
-### Creating Solution Files
+When reading a `.mesh` / `.meshb` file, a sibling `.sol` (same stem, same directory) is auto-loaded into `point_data` / `cell_data`. The reserved keys `metric`, `displacement`, `levelset`, `tensor` are routed to MMG's solution channel on remesh.
 
-<!-- pytest-codeblocks:cont -->
+### Writing companion `.sol` files
 
 ```python
 import numpy as np
+import pyvista as pv
+import mmgpy  # noqa: F401
 
-# Add scalar field
-temperature = np.random.rand(len(mesh.get_vertices()))
-mesh["temperature"] = temperature
+mesh = pv.read("input.mesh")
 
-# Save mesh and solution
-mesh.save("output.mesh")  # Also saves output.sol if fields exist
+# Scalar field on vertices
+mesh.point_data["temperature"] = np.random.rand(mesh.n_points)
+
+# Save every numeric vertex / cell array as a multi-block `.sol`
+mesh.mmg.save_all_sols("output.sol")
+
+# Or write only the MMG-reserved fields (metric / displacement / ...) with save_sol
+mesh.mmg.save_sol("output_metric.sol")
 ```
 
-### Loading Solution Files
-
-<!-- pytest-codeblocks:cont -->
+### Loading solution files
 
 ```python
-# Access user fields
-if "temperature" in mesh:
-    temp = mesh["temperature"]
+import pyvista as pv
+import mmgpy  # noqa: F401
+
+mesh = pv.read("input.mesh")
+
+# Attach extra fields from a separately-stored .sol
+mesh.mmg.load_all_sols("input_fields.sol")
+
+# Vertex-located arrays land in point_data; element-located arrays land in cell_data
+if "temperature" in mesh.point_data:
+    temp = mesh.point_data["temperature"]
 ```
 
 ## Binary vs ASCII
@@ -177,15 +191,16 @@ mesh.save("output.meshb")
 
 ## Format Detection
 
-mmgpy automatically detects format from extension:
-
-<!-- pytest-codeblocks:cont -->
+PyVista (and mmgpy's registered Medit reader) automatically detect the format from the file extension:
 
 ```python
-# Auto-detected from extension
-mesh = mmgpy.read("model.stl")
-mesh = mmgpy.read("simulation.vtu")
-mesh = mmgpy.read("domain.msh")
+import pyvista as pv
+import mmgpy  # noqa: F401
+
+mesh = pv.read("model.stl")
+mesh = pv.read("simulation.vtu")
+mesh = pv.read("domain.msh")
+mesh = pv.read("domain.mesh")  # Medit reader (provided by mmgpy)
 ```
 
 ## Troubleshooting
@@ -194,13 +209,13 @@ mesh = mmgpy.read("domain.msh")
 
 If a format is not recognized:
 
-1. Check the extension is correct
-2. Install `pyvista[io]` if the format is meshio-backed (`.msh`, `.med`, `.inp`, ...)
-3. Try converting to `.mesh` or `.vtk` first
+1. Check the extension is correct.
+2. Install `pyvista[io]` if the format is meshio-backed (`.msh`, `.med`, `.inp`, ...).
+3. Try converting to `.mesh` or `.vtk` first.
 
 ### Lost Data
 
-Some formats don't support all features:
+Some formats do not support all features:
 
 | Data Type     | .mesh    | .vtk | .stl |
 | ------------- | -------- | ---- | ---- |

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -1,11 +1,12 @@
 # MMG Parameters Reference
 
 ```python
-import mmgpy
-mesh = mmgpy.read("input.mesh")
+import pyvista as pv
+import mmgpy  # noqa: F401  -- registers reader/writer + .mmg accessor
+mesh = pv.read("input.mesh")
 ```
 
-Complete reference for all MMG remeshing parameters.
+Complete reference for the keyword arguments accepted by `dataset.mmg.remesh(...)` (and its variants `remesh_optimize`, `remesh_uniform`, `remesh_levelset`, `move`). Each call returns a fresh PyVista dataset; the input is not mutated.
 
 ## Size Parameters
 
@@ -22,7 +23,7 @@ Minimum edge length.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(hmin=0.01)
+remeshed = mesh.mmg.remesh(hmin=0.01)
 ```
 
 Edges shorter than `hmin` will be collapsed or lengthened.
@@ -42,7 +43,7 @@ Maximum edge length.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(hmax=0.1)
+remeshed = mesh.mmg.remesh(hmax=0.1)
 ```
 
 Edges longer than `hmax` will be split.
@@ -62,10 +63,7 @@ Uniform target edge size.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-# hsiz conflicts with prior metric, so reload the mesh
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh(hsiz=0.05)
-mesh = mmgpy.read("input.mesh")
+remeshed = mesh.mmg.remesh(hsiz=0.05)
 ```
 
 When set, overrides `hmin` and `hmax` with uniform sizing.
@@ -85,7 +83,7 @@ Gradation parameter controlling size transition.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(hgrad=1.2)
+remeshed = mesh.mmg.remesh(hgrad=1.2)
 ```
 
 - `hgrad=1.0`: No size variation allowed
@@ -98,7 +96,7 @@ result = mesh.remesh(hgrad=1.2)
 
 ### hausd
 
-Hausdorff distance - maximum distance between input and output geometry.
+Hausdorff distance, maximum distance between input and output geometry.
 
 | Property | Value                         |
 | -------- | ----------------------------- |
@@ -109,16 +107,16 @@ Hausdorff distance - maximum distance between input and output geometry.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(hausd=0.001)
+remeshed = mesh.mmg.remesh(hausd=0.001)
 ```
 
-Smaller values = better geometric approximation but more elements.
+Smaller values produce a closer geometric approximation at the cost of more elements.
 
 ---
 
-### angle
+### ar
 
-Ridge detection angle in degrees.
+Ridge detection angle (degrees).
 
 | Property | Value   |
 | -------- | ------- |
@@ -129,12 +127,11 @@ Ridge detection angle in degrees.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(ar=30)
+remeshed = mesh.mmg.remesh(ar=30)
 ```
 
-- Edges with dihedral angle > `ar` are treated as ridges
-- Ridges are preserved during remeshing
-- `angle=180`: No ridge detection
+- Edges with dihedral angle greater than `ar` are treated as ridges and preserved during remeshing.
+- `ar=180` disables ridge detection.
 
 ---
 
@@ -142,7 +139,7 @@ result = mesh.remesh(ar=30)
 
 ### optim
 
-Enable optimization mode.
+Enable optimization mode (no topology changes).
 
 | Property | Value           |
 | -------- | --------------- |
@@ -153,13 +150,10 @@ Enable optimization mode.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-# optim conflicts with prior metric, so reload the mesh
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh(optim=1)
-mesh = mmgpy.read("input.mesh")
+remeshed = mesh.mmg.remesh(optim=1)
 ```
 
-When enabled, only moves vertices to improve quality (no topology changes).
+When enabled, only moves vertices to improve quality.
 
 ---
 
@@ -176,7 +170,7 @@ Disable vertex insertion.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(noinsert=1)
+remeshed = mesh.mmg.remesh(noinsert=1)
 ```
 
 Prevents adding new vertices during remeshing.
@@ -187,16 +181,10 @@ Prevents adding new vertices during remeshing.
 
 Disable edge/face swapping.
 
-| Property | Value           |
-| -------- | --------------- |
-| Type     | `int`           |
-| Default  | 0               |
-| Values   | 0 (off), 1 (on) |
-
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(noswap=1)
+remeshed = mesh.mmg.remesh(noswap=1)
 ```
 
 Prevents topology changes via edge/face swaps.
@@ -207,16 +195,10 @@ Prevents topology changes via edge/face swaps.
 
 Disable vertex movement.
 
-| Property | Value           |
-| -------- | --------------- |
-| Type     | `int`           |
-| Default  | 0               |
-| Values   | 0 (off), 1 (on) |
-
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(nomove=1)
+remeshed = mesh.mmg.remesh(nomove=1)
 ```
 
 Keeps vertices at their original positions.
@@ -227,16 +209,10 @@ Keeps vertices at their original positions.
 
 Preserve surface vertices.
 
-| Property | Value           |
-| -------- | --------------- |
-| Type     | `int`           |
-| Default  | 0               |
-| Values   | 0 (off), 1 (on) |
-
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(nosurf=1)
+remeshed = mesh.mmg.remesh(nosurf=1)
 ```
 
 Prevents modification of surface mesh vertices.
@@ -258,23 +234,22 @@ Verbosity level.
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(verbose=-1)  # Silent
-result = mesh.remesh(verbose=0)   # Errors only
-result = mesh.remesh(verbose=1)   # Standard info
-result = mesh.remesh(verbose=5)   # Debug output
+silent = mesh.mmg.remesh(verbose=-1)  # Silent
+errors = mesh.mmg.remesh(verbose=0)   # Errors only
+info = mesh.mmg.remesh(verbose=1)     # Standard info
+debug = mesh.mmg.remesh(verbose=5)    # Debug output
 ```
 
 ---
 
 ## Common Combinations
 
-### Quality Optimization Only
+### Quality optimization only
 
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh(optim=1, noinsert=1)
+optimized = mesh.mmg.remesh(optim=1, noinsert=1)
 ```
 
 Or use the convenience method:
@@ -282,19 +257,17 @@ Or use the convenience method:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh_optimize()
+optimized = mesh.mmg.remesh_optimize()
 ```
 
 ---
 
-### Uniform Remeshing
+### Uniform remeshing
 
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh(hsiz=0.05)
+uniform = mesh.mmg.remesh(hsiz=0.05)
 ```
 
 Or use the convenience method:
@@ -302,19 +275,17 @@ Or use the convenience method:
 <!-- pytest-codeblocks:cont -->
 
 ```python
-mesh = mmgpy.read("input.mesh")
-result = mesh.remesh_uniform(size=0.05)
-mesh = mmgpy.read("input.mesh")
+uniform = mesh.mmg.remesh_uniform(size=0.05)
 ```
 
 ---
 
-### High-Quality Surface Approximation
+### High-quality surface approximation
 
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(
+remeshed = mesh.mmg.remesh(
     hmax=0.1,
     hausd=0.0001,  # Tight geometric tolerance
     hgrad=1.1,     # Smooth size transition
@@ -323,42 +294,42 @@ result = mesh.remesh(
 
 ---
 
-### Preserve Sharp Features
+### Preserve sharp features
 
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(
+remeshed = mesh.mmg.remesh(
     hmax=0.1,
-    ar=20,     # Detect more ridges
+    ar=20,         # Detect more ridges
     hausd=0.001,
 )
 ```
 
 ---
 
-### Fast Coarse Remeshing
+### Fast coarse remeshing
 
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(
+remeshed = mesh.mmg.remesh(
     hmax=0.5,
-    hgrad=2.0,  # Allow large size variations
+    hgrad=2.0,     # Allow large size variations
     verbose=-1,
 )
 ```
 
 ---
 
-### Volume Interior Only
+### Volume interior only
 
 <!-- pytest-codeblocks:cont -->
 
 ```python
-result = mesh.remesh(
+remeshed = mesh.mmg.remesh(
     hmax=0.1,
-    nosurf=1,  # Keep surface fixed
+    nosurf=1,      # Keep surface fixed
 )
 ```
 
@@ -371,14 +342,14 @@ result = mesh.remesh(
 | `optim=1, noinsert=1`        | Quality optimization only |
 | `hmin=hmax`                  | Near-uniform sizing       |
 | `hausd` small + `hmax` large | More elements on surface  |
-| `angle=180`                  | No ridge preservation     |
+| `ar=180`                     | No ridge preservation     |
 | `hgrad=1.0`                  | No size gradation         |
 
 ## Best Practices
 
-1. **Start with defaults**: MMG auto-computes reasonable defaults
-2. **Set `hmax` first**: Most important parameter
-3. **Add `hausd` for surfaces**: Controls geometric fidelity
-4. **Tune `hgrad`**: Lower for smoother transitions
-5. **Use `verbose=-1`**: For batch processing
-6. **Validate results**: Always check mesh quality after remeshing
+1. **Start with defaults**, MMG auto-computes reasonable values.
+2. **Set `hmax` first**, it is the most important parameter.
+3. **Add `hausd` for surfaces**, it controls geometric fidelity.
+4. **Tune `hgrad`**, lower values give smoother transitions.
+5. **Use `verbose=-1`** for batch processing.
+6. **Validate results** with `dataset.mmg.validate(detailed=True)` after remeshing.


### PR DESCRIPTION
## Summary
Align the README and remaining doc pages with the post-0.13 PyVista accessor API. `mmgpy.read(...)` is deprecated; everything goes through `pv.read(...)` + `dataset.mmg.<method>` now.

## Changes
- README rewritten around `pv.read` + `.mmg` accessor; refreshed features (local sizing dict spec, metric in `point_data`, multi-material LS, required-entity tags, companion `.sol` I/O).
- `docs/reference/mmg-parameters.md`, `docs/reference/file-formats.md`: drop `mmgpy.read` + `mesh.remesh` patterns.
- `docs/api/sizing.md`: recommend `local_sizing=[...]` on `remesh`; keep typed dataclasses as an alt path.
- `docs/api/metrics.md`: metric goes on `mesh.point_data["metric"]`.
- `docs/api/results-validation.md`: examples via `dataset.mmg.element_qualities()` + `dataset.mmg.validate(...)`.
- `docs/api/lagrangian.md`: boundary-only displacement uses PyVista `extract_surface` instead of reaching into `_impl_unwrap`.
- `docs/api/io.md`, `docs/api/index.md`: `mmgpy.read` reduced to a deprecation admonition.