### PR TITLE
chore: enforce ruff PLR6104/PLR6201/PLR1702 preview rules for src/mmgpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,6 @@ ignore = [
     "PLR0904", # too-many-public-methods                        (2)
     "PLR0914", # too-many-locals                                (10)
     "PLR0917", # too-many-positional-arguments                  (7)
-    "PLR1702", # too-many-nested-blocks                         (2)
-    "PLR6104", # non-augmented-assignment                       (1)
-    "PLR6201", # literal-membership                             (13)
     "PLR6301", # no-self-use                                    (15)
 ]
 

--- a/src/mmgpy/_cli.py
+++ b/src/mmgpy/_cli.py
@@ -219,7 +219,7 @@ def _parse_args(args: list[str]) -> _ParsedArgs:
             value = args[i + 1]
             if arg == "-in":
                 parsed.input_mesh = value
-            elif arg in ("-o", "-out"):
+            elif arg in {"-o", "-out"}:
                 parsed.output_mesh = value
             elif arg == "-sol":
                 parsed.sol_file = value
@@ -288,7 +288,7 @@ def _run_mmg() -> None:  # pragma: no cover
     args = sys.argv[1:]
 
     # -- help ----------------------------------------------------------------
-    if not args or args[0] in ("-h", "--help"):
+    if not args or args[0] in {"-h", "--help"}:
         print(
             "mmg - Unified mesh remeshing tool with auto-detection\n\n"
             "Usage: mmg [options] <input_mesh>\n"
@@ -324,7 +324,7 @@ def _run_mmg() -> None:  # pragma: no cover
         sys.exit(0)
 
     # -- version -------------------------------------------------------------
-    if args[0] in ("-V", "--version"):
+    if args[0] in {"-V", "--version"}:
         try:
             from . import _version  # type: ignore[attr-defined]  # noqa: PLC0415
 

--- a/src/mmgpy/_io.py
+++ b/src/mmgpy/_io.py
@@ -294,7 +294,7 @@ def _read_mesh_internal(
         # Use native MMG loading for Medit format to preserve MMG-specific
         # keywords (Ridges, RequiredVertices, Tangents, reference markers)
         suffix = path.suffix.lower()
-        if suffix in (".mesh", ".meshb"):
+        if suffix in {".mesh", ".meshb"}:
             impl = _load_medit_native(path, mesh_kind)
             kind = _impl_to_kind(impl)
             return Mesh._from_impl(impl, kind)  # noqa: SLF001

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -585,7 +585,7 @@ def _normalize_multi_materials(
             )
             raise ValueError(msg)  # noqa: TRY004
         split = int(split_raw)
-        if split not in (0, 1):
+        if split not in {0, 1}:
             msg = f"materials[{i}]['split'] must be 0 or 1, got {split}"
             raise ValueError(msg)
         normalized.append(
@@ -1744,10 +1744,10 @@ class Mesh:
             for name, arr in self._user_fields.items():
                 pv_mesh.point_data[name] = arr
             # Cast PolyData → UnstructuredGrid for formats that require it
-            if isinstance(pv_mesh, pv.PolyData) and path.suffix.lower() in (
+            if isinstance(pv_mesh, pv.PolyData) and path.suffix.lower() in {
                 ".vtu",
                 ".vtkhdf",
-            ):
+            }:
                 pv_mesh = pv_mesh.cast_to_unstructured_grid()
             pv_mesh.save(str(path))
 

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -225,7 +225,7 @@ def _build_mesh_with_mmg_fields(dataset: pv.UnstructuredGrid | pv.PolyData) -> _
         arr = np.asarray(dataset.point_data[key], dtype=np.float64)
         # MMG's scalar metric / levelset bindings want an Nx1 array; PyVista
         # users naturally store these as 1D, so reshape on the way through.
-        if arr.ndim == 1 and key in ("metric", "levelset"):
+        if arr.ndim == 1 and key in {"metric", "levelset"}:
             arr = arr.reshape(-1, 1)
         mesh[key] = arr
     return mesh
@@ -346,7 +346,7 @@ def _per_type_indices_marked(
         n_polys = int(dataset.n_cells) - n_verts - n_lines - n_strips
         if cell_type == pv.CellType.LINE:
             start, length = n_verts, n_lines
-        elif cell_type in (pv.CellType.TRIANGLE, pv.CellType.QUAD):
+        elif cell_type in {pv.CellType.TRIANGLE, pv.CellType.QUAD}:
             start, length = n_verts + n_lines, n_polys
         elif cell_type == pv.CellType.VERTEX:
             start, length = 0, n_verts
@@ -861,7 +861,7 @@ def _coerce_metric_kwarg(
             f"{tuple(np.asarray(metric).shape)} for n_points={n_points}"
         )
         raise ValueError(msg)
-    if arr.shape[1] not in (1, 3, 6):
+    if arr.shape[1] not in {1, 3, 6}:
         msg = (
             f"metric last dimension must be 1 (scalar), 3 (2D tensor) "
             f"or 6 (3D tensor); got {arr.shape[1]}"

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -1121,7 +1121,7 @@ def polydata_from_2d_triangles(
 
     """
     verts = np.asarray(vertices, dtype=np.float64)
-    if verts.ndim != _NDIM_2D_ARRAY or verts.shape[1] not in (_DIMS_2D, _DIMS_3D):
+    if verts.ndim != _NDIM_2D_ARRAY or verts.shape[1] not in {_DIMS_2D, _DIMS_3D}:
         msg = f"vertices must have shape (n, 2) or (n, 3); got {verts.shape}"
         raise ValueError(msg)
     if verts.shape[1] == _DIMS_2D:

--- a/src/mmgpy/_reorder.py
+++ b/src/mmgpy/_reorder.py
@@ -89,7 +89,7 @@ def _build_adjacency(
     """
     adj = vertex_adjacency(n_vertices, blocks[0])
     for extra in blocks[1:]:
-        adj = adj + vertex_adjacency(n_vertices, extra)
+        adj += vertex_adjacency(n_vertices, extra)
     adj.data[:] = 1.0
     return adj
 

--- a/src/mmgpy/_sol.py
+++ b/src/mmgpy/_sol.py
@@ -27,6 +27,92 @@ _TYPE_VECTOR = 2
 _TYPE_TENSOR = 3
 
 
+def _parse_sol_block(
+    lines: list[str],
+    start: int,
+    location: str,
+    dimension: int,
+) -> tuple[int, dict[str, dict]]:
+    """Parse one ``SolAt*`` block.
+
+    Returns
+    -------
+    tuple[int, dict[str, dict]]
+        The line index just after the consumed block and the fields parsed
+        from it (empty if the block contained no data rows).
+
+    """
+    i = start
+    if i >= len(lines):
+        return i, {}
+    n_entities = int(lines[i].strip())
+    i += 1
+    if i >= len(lines):
+        return i, {}
+
+    type_line = lines[i].strip().split()
+    n_solutions = int(type_line[0])
+    sol_types = [int(t) for t in type_line[1 : 1 + n_solutions]]
+    i += 1
+
+    values: list[list[float]] = []
+    while len(values) < n_entities and i < len(lines):
+        line = lines[i].strip()
+        if line == "End" or line.startswith(("Mesh", "Sol")):
+            break
+        if not line:
+            i += 1
+            continue
+        values.append([float(v) for v in line.split()])
+        i += 1
+
+    if not values:
+        return i, {}
+    return i, _fields_from_block(values, sol_types, n_solutions, location, dimension)
+
+
+def _fields_from_block(
+    values: list[list[float]],
+    sol_types: list[int],
+    n_solutions: int,
+    location: str,
+    dimension: int,
+) -> dict[str, dict]:
+    """Build the field dict from a parsed ``SolAt*`` block's raw values.
+
+    Returns
+    -------
+    dict[str, dict]
+        Field names mapped to ``{"data": array, "location": location}``.
+
+    """
+    data = np.array(values, dtype=np.float64)
+    fields: dict[str, dict] = {}
+    col_idx = 0
+    for sol_idx, sol_type in enumerate(sol_types):
+        if sol_type == 1:
+            base = f"solution_{sol_idx}" if n_solutions > 1 else "solution"
+            payload = data if data.ndim == 1 else data[:, col_idx]
+            fields[f"{base}@{location}"] = {"data": payload, "location": location}
+            col_idx += 1
+        elif sol_type == 2:
+            base = f"vector_{sol_idx}" if n_solutions > 1 else "vector"
+            fields[f"{base}@{location}"] = {
+                "data": data[:, col_idx : col_idx + dimension],
+                "location": location,
+            }
+            col_idx += dimension
+        elif sol_type == 3:
+            tensor_size = 6 if dimension == 3 else 3
+            base = f"tensor_{sol_idx}" if n_solutions > 1 else "tensor"
+            fields[f"{base}@{location}"] = {
+                "data": data[:, col_idx : col_idx + tensor_size],
+                "location": location,
+            }
+            col_idx += tensor_size
+    return fields
+
+
 def parse_sol_file(content: str) -> dict[str, dict]:
     """Parse a Medit .sol file and return solution fields.
 
@@ -96,64 +182,8 @@ def parse_sol_file(content: str) -> dict[str, dict]:
                 break
 
         if location is not None:
-            i += 1
-            if i >= len(lines):
-                break
-
-            n_entities = int(lines[i].strip())
-            i += 1
-            if i >= len(lines):
-                break
-
-            type_line = lines[i].strip().split()
-            n_solutions = int(type_line[0])
-            sol_types = [int(t) for t in type_line[1 : 1 + n_solutions]]
-
-            i += 1
-            values: list[list[float]] = []
-            while len(values) < n_entities and i < len(lines):
-                line = lines[i].strip()
-                if line == "End" or line.startswith(("Mesh", "Sol")):
-                    break
-                if not line:
-                    i += 1
-                    continue
-                row_values = [float(v) for v in line.split()]
-                values.append(row_values)
-                i += 1
-
-            if values:
-                data = np.array(values, dtype=np.float64)
-                col_idx = 0
-                for sol_idx, sol_type in enumerate(sol_types):
-                    if sol_type == 1:
-                        base = f"solution_{sol_idx}" if n_solutions > 1 else "solution"
-                        name = f"{base}@{location}"
-                        if data.ndim == 1:
-                            fields[name] = {"data": data, "location": location}
-                        else:
-                            fields[name] = {
-                                "data": data[:, col_idx],
-                                "location": location,
-                            }
-                        col_idx += 1
-                    elif sol_type == 2:
-                        base = f"vector_{sol_idx}" if n_solutions > 1 else "vector"
-                        name = f"{base}@{location}"
-                        fields[name] = {
-                            "data": data[:, col_idx : col_idx + dimension],
-                            "location": location,
-                        }
-                        col_idx += dimension
-                    elif sol_type == 3:
-                        tensor_size = 6 if dimension == 3 else 3
-                        base = f"tensor_{sol_idx}" if n_solutions > 1 else "tensor"
-                        name = f"{base}@{location}"
-                        fields[name] = {
-                            "data": data[:, col_idx : col_idx + tensor_size],
-                            "location": location,
-                        }
-                        col_idx += tensor_size
+            i, block_fields = _parse_sol_block(lines, i + 1, location, dimension)
+            fields.update(block_fields)
             continue
 
         i += 1
@@ -237,7 +267,7 @@ def write_sol_file(
         layout for the given dimension.
 
     """
-    if dimension not in (2, 3):
+    if dimension not in {2, 3}:
         msg = f"dimension must be 2 or 3, got {dimension}"
         raise ValueError(msg)
     if not fields:

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -90,7 +90,7 @@ def create_isotropic_metric(
     (100, 6)
 
     """
-    if dim not in (2, 3):
+    if dim not in {2, 3}:
         msg = f"dim must be 2 or 3, got {dim}"
         raise ValueError(msg)
 
@@ -190,7 +190,7 @@ def create_anisotropic_metric(
         msg = f"sizes must be 1D or 2D array, got shape {sizes.shape}"
         raise ValueError(msg)
 
-    if dim not in (2, 3):
+    if dim not in {2, 3}:
         msg = f"sizes must have 2 or 3 components, got {dim}"
         raise ValueError(msg)
 

--- a/src/mmgpy/ui/app.py
+++ b/src/mmgpy/ui/app.py
@@ -420,6 +420,22 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
         self._update_viewer(reset_camera=False)
         self.state.sol_filename = filename
 
+    def _insert_boundary_refs_option(self, base_options: list[dict]) -> None:
+        """Insert a Boundary Refs entry after the existing Refs option, if any."""
+        try:
+            _, tri_refs = self._mesh.get_triangles_with_refs()
+        except Exception:
+            return
+        if len(np.unique(tri_refs)) == 0:
+            return
+        for i, opt in enumerate(base_options):
+            if opt.get("value") == "refs":
+                base_options.insert(
+                    i + 1,
+                    {"title": "Boundary Refs", "value": "boundary_refs"},
+                )
+                return
+
     def _update_scalar_field_options(self) -> None:
         """Update scalar field dropdown options based on available fields and mesh type."""
         base_options = list(DEFAULT_SCALAR_FIELD_OPTIONS)
@@ -438,23 +454,7 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
 
             # Add Boundary Refs option for tetrahedral meshes with boundary triangles
             if self._mesh is not None:
-                try:
-                    _, tri_refs = self._mesh.get_triangles_with_refs()
-                    unique_tri_refs = np.unique(tri_refs)
-                    if len(unique_tri_refs) > 0:
-                        # Find the "-- Other --" section and add Boundary Refs after Refs
-                        for i, opt in enumerate(base_options):
-                            if opt.get("value") == "refs":
-                                base_options.insert(
-                                    i + 1,
-                                    {
-                                        "title": "Boundary Refs",
-                                        "value": "boundary_refs",
-                                    },
-                                )
-                                break
-                except Exception:
-                    pass
+                self._insert_boundary_refs_option(base_options)
 
         if self._solution_fields:
             base_options.append({"type": "subheader", "title": "-- Solution --"})

--- a/tests/internal/ui_test.py
+++ b/tests/internal/ui_test.py
@@ -834,4 +834,4 @@ class TestDefaultState:
         from mmgpy.ui.utils import DEFAULT_STATE
 
         assert "theme_name" in DEFAULT_STATE
-        assert DEFAULT_STATE["theme_name"] in ("light", "dark")
+        assert DEFAULT_STATE["theme_name"] in {"light", "dark"}

--- a/tests/mmg3d_test.py
+++ b/tests/mmg3d_test.py
@@ -195,7 +195,7 @@ def test_mesh_quality_analysis(generated_meshes: tuple[pv.DataSet, pv.DataSet]) 
                 continue  # Skip unknown cell types
 
             cell_type_name = cell_type_map[cell_type_id]
-            if cell_type_id in [1, 3, 5]:  # Skip 1D/2D elements in 3D mesh
+            if cell_type_id in {1, 3, 5}:  # Skip 1D/2D elements in 3D mesh
                 continue
 
             # Get quality info from PyVista


### PR DESCRIPTION
## Summary

Resolve and enforce three preview-only PLR rules previously ignored repo-wide.

## Changes

- `PLR6104` (1): `+=` in `_reorder.py`
- `PLR6201` (13 in src, 2 in tests): tuples to set literals
- `PLR1702` (2): extract helpers in `_sol.py` and `ui/app.py` to flatten nesting
- drop the three rules from `pyproject.toml` ignore list