### PR TITLE
fix(docs): pin pygments<2.20 to keep zensical builds rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,11 @@ dev = [
 docs = [
     "mike @ git+https://github.com/squidfunk/mike.git@0f62791256ebeba60d20d2f1d8fe6ec3b7d1e2b3",
     "mkdocstrings-python>=0.24.0",
+    # Pygments 2.20 strictened html.escape to reject None; pymdownx 10.20 still
+    # passes filename=None for separate-signature blocks rendered by
+    # mkdocstrings, which silently kills the build. Pin until pymdownx
+    # ships a fix.
+    "pygments<2.20",
     "zensical>=0.0.28",
 ]
 ui = [

--- a/uv.lock
+++ b/uv.lock
@@ -1487,6 +1487,7 @@ dev = [
 docs = [
     { name = "mike" },
     { name = "mkdocstrings-python" },
+    { name = "pygments" },
     { name = "zensical" },
 ]
 ui = [
@@ -1534,6 +1535,7 @@ dev = [
 docs = [
     { name = "mike", git = "https://github.com/squidfunk/mike.git?rev=0f62791256ebeba60d20d2f1d8fe6ec3b7d1e2b3" },
     { name = "mkdocstrings-python", specifier = ">=0.24.0" },
+    { name = "pygments", specifier = "<2.20" },
     { name = "zensical", specifier = ">=0.0.28" },
 ]
 ui = [
@@ -2291,11 +2293,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Every docs deploy since the 0.13 release has silently produced an empty site (16 static files, no HTML). Reproduced locally with \`uv run zensical build\`:

\`\`\`
Build started
Error: AttributeError: 'NoneType' object has no attribute 'replace'   (x5)
Build finished in 0.21s
\`\`\`

## Root cause
mkdocstrings-python renders separate function signatures by calling the pymdownx \`highlight\` filter without a \`title\` kwarg. pymdownx 10.20 forwards \`filename=title\` (i.e. \`None\`) to Pygments' \`HtmlFormatter\`. Pygments 2.20 changed \`html.escape\` to require \`str\`, so \`html.escape(None)\` crashes.

Zensical's Rust runtime catches the exception, prints \`Error:\`, and continues; mike commits the partial output as success.

## Fix
Pin \`pygments<2.20\` in the \`docs\` dependency group. Local build now produces a 47-file site (matches the last-known-good 0.12 deploy). Revert when pymdownx ships an upstream fix.

## Changes
- \`pyproject.toml\`: add \`pygments<2.20\` to \`[dependency-groups].docs\`
- \`uv.lock\`: refreshed (pygments 2.20.0 -> 2.19.2)