### PR TITLE
lint: drop PLR0914 ignores by extracting helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,15 +190,6 @@ ignore = [
 "src/mmgpy/_pv_plugin.py" = [
     "PLR0904", # PyVista accessor exposes the full public API surface
 ]
-"src/mmgpy/_reorder.py" = [
-    "PLR0914", # RCM reordering manipulates many intermediate arrays
-]
-"src/mmgpy/_transfer.py" = [
-    "PLR0914", # field interpolation manipulates many intermediate arrays
-]
-"src/mmgpy/repair/_vertices.py" = [
-    "PLR0914", # duplicate-vertex removal manipulates many intermediate arrays
-]
 "tests/**/*.py" = [
     "S101",    # asserts allowed in tests
     "T201",    # print statements allowed in tests for debugging

--- a/src/mmgpy/_reorder.py
+++ b/src/mmgpy/_reorder.py
@@ -318,6 +318,28 @@ def _snapshot_permuted_fields(
     return mmg_snapshots, user_snapshots
 
 
+def _apply_permuted_elements(
+    mesh: Mesh,
+    inv_perm32: NDArray[np.int32],
+    tets: tuple[NDArray[np.int32], NDArray[np.int64]] | None,
+    tris: tuple[NDArray[np.int32], NDArray[np.int64]] | None,
+    edge_block: tuple[NDArray[np.int32], NDArray[np.int64]],
+) -> None:
+    """Write each element block back to *mesh* with vertex indices remapped."""
+    from mmgpy._mesh import MeshKind  # noqa: PLC0415
+
+    if mesh.kind == MeshKind.TETRAHEDRAL and tets is not None:
+        tetrahedra, tetrahedra_refs = tets
+        impl_3d = cast("MmgMesh3D", mesh._impl)  # noqa: SLF001
+        impl_3d.set_tetrahedra(inv_perm32[tetrahedra], tetrahedra_refs)
+    if tris is not None:
+        triangles, triangle_refs = tris
+        mesh.set_triangles(inv_perm32[triangles], triangle_refs)
+    edges, edge_refs = edge_block
+    if edges.size:
+        mesh.set_edges(inv_perm32[edges], edge_refs)
+
+
 def _apply_rcm_to_mesh(mesh: Mesh) -> None:
     """In-place reverse Cuthill-McKee reordering of a :class:`Mesh`.
 
@@ -325,14 +347,12 @@ def _apply_rcm_to_mesh(mesh: Mesh) -> None:
     every MMG-known field stored on the C++ side (metric, displacement,
     levelset, tensor), and every user field. Sizes are preserved.
     """
-    from mmgpy._mesh import MeshKind  # noqa: PLC0415
-
     vertices, vertex_refs = mesh.get_vertices_with_refs()
     n_vertices = len(vertices)
     if n_vertices == 0:
         return
 
-    blocks, tets, tris, (edges, edge_refs) = _collect_mesh_element_blocks(mesh)
+    blocks, tets, tris, edge_block = _collect_mesh_element_blocks(mesh)
     if not blocks:
         return
 
@@ -342,15 +362,7 @@ def _apply_rcm_to_mesh(mesh: Mesh) -> None:
     mmg_snapshots, user_snapshots = _snapshot_permuted_fields(mesh, perm, n_vertices)
 
     mesh.set_vertices(vertices[perm], vertex_refs[perm])
-    if mesh.kind == MeshKind.TETRAHEDRAL and tets is not None:
-        tetrahedra, tetrahedra_refs = tets
-        impl_3d = cast("MmgMesh3D", mesh._impl)  # noqa: SLF001
-        impl_3d.set_tetrahedra(inv_perm32[tetrahedra], tetrahedra_refs)
-    if tris is not None:
-        triangles, triangle_refs = tris
-        mesh.set_triangles(inv_perm32[triangles], triangle_refs)
-    if edges.size:
-        mesh.set_edges(inv_perm32[edges], edge_refs)
+    _apply_permuted_elements(mesh, inv_perm32, tets, tris, edge_block)
 
     for name, permuted in mmg_snapshots.items():
         mesh._impl.set_field(name, permuted)  # noqa: SLF001

--- a/src/mmgpy/_transfer.py
+++ b/src/mmgpy/_transfer.py
@@ -29,6 +29,8 @@ import numpy as np
 from scipy.spatial import Delaunay, cKDTree
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from numpy.typing import NDArray
 
 _TOLERANCE = 1e-15
@@ -123,6 +125,26 @@ def _compute_barycentric_tri(
     return np.column_stack([b0, b1, b2])
 
 
+def _barycentric_interpolate_inside(
+    target_points: NDArray[np.float64],
+    source_vertices: NDArray[np.float64],
+    field: NDArray[np.float64],
+    element_vertex_indices: NDArray[np.int32],
+    bary_fn: Callable[[NDArray[np.float64], NDArray[np.float64]], NDArray[np.float64]],
+) -> NDArray[np.float64]:
+    """Barycentric interpolation for target points known to lie inside the hull.
+
+    Returns
+    -------
+    ndarray
+        Interpolated values at *target_points*, shape ``(n_inside, n_components)``.
+
+    """
+    element_vertices = source_vertices[element_vertex_indices]
+    bary = bary_fn(target_points, element_vertices)
+    return np.einsum("ij,ijk->ik", bary, field[element_vertex_indices])
+
+
 def interpolate_field(
     source_vertices: NDArray[np.float64],
     source_elements: NDArray[np.int32],
@@ -157,8 +179,6 @@ def interpolate_field(
         n_source_vertices.
 
     """
-    n_element_verts = source_elements.shape[1]
-
     field = np.atleast_2d(field)
     if field.shape[0] == 1 and field.shape[1] == len(source_vertices):
         field = field.T
@@ -181,28 +201,21 @@ def interpolate_field(
 
     result = np.zeros((len(target_points), n_components), dtype=np.float64)
 
-    inside_mask = ~outside_mask
-    inside_indices = np.where(inside_mask)[0]
+    inside_indices = np.where(~outside_mask)[0]
 
     if len(inside_indices) > 0:
-        inside_simplices = simplex_indices[inside_indices]
-        element_vertex_indices = delaunay.simplices[inside_simplices]
-
-        element_vertices = source_vertices[element_vertex_indices]
-
-        if n_element_verts == _TETRA_VERTICES:
-            bary = _compute_barycentric_tetra(
-                target_points[inside_indices],
-                element_vertices,
-            )
-        else:
-            bary = _compute_barycentric_tri(
-                target_points[inside_indices],
-                element_vertices,
-            )
-
-        field_at_vertices = field[element_vertex_indices]
-        result[inside_indices] = np.einsum("ij,ijk->ik", bary, field_at_vertices)
+        bary_fn = (
+            _compute_barycentric_tetra
+            if source_elements.shape[1] == _TETRA_VERTICES
+            else _compute_barycentric_tri
+        )
+        result[inside_indices] = _barycentric_interpolate_inside(
+            target_points[inside_indices],
+            source_vertices,
+            field,
+            delaunay.simplices[simplex_indices[inside_indices]],
+            bary_fn,
+        )
 
     if np.any(outside_mask):
         assert tree is not None  # noqa: S101

--- a/src/mmgpy/repair/_vertices.py
+++ b/src/mmgpy/repair/_vertices.py
@@ -36,6 +36,38 @@ _logger = logging.getLogger(__name__)
 _LARGE_PAIR_THRESHOLD = 100_000
 
 
+def _build_vertex_remap(
+    pairs: np.ndarray,
+    n_vertices: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Union-find over duplicate *pairs*, then compact to a dense remap.
+
+    Returns
+    -------
+    tuple[ndarray, ndarray]
+        ``(unique_indices, final_mapping)`` where ``unique_indices`` selects
+        the surviving vertices from the original array and ``final_mapping``
+        is the per-vertex old-to-new index map.
+
+    """
+    mapping = np.arange(n_vertices)
+    for i, j in pairs:
+        canonical = min(mapping[i], mapping[j])
+        mapping[i] = canonical
+        mapping[j] = canonical
+
+    for i in range(n_vertices):
+        root = i
+        while mapping[root] != root:
+            root = mapping[root]
+        mapping[i] = root
+
+    unique_indices = np.where(mapping == np.arange(n_vertices))[0]
+    old_to_new = np.zeros(n_vertices, dtype=np.int32)
+    old_to_new[unique_indices] = np.arange(len(unique_indices), dtype=np.int32)
+    return unique_indices, old_to_new[mapping]
+
+
 def remove_duplicate_vertices(
     mesh: Mesh,
     tolerance: float = 1e-10,
@@ -91,26 +123,8 @@ def remove_duplicate_vertices(
             tolerance,
         )
 
-    mapping = np.arange(n_vertices)
-    for i, j in pairs:
-        canonical = min(mapping[i], mapping[j])
-        mapping[i] = canonical
-        mapping[j] = canonical
-
-    for i in range(n_vertices):
-        root = i
-        while mapping[root] != root:
-            root = mapping[root]
-        mapping[i] = root
-
-    unique_indices = np.where(mapping == np.arange(n_vertices))[0]
+    unique_indices, final_mapping = _build_vertex_remap(pairs, n_vertices)
     new_vertices = vertices[unique_indices]
-
-    old_to_new = np.zeros(n_vertices, dtype=np.int32)
-    for new_idx, old_idx in enumerate(unique_indices):
-        old_to_new[old_idx] = new_idx
-
-    final_mapping = old_to_new[mapping]
 
     if mesh.kind == MeshKind.TETRAHEDRAL:
         elements = mesh.get_tetrahedra()


### PR DESCRIPTION
## Summary

Drop `PLR0914` (too-many-locals) ignores on `_reorder.py`, `_transfer.py`, and `repair/_vertices.py` by extracting one helper from each offending function. No behavior change.

## Changes

- `_reorder.py`: extract `_apply_permuted_elements` (per-element-block writeback) from `_apply_rcm_to_mesh`
- `_transfer.py`: extract `_barycentric_interpolate_inside` (inside-hull path) from `interpolate_field`; pass the chosen bary function explicitly so `source_elements` keeps driving tetra-vs-tri dispatch
- `repair/_vertices.py`: extract `_build_vertex_remap` (union-find + compaction) from `remove_duplicate_vertices`
- `pyproject.toml`: remove the three `PLR0914` per-file-ignores