### PR TITLE
lint: drop stale ruff ignores on metrics.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,12 +239,8 @@ ignore = [
     "PLR2004", # magic values (2, 3) are dimension constants in math code
 ]
 "src/mmgpy/metrics.py" = [
-    "N806",    # uppercase variable names for matrices (M, D, H) standard in math
-    "N803",    # uppercase argument names for matrices standard in math
-    "PLR2004", # magic values (2, 3, 6) are dimension constants in math code
-    "C901",    # complex functions acceptable for mathematical algorithms
-    "PLR0912", # many branches acceptable for 2D/3D dispatch
-    "PLR0914", # many locals acceptable for matrix-heavy math
+    "N806", # uppercase variable names for matrices (M, D, H) standard in math
+    "N803", # uppercase argument names for matrices standard in math
 ]
 "examples/**/*.py" = [
     "T201",    # print statements essential for example output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,10 +238,6 @@ ignore = [
     "PLR0917", # many positional arguments acceptable for elasticity solver
     "PLR2004", # magic values (2, 3) are dimension constants in math code
 ]
-"src/mmgpy/metrics.py" = [
-    "N806", # uppercase variable names for matrices (M, D, H) standard in math
-    "N803", # uppercase argument names for matrices standard in math
-]
 "examples/**/*.py" = [
     "T201",    # print statements essential for example output
     "PLR0913", # many arguments allowed for clarity in examples

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -48,6 +48,16 @@ from mmgpy._topology import two_ring_patches, vertex_adjacency
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
+# Mesh dimensions supported by MMG.
+_DIM_2D = 2
+_DIM_3D = 3
+# Symmetric tensor storage widths: 3 components in 2D, 6 in 3D
+# (upper-triangle row-major: 2D [m11, m12, m22]; 3D [m11, m12, m13, m22, m23, m33]).
+_TENSOR_SIZE_2D = 3
+_TENSOR_SIZE_3D = 6
+# ndim of a single (dim, dim) matrix or a per-vertex (n_vertices, dim) array.
+_NDIM_2D = 2
+
 
 def create_isotropic_metric(
     h: float | NDArray[np.float64],
@@ -90,7 +100,7 @@ def create_isotropic_metric(
     (100, 6)
 
     """
-    if dim not in {2, 3}:
+    if dim not in {_DIM_2D, _DIM_3D}:
         msg = f"dim must be 2 or 3, got {dim}"
         raise ValueError(msg)
 
@@ -100,7 +110,7 @@ def create_isotropic_metric(
             msg = "n_vertices required when h is a scalar"
             raise ValueError(msg)
         h = np.full(n_vertices, h.item(), dtype=np.float64)
-    elif h.ndim == 2 and h.shape[1] == 1:
+    elif h.ndim == _NDIM_2D and h.shape[1] == 1:
         h = h.ravel()
 
     if h.ndim != 1:
@@ -111,13 +121,13 @@ def create_isotropic_metric(
 
     eigenvalue = 1.0 / (h * h)
 
-    if dim == 3:
-        metric = np.zeros((n_verts, 6), dtype=np.float64)
+    if dim == _DIM_3D:
+        metric = np.zeros((n_verts, _TENSOR_SIZE_3D), dtype=np.float64)
         metric[:, 0] = eigenvalue  # m11
         metric[:, 3] = eigenvalue  # m22
         metric[:, 5] = eigenvalue  # m33
     else:
-        metric = np.zeros((n_verts, 3), dtype=np.float64)
+        metric = np.zeros((n_verts, _TENSOR_SIZE_2D), dtype=np.float64)
         metric[:, 0] = eigenvalue  # m11
         metric[:, 2] = eigenvalue  # m22
 
@@ -183,14 +193,14 @@ def create_anisotropic_metric(
         single_metric = True
         sizes = sizes.reshape(1, dim)
         n_vertices = 1
-    elif sizes.ndim == 2:
+    elif sizes.ndim == _NDIM_2D:
         n_vertices, dim = sizes.shape
         single_metric = False
     else:
         msg = f"sizes must be 1D or 2D array, got shape {sizes.shape}"
         raise ValueError(msg)
 
-    if dim not in {2, 3}:
+    if dim not in {_DIM_2D, _DIM_3D}:
         msg = f"sizes must have 2 or 3 components, got {dim}"
         raise ValueError(msg)
 
@@ -201,7 +211,7 @@ def create_anisotropic_metric(
 
     directions = np.asarray(directions, dtype=np.float64)
 
-    if single_metric and directions.ndim == 2:
+    if single_metric and directions.ndim == _NDIM_2D:
         directions = directions.reshape(1, dim, dim)
 
     if directions.shape[-2:] != (dim, dim):
@@ -209,29 +219,12 @@ def create_anisotropic_metric(
         raise ValueError(msg)
 
     eigenvalues = 1.0 / (sizes * sizes)
-    D = np.zeros((n_vertices, dim, dim), dtype=np.float64)
+    diag = np.zeros((n_vertices, dim, dim), dtype=np.float64)
     for i in range(dim):
-        D[:, i, i] = eigenvalues[:, i]
+        diag[:, i, i] = eigenvalues[:, i]
 
-    M = np.einsum("...ij,...jk,...lk->...il", directions, D, directions)
-
-    if dim == 3:
-        metric = np.zeros((n_vertices, 6), dtype=np.float64)
-        metric[:, 0] = M[:, 0, 0]  # m11
-        metric[:, 1] = M[:, 0, 1]  # m12
-        metric[:, 2] = M[:, 0, 2]  # m13
-        metric[:, 3] = M[:, 1, 1]  # m22
-        metric[:, 4] = M[:, 1, 2]  # m23
-        metric[:, 5] = M[:, 2, 2]  # m33
-    else:
-        metric = np.zeros((n_vertices, 3), dtype=np.float64)
-        metric[:, 0] = M[:, 0, 0]  # m11
-        metric[:, 1] = M[:, 0, 1]  # m12
-        metric[:, 2] = M[:, 1, 1]  # m22
-
-    if single_metric:
-        return metric[0]
-    return metric
+    matrices = np.einsum("...ij,...jk,...lk->...il", directions, diag, directions)
+    return matrix_to_tensor(matrices[0] if single_metric else matrices)
 
 
 def tensor_to_matrix(
@@ -262,12 +255,12 @@ def tensor_to_matrix(
 
     n_components = tensor.shape[1]
     if dim is None:
-        dim = 3 if n_components == 6 else 2
+        dim = _DIM_3D if n_components == _TENSOR_SIZE_3D else _DIM_2D
 
     n = tensor.shape[0]
     M = np.zeros((n, dim, dim), dtype=np.float64)
 
-    if dim == 3:
+    if dim == _DIM_3D:
         M[:, 0, 0] = tensor[:, 0]  # m11
         M[:, 0, 1] = tensor[:, 1]  # m12
         M[:, 0, 2] = tensor[:, 2]  # m13
@@ -307,15 +300,15 @@ def matrix_to_tensor(
 
     """
     M = np.asarray(M, dtype=np.float64)
-    single = M.ndim == 2
+    single = M.ndim == _NDIM_2D
     if single:
         M = M.reshape(1, *M.shape)
 
     dim = M.shape[1]
     n = M.shape[0]
 
-    if dim == 3:
-        tensor = np.zeros((n, 6), dtype=np.float64)
+    if dim == _DIM_3D:
+        tensor = np.zeros((n, _TENSOR_SIZE_3D), dtype=np.float64)
         tensor[:, 0] = M[:, 0, 0]  # m11
         tensor[:, 1] = M[:, 0, 1]  # m12
         tensor[:, 2] = M[:, 0, 2]  # m13
@@ -323,7 +316,7 @@ def matrix_to_tensor(
         tensor[:, 4] = M[:, 1, 2]  # m23
         tensor[:, 5] = M[:, 2, 2]  # m33
     else:
-        tensor = np.zeros((n, 3), dtype=np.float64)
+        tensor = np.zeros((n, _TENSOR_SIZE_2D), dtype=np.float64)
         tensor[:, 0] = M[:, 0, 0]  # m11
         tensor[:, 1] = M[:, 0, 1]  # m12
         tensor[:, 2] = M[:, 1, 1]  # m22
@@ -378,7 +371,7 @@ def validate_metric_tensor(
     tensor = np.asarray(tensor, dtype=np.float64)
     M = tensor_to_matrix(tensor, dim)
 
-    single = M.ndim == 2
+    single = M.ndim == _NDIM_2D
     if single:
         M = M.reshape(1, *M.shape)
 
@@ -439,7 +432,7 @@ def compute_metric_eigenpairs(
     """
     M = tensor_to_matrix(tensor, dim)
 
-    single = M.ndim == 2
+    single = M.ndim == _NDIM_2D
     if single:
         M = M.reshape(1, *M.shape)
 
@@ -503,39 +496,45 @@ def intersect_metrics(
     M1 = tensor_to_matrix(m1, dim)
     M2 = tensor_to_matrix(m2, dim)
 
-    single = M1.ndim == 2
+    single = M1.ndim == _NDIM_2D
     if single:
         M1 = M1.reshape(1, *M1.shape)
         M2 = M2.reshape(1, *M2.shape)
 
-    n = M1.shape[0]
     M_intersect = np.zeros_like(M1)
-
-    for i in range(n):
-        eigvals1, eigvecs1 = np.linalg.eigh(M1[i])
-
-        # Guard against near-singular metrics (eigenvalues close to zero)
-        # Use machine epsilon scaled by max eigenvalue for numerical stability
-        eps = np.finfo(np.float64).eps * np.max(np.abs(eigvals1)) * 100
-        eigvals1 = np.maximum(eigvals1, eps)
-
-        sqrt_eigvals1 = np.sqrt(eigvals1)
-        inv_sqrt_eigvals1 = 1.0 / sqrt_eigvals1
-
-        M1_sqrt = eigvecs1 @ np.diag(sqrt_eigvals1) @ eigvecs1.T
-        M1_inv_sqrt = eigvecs1 @ np.diag(inv_sqrt_eigvals1) @ eigvecs1.T
-
-        P = M1_inv_sqrt @ M2[i] @ M1_inv_sqrt
-
-        eigvals_P, eigvecs_P = np.linalg.eigh(P)
-
-        max_eigvals = np.maximum(eigvals_P, 1.0)
-
-        M_intersect[i] = (
-            M1_sqrt @ eigvecs_P @ np.diag(max_eigvals) @ eigvecs_P.T @ M1_sqrt
-        )
+    for i in range(M1.shape[0]):
+        M_intersect[i] = _intersect_metric_pair(M1[i], M2[i])
 
     return matrix_to_tensor(M_intersect if not single else M_intersect[0])
+
+
+def _intersect_metric_pair(
+    M1: NDArray[np.float64],
+    M2: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Intersect two single positive-definite matrices via simultaneous diagonalization.
+
+    Returns
+    -------
+    NDArray[np.float64]
+        The intersected matrix, same shape as *M1*.
+
+    """
+    eigvals1, eigvecs1 = np.linalg.eigh(M1)
+
+    # Guard against near-singular metrics (eigenvalues close to zero) using
+    # machine epsilon scaled by max eigenvalue for numerical stability.
+    eps = np.finfo(np.float64).eps * np.max(np.abs(eigvals1)) * 100
+    eigvals1 = np.maximum(eigvals1, eps)
+
+    sqrt_eigvals1 = np.sqrt(eigvals1)
+    M1_sqrt = eigvecs1 @ np.diag(sqrt_eigvals1) @ eigvecs1.T
+    M1_inv_sqrt = eigvecs1 @ np.diag(1.0 / sqrt_eigvals1) @ eigvecs1.T
+
+    eigvals_P, eigvecs_P = np.linalg.eigh(M1_inv_sqrt @ M2 @ M1_inv_sqrt)
+    max_eigvals = np.maximum(eigvals_P, 1.0)
+
+    return M1_sqrt @ eigvecs_P @ np.diag(max_eigvals) @ eigvecs_P.T @ M1_sqrt
 
 
 def create_metric_from_hessian(
@@ -581,7 +580,7 @@ def create_metric_from_hessian(
     hessian = np.asarray(hessian, dtype=np.float64)
     H = tensor_to_matrix(hessian)
 
-    single = H.ndim == 2
+    single = H.ndim == _NDIM_2D
     if single:
         H = H.reshape(1, *H.shape)
 
@@ -668,11 +667,13 @@ def compute_hessian(
     adj = vertex_adjacency(n_vertices, elements)
     patches = two_ring_patches(adj)
 
-    if n_dims == 2:
-        hessian = np.zeros((n_vertices, 3), dtype=np.float64)
+    if n_dims == _DIM_2D:
+        hessian = np.zeros((n_vertices, _TENSOR_SIZE_2D), dtype=np.float64)
+        solve = _solve_hessian_2d
         n_basis = 5
     else:
-        hessian = np.zeros((n_vertices, 6), dtype=np.float64)
+        hessian = np.zeros((n_vertices, _TENSOR_SIZE_3D), dtype=np.float64)
+        solve = _solve_hessian_3d
         n_basis = 9
 
     for i in range(n_vertices):
@@ -693,45 +694,47 @@ def compute_hessian(
         scale = float(np.linalg.norm(coords, axis=1).max())
         if not scale:
             continue
-        coords_n = coords / scale
-        scale2 = scale * scale
 
-        if n_dims == 2:
-            # Monomial basis: x, y, x^2/2, xy, y^2/2
-            x, y = coords_n[:, 0], coords_n[:, 1]
-            A = np.column_stack([x, y, 0.5 * x * x, x * y, 0.5 * y * y])
-            coeffs, _, _, _ = np.linalg.lstsq(A, vals, rcond=None)
-            # H11 = d2f/dx2, H12 = d2f/dxdy, H22 = d2f/dy2
-            hessian[i] = [
-                coeffs[2] / scale2,
-                coeffs[3] / scale2,
-                coeffs[4] / scale2,
-            ]
-        else:
-            # Monomial basis: x, y, z, x^2/2, xy, xz, y^2/2, yz, z^2/2
-            x, y, z = coords_n[:, 0], coords_n[:, 1], coords_n[:, 2]
-            A = np.column_stack(
-                [
-                    x,
-                    y,
-                    z,
-                    0.5 * x * x,
-                    x * y,
-                    x * z,
-                    0.5 * y * y,
-                    y * z,
-                    0.5 * z * z,
-                ],
-            )
-            coeffs, _, _, _ = np.linalg.lstsq(A, vals, rcond=None)
-            # Returned ordering: H11, H12, H13, H22, H23, H33
-            hessian[i] = [
-                coeffs[3] / scale2,
-                coeffs[4] / scale2,
-                coeffs[5] / scale2,
-                coeffs[6] / scale2,
-                coeffs[7] / scale2,
-                coeffs[8] / scale2,
-            ]
+        hessian[i] = solve(coords / scale, vals) / (scale * scale)
 
     return hessian
+
+
+def _solve_hessian_2d(
+    coords_n: NDArray[np.float64],
+    vals: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Least-squares quadratic fit recovering the 2D Hessian components.
+
+    Returns
+    -------
+    NDArray[np.float64]
+        Hessian components ``[H11, H12, H22]`` in normalized coords (unscaled).
+
+    """
+    # Monomial basis: x, y, x^2/2, xy, y^2/2
+    x, y = coords_n[:, 0], coords_n[:, 1]
+    A = np.column_stack([x, y, 0.5 * x * x, x * y, 0.5 * y * y])
+    coeffs, _, _, _ = np.linalg.lstsq(A, vals, rcond=None)
+    return coeffs[2:5]
+
+
+def _solve_hessian_3d(
+    coords_n: NDArray[np.float64],
+    vals: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Least-squares quadratic fit recovering the 3D Hessian components.
+
+    Returns
+    -------
+    NDArray[np.float64]
+        Hessian components ``[H11, H12, H13, H22, H23, H33]`` (unscaled).
+
+    """
+    # Monomial basis: x, y, z, x^2/2, xy, xz, y^2/2, yz, z^2/2
+    x, y, z = coords_n[:, 0], coords_n[:, 1], coords_n[:, 2]
+    A = np.column_stack(
+        [x, y, z, 0.5 * x * x, x * y, x * z, 0.5 * y * y, y * z, 0.5 * z * z],
+    )
+    coeffs, _, _, _ = np.linalg.lstsq(A, vals, rcond=None)
+    return coeffs[3:9]

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -258,37 +258,37 @@ def tensor_to_matrix(
         dim = _DIM_3D if n_components == _TENSOR_SIZE_3D else _DIM_2D
 
     n = tensor.shape[0]
-    M = np.zeros((n, dim, dim), dtype=np.float64)
+    matrix = np.zeros((n, dim, dim), dtype=np.float64)
 
     if dim == _DIM_3D:
-        M[:, 0, 0] = tensor[:, 0]  # m11
-        M[:, 0, 1] = tensor[:, 1]  # m12
-        M[:, 0, 2] = tensor[:, 2]  # m13
-        M[:, 1, 0] = tensor[:, 1]  # m21 = m12
-        M[:, 1, 1] = tensor[:, 3]  # m22
-        M[:, 1, 2] = tensor[:, 4]  # m23
-        M[:, 2, 0] = tensor[:, 2]  # m31 = m13
-        M[:, 2, 1] = tensor[:, 4]  # m32 = m23
-        M[:, 2, 2] = tensor[:, 5]  # m33
+        matrix[:, 0, 0] = tensor[:, 0]  # m11
+        matrix[:, 0, 1] = tensor[:, 1]  # m12
+        matrix[:, 0, 2] = tensor[:, 2]  # m13
+        matrix[:, 1, 0] = tensor[:, 1]  # m21 = m12
+        matrix[:, 1, 1] = tensor[:, 3]  # m22
+        matrix[:, 1, 2] = tensor[:, 4]  # m23
+        matrix[:, 2, 0] = tensor[:, 2]  # m31 = m13
+        matrix[:, 2, 1] = tensor[:, 4]  # m32 = m23
+        matrix[:, 2, 2] = tensor[:, 5]  # m33
     else:
-        M[:, 0, 0] = tensor[:, 0]  # m11
-        M[:, 0, 1] = tensor[:, 1]  # m12
-        M[:, 1, 0] = tensor[:, 1]  # m21 = m12
-        M[:, 1, 1] = tensor[:, 2]  # m22
+        matrix[:, 0, 0] = tensor[:, 0]  # m11
+        matrix[:, 0, 1] = tensor[:, 1]  # m12
+        matrix[:, 1, 0] = tensor[:, 1]  # m21 = m12
+        matrix[:, 1, 1] = tensor[:, 2]  # m22
 
     if single:
-        return M[0]
-    return M
+        return matrix[0]
+    return matrix
 
 
 def matrix_to_tensor(
-    M: NDArray[np.float64],
+    matrix: NDArray[np.float64],
 ) -> NDArray[np.float64]:
     """Convert full symmetric matrix to tensor storage format.
 
     Parameters
     ----------
-    M : array_like
+    matrix : array_like
         Full symmetric matrix. Shape (3, 3) or (n, 3, 3) for 3D,
         (2, 2) or (n, 2, 2) for 2D.
 
@@ -299,27 +299,27 @@ def matrix_to_tensor(
         (3,) or (n, 3) for 2D.
 
     """
-    M = np.asarray(M, dtype=np.float64)
-    single = M.ndim == _NDIM_2D
+    matrix = np.asarray(matrix, dtype=np.float64)
+    single = matrix.ndim == _NDIM_2D
     if single:
-        M = M.reshape(1, *M.shape)
+        matrix = matrix.reshape(1, *matrix.shape)
 
-    dim = M.shape[1]
-    n = M.shape[0]
+    dim = matrix.shape[1]
+    n = matrix.shape[0]
 
     if dim == _DIM_3D:
         tensor = np.zeros((n, _TENSOR_SIZE_3D), dtype=np.float64)
-        tensor[:, 0] = M[:, 0, 0]  # m11
-        tensor[:, 1] = M[:, 0, 1]  # m12
-        tensor[:, 2] = M[:, 0, 2]  # m13
-        tensor[:, 3] = M[:, 1, 1]  # m22
-        tensor[:, 4] = M[:, 1, 2]  # m23
-        tensor[:, 5] = M[:, 2, 2]  # m33
+        tensor[:, 0] = matrix[:, 0, 0]  # m11
+        tensor[:, 1] = matrix[:, 0, 1]  # m12
+        tensor[:, 2] = matrix[:, 0, 2]  # m13
+        tensor[:, 3] = matrix[:, 1, 1]  # m22
+        tensor[:, 4] = matrix[:, 1, 2]  # m23
+        tensor[:, 5] = matrix[:, 2, 2]  # m33
     else:
         tensor = np.zeros((n, _TENSOR_SIZE_2D), dtype=np.float64)
-        tensor[:, 0] = M[:, 0, 0]  # m11
-        tensor[:, 1] = M[:, 0, 1]  # m12
-        tensor[:, 2] = M[:, 1, 1]  # m22
+        tensor[:, 0] = matrix[:, 0, 0]  # m11
+        tensor[:, 1] = matrix[:, 0, 1]  # m12
+        tensor[:, 2] = matrix[:, 1, 1]  # m22
 
     if single:
         return tensor[0]
@@ -369,16 +369,16 @@ def validate_metric_tensor(
 
     """
     tensor = np.asarray(tensor, dtype=np.float64)
-    M = tensor_to_matrix(tensor, dim)
+    matrix = tensor_to_matrix(tensor, dim)
 
-    single = M.ndim == _NDIM_2D
+    single = matrix.ndim == _NDIM_2D
     if single:
-        M = M.reshape(1, *M.shape)
+        matrix = matrix.reshape(1, *matrix.shape)
 
     all_valid = True
     messages = []
 
-    for i, m in enumerate(M):
+    for i, m in enumerate(matrix):
         eigvals = np.linalg.eigvalsh(m)
 
         if not np.all(eigvals > 0):
@@ -430,19 +430,19 @@ def compute_metric_eigenpairs(
     array([0.1, 1. , 1. ])
 
     """
-    M = tensor_to_matrix(tensor, dim)
+    matrix = tensor_to_matrix(tensor, dim)
 
-    single = M.ndim == _NDIM_2D
+    single = matrix.ndim == _NDIM_2D
     if single:
-        M = M.reshape(1, *M.shape)
+        matrix = matrix.reshape(1, *matrix.shape)
 
-    n = M.shape[0]
-    actual_dim = M.shape[1]
+    n = matrix.shape[0]
+    actual_dim = matrix.shape[1]
 
     sizes = np.zeros((n, actual_dim), dtype=np.float64)
     directions = np.zeros((n, actual_dim, actual_dim), dtype=np.float64)
 
-    for i, m in enumerate(M):
+    for i, m in enumerate(matrix):
         eigvals, eigvecs = np.linalg.eigh(m)
         sizes[i] = 1.0 / np.sqrt(eigvals)
         directions[i] = eigvecs
@@ -493,34 +493,34 @@ def intersect_metrics(
         msg = f"Metrics must have same shape: {m1.shape} vs {m2.shape}"
         raise ValueError(msg)
 
-    M1 = tensor_to_matrix(m1, dim)
-    M2 = tensor_to_matrix(m2, dim)
+    matrix1 = tensor_to_matrix(m1, dim)
+    matrix2 = tensor_to_matrix(m2, dim)
 
-    single = M1.ndim == _NDIM_2D
+    single = matrix1.ndim == _NDIM_2D
     if single:
-        M1 = M1.reshape(1, *M1.shape)
-        M2 = M2.reshape(1, *M2.shape)
+        matrix1 = matrix1.reshape(1, *matrix1.shape)
+        matrix2 = matrix2.reshape(1, *matrix2.shape)
 
-    M_intersect = np.zeros_like(M1)
-    for i in range(M1.shape[0]):
-        M_intersect[i] = _intersect_metric_pair(M1[i], M2[i])
+    intersected = np.zeros_like(matrix1)
+    for i in range(matrix1.shape[0]):
+        intersected[i] = _intersect_metric_pair(matrix1[i], matrix2[i])
 
-    return matrix_to_tensor(M_intersect if not single else M_intersect[0])
+    return matrix_to_tensor(intersected if not single else intersected[0])
 
 
 def _intersect_metric_pair(
-    M1: NDArray[np.float64],
-    M2: NDArray[np.float64],
+    matrix1: NDArray[np.float64],
+    matrix2: NDArray[np.float64],
 ) -> NDArray[np.float64]:
     """Intersect two single positive-definite matrices via simultaneous diagonalization.
 
     Returns
     -------
     NDArray[np.float64]
-        The intersected matrix, same shape as *M1*.
+        The intersected matrix, same shape as *matrix1*.
 
     """
-    eigvals1, eigvecs1 = np.linalg.eigh(M1)
+    eigvals1, eigvecs1 = np.linalg.eigh(matrix1)
 
     # Guard against near-singular metrics (eigenvalues close to zero) using
     # machine epsilon scaled by max eigenvalue for numerical stability.
@@ -528,13 +528,21 @@ def _intersect_metric_pair(
     eigvals1 = np.maximum(eigvals1, eps)
 
     sqrt_eigvals1 = np.sqrt(eigvals1)
-    M1_sqrt = eigvecs1 @ np.diag(sqrt_eigvals1) @ eigvecs1.T
-    M1_inv_sqrt = eigvecs1 @ np.diag(1.0 / sqrt_eigvals1) @ eigvecs1.T
+    sqrt1 = eigvecs1 @ np.diag(sqrt_eigvals1) @ eigvecs1.T
+    inv_sqrt1 = eigvecs1 @ np.diag(1.0 / sqrt_eigvals1) @ eigvecs1.T
 
-    eigvals_P, eigvecs_P = np.linalg.eigh(M1_inv_sqrt @ M2 @ M1_inv_sqrt)
-    max_eigvals = np.maximum(eigvals_P, 1.0)
+    transformed_eigvals, transformed_eigvecs = np.linalg.eigh(
+        inv_sqrt1 @ matrix2 @ inv_sqrt1,
+    )
+    max_eigvals = np.maximum(transformed_eigvals, 1.0)
 
-    return M1_sqrt @ eigvecs_P @ np.diag(max_eigvals) @ eigvecs_P.T @ M1_sqrt
+    return (
+        sqrt1
+        @ transformed_eigvecs
+        @ np.diag(max_eigvals)
+        @ transformed_eigvecs.T
+        @ sqrt1
+    )
 
 
 def create_metric_from_hessian(
@@ -578,19 +586,19 @@ def create_metric_from_hessian(
 
     """
     hessian = np.asarray(hessian, dtype=np.float64)
-    H = tensor_to_matrix(hessian)
+    hessian_matrix = tensor_to_matrix(hessian)
 
-    single = H.ndim == _NDIM_2D
+    single = hessian_matrix.ndim == _NDIM_2D
     if single:
-        H = H.reshape(1, *H.shape)
+        hessian_matrix = hessian_matrix.reshape(1, *hessian_matrix.shape)
 
-    n = H.shape[0]
-    M = np.zeros_like(H)
+    n = hessian_matrix.shape[0]
+    metric_matrix = np.zeros_like(hessian_matrix)
 
     c = 1.0 / 8.0
 
     for i in range(n):
-        eigvals, eigvecs = np.linalg.eigh(H[i])
+        eigvals, eigvecs = np.linalg.eigh(hessian_matrix[i])
         abs_eigvals = np.abs(eigvals)
 
         metric_eigvals = c * abs_eigvals / target_error
@@ -609,9 +617,9 @@ def create_metric_from_hessian(
             min_eigval = 1.0 / (hmax * hmax)
             metric_eigvals = np.maximum(metric_eigvals, min_eigval)
 
-        M[i] = eigvecs @ np.diag(metric_eigvals) @ eigvecs.T
+        metric_matrix[i] = eigvecs @ np.diag(metric_eigvals) @ eigvecs.T
 
-    return matrix_to_tensor(M if not single else M[0])
+    return matrix_to_tensor(metric_matrix if not single else metric_matrix[0])
 
 
 def compute_hessian(
@@ -714,8 +722,8 @@ def _solve_hessian_2d(
     """
     # Monomial basis: x, y, x^2/2, xy, y^2/2
     x, y = coords_n[:, 0], coords_n[:, 1]
-    A = np.column_stack([x, y, 0.5 * x * x, x * y, 0.5 * y * y])
-    coeffs, _, _, _ = np.linalg.lstsq(A, vals, rcond=None)
+    basis = np.column_stack([x, y, 0.5 * x * x, x * y, 0.5 * y * y])
+    coeffs, _, _, _ = np.linalg.lstsq(basis, vals, rcond=None)
     return coeffs[2:5]
 
 
@@ -733,8 +741,8 @@ def _solve_hessian_3d(
     """
     # Monomial basis: x, y, z, x^2/2, xy, xz, y^2/2, yz, z^2/2
     x, y, z = coords_n[:, 0], coords_n[:, 1], coords_n[:, 2]
-    A = np.column_stack(
+    basis = np.column_stack(
         [x, y, z, 0.5 * x * x, x * y, x * z, 0.5 * y * y, y * z, 0.5 * z * z],
     )
-    coeffs, _, _, _ = np.linalg.lstsq(A, vals, rcond=None)
+    coeffs, _, _, _ = np.linalg.lstsq(basis, vals, rcond=None)
     return coeffs[3:9]

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -46,7 +46,14 @@ import numpy as np
 from mmgpy._topology import two_ring_patches, vertex_adjacency
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from numpy.typing import NDArray
+
+    HessianSolver = Callable[
+        [NDArray[np.float64], NDArray[np.float64]],
+        NDArray[np.float64],
+    ]
 
 # Mesh dimensions supported by MMG.
 _DIM_2D = 2
@@ -594,12 +601,11 @@ def create_metric_from_hessian(
     if single:
         hessian_matrix = hessian_matrix.reshape(1, *hessian_matrix.shape)
 
-    n = hessian_matrix.shape[0]
     metric_matrix = np.zeros_like(hessian_matrix)
 
     c = 1.0 / 8.0
 
-    for i in range(n):
+    for i in range(hessian_matrix.shape[0]):
         eigvals, eigvecs = np.linalg.eigh(hessian_matrix[i])
         abs_eigvals = np.abs(eigvals)
 
@@ -677,6 +683,7 @@ def compute_hessian(
     adj = vertex_adjacency(n_vertices, elements)
     patches = two_ring_patches(adj)
 
+    solve: HessianSolver
     if n_dims == _DIM_2D:
         hessian = np.zeros((n_vertices, _TENSOR_SIZE_2D), dtype=np.float64)
         solve = _solve_hessian_2d
@@ -719,7 +726,8 @@ def _solve_hessian_2d(
     Returns
     -------
     NDArray[np.float64]
-        Hessian components ``[H11, H12, H22]`` in normalized coords (unscaled).
+        Hessian components ``[H11, H12, H22]`` before the ``/ scale**2``
+        correction applied by the caller.
 
     """
     # Monomial basis: x, y, x^2/2, xy, y^2/2
@@ -738,7 +746,8 @@ def _solve_hessian_3d(
     Returns
     -------
     NDArray[np.float64]
-        Hessian components ``[H11, H12, H13, H22, H23, H33]`` (unscaled).
+        Hessian components ``[H11, H12, H13, H22, H23, H33]`` before the
+        ``/ scale**2`` correction applied by the caller.
 
     """
     # Monomial basis: x, y, z, x^2/2, xy, xz, y^2/2, yz, z^2/2

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -55,8 +55,10 @@ _DIM_3D = 3
 # (upper-triangle row-major: 2D [m11, m12, m22]; 3D [m11, m12, m13, m22, m23, m33]).
 _TENSOR_SIZE_2D = 3
 _TENSOR_SIZE_3D = 6
-# ndim of a single (dim, dim) matrix or a per-vertex (n_vertices, dim) array.
-_NDIM_2D = 2
+# ndim of a 2D input array, shape (n_vertices, dim).
+_ARRAY_NDIM_2D = 2
+# ndim of a single (unbatched) matrix, shape (dim, dim).
+_SINGLE_MATRIX_NDIM = 2
 
 
 def create_isotropic_metric(
@@ -110,7 +112,7 @@ def create_isotropic_metric(
             msg = "n_vertices required when h is a scalar"
             raise ValueError(msg)
         h = np.full(n_vertices, h.item(), dtype=np.float64)
-    elif h.ndim == _NDIM_2D and h.shape[1] == 1:
+    elif h.ndim == _ARRAY_NDIM_2D and h.shape[1] == 1:
         h = h.ravel()
 
     if h.ndim != 1:
@@ -193,7 +195,7 @@ def create_anisotropic_metric(
         single_metric = True
         sizes = sizes.reshape(1, dim)
         n_vertices = 1
-    elif sizes.ndim == _NDIM_2D:
+    elif sizes.ndim == _ARRAY_NDIM_2D:
         n_vertices, dim = sizes.shape
         single_metric = False
     else:
@@ -211,7 +213,7 @@ def create_anisotropic_metric(
 
     directions = np.asarray(directions, dtype=np.float64)
 
-    if single_metric and directions.ndim == _NDIM_2D:
+    if single_metric and directions.ndim == _SINGLE_MATRIX_NDIM:
         directions = directions.reshape(1, dim, dim)
 
     if directions.shape[-2:] != (dim, dim):
@@ -300,7 +302,7 @@ def matrix_to_tensor(
 
     """
     matrix = np.asarray(matrix, dtype=np.float64)
-    single = matrix.ndim == _NDIM_2D
+    single = matrix.ndim == _SINGLE_MATRIX_NDIM
     if single:
         matrix = matrix.reshape(1, *matrix.shape)
 
@@ -371,7 +373,7 @@ def validate_metric_tensor(
     tensor = np.asarray(tensor, dtype=np.float64)
     matrix = tensor_to_matrix(tensor, dim)
 
-    single = matrix.ndim == _NDIM_2D
+    single = matrix.ndim == _SINGLE_MATRIX_NDIM
     if single:
         matrix = matrix.reshape(1, *matrix.shape)
 
@@ -432,7 +434,7 @@ def compute_metric_eigenpairs(
     """
     matrix = tensor_to_matrix(tensor, dim)
 
-    single = matrix.ndim == _NDIM_2D
+    single = matrix.ndim == _SINGLE_MATRIX_NDIM
     if single:
         matrix = matrix.reshape(1, *matrix.shape)
 
@@ -496,7 +498,7 @@ def intersect_metrics(
     matrix1 = tensor_to_matrix(m1, dim)
     matrix2 = tensor_to_matrix(m2, dim)
 
-    single = matrix1.ndim == _NDIM_2D
+    single = matrix1.ndim == _SINGLE_MATRIX_NDIM
     if single:
         matrix1 = matrix1.reshape(1, *matrix1.shape)
         matrix2 = matrix2.reshape(1, *matrix2.shape)
@@ -588,7 +590,7 @@ def create_metric_from_hessian(
     hessian = np.asarray(hessian, dtype=np.float64)
     hessian_matrix = tensor_to_matrix(hessian)
 
-    single = hessian_matrix.ndim == _NDIM_2D
+    single = hessian_matrix.ndim == _SINGLE_MATRIX_NDIM
     if single:
         hessian_matrix = hessian_matrix.reshape(1, *hessian_matrix.shape)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1441,7 +1441,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.14.0.dev0"
+version = "0.15.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Drop all stale ruff ignores on `metrics.py` by introducing dim/tensor-size constants, extracting per-dim helpers, and renaming single-letter math variables to descriptive names.

## Changes

- Add module constants: `_DIM_2D`, `_DIM_3D`, `_TENSOR_SIZE_2D`, `_TENSOR_SIZE_3D`, `_NDIM_2D`
- `create_anisotropic_metric`: collapse the explicit 3D/2D packing into a call to the existing `matrix_to_tensor`
- `intersect_metrics`: extract `_intersect_metric_pair` for the per-tensor body
- `compute_hessian`: extract `_solve_hessian_2d` / `_solve_hessian_3d` for the LSQ branches
- Replace all `2` / `3` / `6` literals with the named constants
- Rename single-letter locals/params for clarity: `M` -> `matrix`, `H` -> `hessian_matrix`, `M1`/`M2` -> `matrix1`/`matrix2`, `A` -> `basis`, `D` -> `diag`, `M_intersect` -> `intersected`, `M1_sqrt`/`M1_inv_sqrt` -> `sqrt1`/`inv_sqrt1`, `eigvals_P`/`eigvecs_P` -> `transformed_eigvals`/`transformed_eigvecs`
- `pyproject.toml`: remove the entire `metrics.py` ignore block (no exceptions left)