### PR TITLE
chore: scope PLR ignores per-file and fix PLR6301 in src/mmgpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,14 +156,8 @@ ignore = [
     "D203",   # incompatible with D211 (no-blank-line-before-class)
     "D213",   # incompatible with D212 (multi-line-summary-first-line)
     "COM812", # conflicts with formatter
-    # Preview rules — opt out for now and fix in dedicated PRs.
-    # Each entry below corresponds to one currently-failing rule;
-    # remove it once the rule's findings are resolved.
-    "CPY001",  # missing-copyright-notice (header boilerplate not wanted)
-    "PLR0904", # too-many-public-methods                        (2)
-    "PLR0914", # too-many-locals                                (10)
-    "PLR0917", # too-many-positional-arguments                  (7)
-    "PLR6301", # no-self-use                                    (15)
+    # Project-wide opt-out (header boilerplate not wanted).
+    "CPY001", # missing-copyright-notice
 ]
 
 # Preview-rule enforcement is currently scoped to ``src/mmgpy/`` (the public
@@ -193,6 +187,23 @@ ignore = [
     "FBT002",  # transfer_fields has a boolean default for consistency with Mesh.remesh()
     "N801",    # class names match C++ API (mmg2d, mmg3d, mmgs)
     "PLR0913", # _wrapped_remesh mirrors C++ function signatures
+    "PLR0917", # _wrapped_remesh mirrors C++ function signatures (positional)
+]
+"src/mmgpy/_mesh.py" = [
+    "PLR0904", # Mesh exposes the full public API (auto-detected 2D/3D/surface)
+    "PLR0917", # _create_impl mirrors a C++ constructor (positional)
+]
+"src/mmgpy/_pv_plugin.py" = [
+    "PLR0904", # PyVista accessor exposes the full public API surface
+]
+"src/mmgpy/_reorder.py" = [
+    "PLR0914", # RCM reordering manipulates many intermediate arrays
+]
+"src/mmgpy/_transfer.py" = [
+    "PLR0914", # field interpolation manipulates many intermediate arrays
+]
+"src/mmgpy/repair/_vertices.py" = [
+    "PLR0914", # duplicate-vertex removal manipulates many intermediate arrays
 ]
 "tests/**/*.py" = [
     "S101",    # asserts allowed in tests
@@ -202,7 +213,10 @@ ignore = [
     "PLC0415", # imports inside functions are intentional for fixtures
     "N806",    # uppercase variable names for matrices (M, D, H) standard in math
     "PLR2004", # magic values allowed in tests
+    "PLR0904", # test classes group many test methods
     "PLR0913", # many arguments allowed in test helper functions
+    "PLR0914", # many locals allowed in test setup
+    "PLR6301", # test methods don't need to use self
     "PLC1901", # tests assert empty-string sentinels literally
     "S603",    # subprocess calls allowed in tests
     "S607",    # partial executable paths allowed in tests
@@ -232,7 +246,9 @@ ignore = [
     "C901",    # complex functions acceptable for mathematical algorithms
     "PLR0912", # many branches acceptable for element-type dispatch
     "PLR0913", # many arguments acceptable for elasticity solver (E, nu, etc.)
+    "PLR0914", # many locals acceptable for elasticity solver
     "PLR0915", # many statements acceptable for elasticity solver
+    "PLR0917", # many positional arguments acceptable for elasticity solver
     "PLR2004", # magic values (2, 3) are dimension constants in math code
 ]
 "src/mmgpy/metrics.py" = [
@@ -241,10 +257,12 @@ ignore = [
     "PLR2004", # magic values (2, 3, 6) are dimension constants in math code
     "C901",    # complex functions acceptable for mathematical algorithms
     "PLR0912", # many branches acceptable for 2D/3D dispatch
+    "PLR0914", # many locals acceptable for matrix-heavy math
 ]
 "examples/**/*.py" = [
     "T201",    # print statements essential for example output
     "PLR0913", # many arguments allowed for clarity in examples
+    "PLR0914", # many locals allowed for didactic examples
     "PLR0915", # long functions allowed for comprehensive examples
     "PERF401", # list comprehensions not required in examples (readability first)
     "PTH123",  # open() is fine for simple examples
@@ -270,6 +288,8 @@ ignore = [
 "benchmarks/**/*.py" = [
     "S101",    # asserts allowed in benchmarks
     "PLR2004", # magic values allowed in benchmarks
+    "PLR0914", # many locals allowed in benchmark setup
+    "PLR6301", # benchmark methods don't need to use self
     "INP001",  # benchmarks directory is not a package
     "TC002",   # third-party imports in runtime for type annotations
     "TC003",   # stdlib imports in runtime for type annotations
@@ -299,6 +319,7 @@ ignore = [
 ]
 "src/mmgpy/_progress.py" = [
     "PLC0415", # imports inside functions for optional Rich dependency
+    "PLR0917", # _emit_event mirrors the progress callback signature (positional)
 ]
 "src/mmgpy/_mmgpy.pyi" = [
     "PYI021",  # Docstrings intentionally included for IDE support (issue #111)
@@ -319,6 +340,7 @@ ignore = [
     "C901",    # complex functions in parsers and remeshing
     "PLR0911", # many returns in recursive AST evaluator
     "PLR0912", # many branches in parser and validation logic
+    "PLR0914", # many locals in upload handlers and remeshing flow
     "PLR0915", # many statements in sol file parser
     "PLR2004", # magic values (MMG solution types, VTK cell types)
     # Error handling

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -1425,8 +1425,8 @@ class Mesh:
     # Geometry operations
     # =========================================================================
 
+    @staticmethod
     def _compute_tetrahedra_volumes(
-        self,
         vertices: NDArray[np.float64],
         tetrahedra: NDArray[np.int32],
     ) -> NDArray[np.float64]:

--- a/src/mmgpy/ui/app.py
+++ b/src/mmgpy/ui/app.py
@@ -781,7 +781,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
 
         return layout
 
-    def _build_footer(self) -> None:
+    @staticmethod
+    def _build_footer() -> None:
         """Build footer with version and GitHub link."""
         try:
             from importlib.metadata import version
@@ -803,7 +804,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
                 classes="text-caption",
             )
 
-    def _build_toolbar(self) -> None:
+    @staticmethod
+    def _build_toolbar() -> None:
         """Build toolbar content."""
         v3.VBtn(
             icon="mdi-refresh",
@@ -895,7 +897,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
         v3.VDivider(classes="mb-3")
         self._build_run_section()
 
-    def _build_file_upload_section(self) -> None:
+    @staticmethod
+    def _build_file_upload_section() -> None:
         """Build file upload inputs for mesh and solution files."""
         # Import mesh row with file input and sample menu
         with v3.VRow(dense=True, classes="mb-2", no_gutters=True):
@@ -986,7 +989,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
             click="sol_file_upload = null",
         )
 
-    def _build_solution_options_section(self) -> None:
+    @staticmethod
+    def _build_solution_options_section() -> None:
         """Build solution type alerts and usage options."""
         v3.VAlert(
             text="Solution detected as levelset (signed distance)",
@@ -1023,7 +1027,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
             title="Use solution as levelset field for iso-surface extraction",
         )
 
-    def _build_mode_and_preset_section(self) -> None:
+    @staticmethod
+    def _build_mode_and_preset_section() -> None:
         """Build mode selection and preset buttons."""
         with html.Div(classes="d-flex align-center mb-2"):
             v3.VIcon("mdi-tune", size="small", color="primary", classes="mr-2")
@@ -1099,7 +1104,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
                 click="trigger('apply_preset', ['coarse'])",
             )
 
-    def _build_size_parameters_section(self) -> None:
+    @staticmethod
+    def _build_size_parameters_section() -> None:
         """Build size control parameters (hsiz, hmax, hmin, hausd, hgrad, ar)."""
         with html.Div(classes="d-flex align-center mb-2"):
             v3.VIcon("mdi-resize", size="small", color="success", classes="mr-2")
@@ -1199,7 +1205,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
                     title="Angle detection threshold in degrees (default: 45)",
                 )
 
-    def _build_advanced_options_section(self) -> None:
+    @staticmethod
+    def _build_advanced_options_section() -> None:
         """Build advanced optimization options (optim, noinsert, noswap, etc.)."""
         with html.Div(classes="d-flex align-center mb-2"):
             v3.VIcon("mdi-cog", size="small", color="warning", classes="mr-2")
@@ -1330,7 +1337,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
                         title="Maximum memory usage in MB. Leave empty for automatic.",
                     )
 
-    def _build_mode_specific_options(self) -> None:
+    @staticmethod
+    def _build_mode_specific_options() -> None:
         """Build mode-specific options (levelset formula, source)."""
         v3.VTextField(
             v_model=("levelset_formula",),
@@ -1381,7 +1389,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
                 title="Remesh from last result (iterative)",
             )
 
-    def _build_run_section(self) -> None:
+    @staticmethod
+    def _build_run_section() -> None:
         """Build run button and result alerts."""
         v3.VBtn(
             "Run Remesh",
@@ -1473,7 +1482,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
                     # Top-right toolbar overlay
                     self._build_viewer_toolbar()
 
-    def _build_viewer_toolbar(self) -> None:
+    @staticmethod
+    def _build_viewer_toolbar() -> None:
         """Build the viewer toolbar overlay."""
         with v3.VCard(
             classes="position-absolute",
@@ -1668,7 +1678,8 @@ class MmgpyApp(ViewerMixin, RemeshingMixin):
                     variant="text",
                 )
 
-    def _build_info_panel(self) -> None:
+    @staticmethod
+    def _build_info_panel() -> None:
         """Build the right-side mesh info panel (inside drawer)."""
         with v3.VCard(
             classes="fill-height overflow-auto",

--- a/src/mmgpy/ui/parsers.py
+++ b/src/mmgpy/ui/parsers.py
@@ -283,7 +283,8 @@ class SafeFormulaEvaluator:
         msg = "Invalid function call"
         raise ValueError(msg)
 
-    def _eval_attribute(self, node: ast.Attribute) -> float:
+    @staticmethod
+    def _eval_attribute(node: ast.Attribute) -> float:
         """Evaluate an attribute access node.
 
         Parameters

--- a/src/mmgpy/ui/viewer.py
+++ b/src/mmgpy/ui/viewer.py
@@ -538,7 +538,8 @@ class ViewerMixin:
 
         return boundary_mesh
 
-    def _compute_edge_lengths_per_cell(self, pv_mesh) -> np.ndarray | None:
+    @staticmethod
+    def _compute_edge_lengths_per_cell(pv_mesh) -> np.ndarray | None:
         """Compute average edge length per cell for visualization.
 
         Returns
@@ -582,7 +583,8 @@ class ViewerMixin:
 
         return None
 
-    def _compute_all_edge_lengths(self, pv_mesh) -> np.ndarray | None:
+    @staticmethod
+    def _compute_all_edge_lengths(pv_mesh) -> np.ndarray | None:
         """Compute all edge lengths in the mesh for statistics.
 
         Returns


### PR DESCRIPTION
## Summary
- Removes `PLR0904`, `PLR0914`, `PLR0917`, `PLR6301` from the global `ignore` list.
- Fixes all 15 `PLR6301` (`no-self-use`) warnings in `src/mmgpy` by converting affected methods to `@staticmethod`.
- Scopes the remaining preview PLR rules to per-file ignores so each opt-out is justified at the file level.

## Changes

### `@staticmethod` conversions
- `src/mmgpy/_mesh.py`: `_compute_tetrahedra_volumes`.
- `src/mmgpy/ui/app.py`: 11 `_build_*` methods.
- `src/mmgpy/ui/parsers.py`: `_eval_attribute`.
- `src/mmgpy/ui/viewer.py`: `_compute_edge_lengths_per_cell`, `_compute_all_edge_lengths`.

### Per-file ignores added (`pyproject.toml`)
- `src/mmgpy/_remesh.py`: `PLR0917`.
- `src/mmgpy/_mesh.py`: `PLR0904`, `PLR0917`.
- `src/mmgpy/_pv_plugin.py`: `PLR0904`.
- `src/mmgpy/_reorder.py`: `PLR0914`.
- `src/mmgpy/_transfer.py`: `PLR0914`.
- `src/mmgpy/repair/_vertices.py`: `PLR0914`.
- `src/mmgpy/lagrangian.py`: `PLR0914`, `PLR0917`.
- `src/mmgpy/metrics.py`: `PLR0914`.
- `src/mmgpy/_progress.py`: `PLR0917`.
- `src/mmgpy/ui/**`: `PLR0914`.
- `tests/**`: `PLR0904`, `PLR0914`, `PLR6301`.
- `examples/**`: `PLR0914`.
- `benchmarks/**`: `PLR0914`, `PLR6301`.

## Notes
- All `self.method(...)` call sites continue to work after `@staticmethod` conversion.
- `ruff check --preview` is clean across the whole repo.