### PR TITLE
refactor: eliminate PLR0913 in _remesh.py and _mesh.py

### DIFF
--- a/docs/api/results-validation.md
+++ b/docs/api/results-validation.md
@@ -133,17 +133,13 @@ except ValidationError as e:
 # Only check geometry
 report = mesh.mmg.validate(
     detailed=True,
-    check_geometry=True,
-    check_topology=False,
-    check_quality=False,
+    checks={"geometry"},
 )
 
 # Only check quality with a custom threshold
 report = mesh.mmg.validate(
     detailed=True,
-    check_geometry=False,
-    check_topology=False,
-    check_quality=True,
+    checks={"quality"},
     min_quality=0.2,
 )
 ```

--- a/examples/mmg2d/implicit_2d_domain_meshing.py
+++ b/examples/mmg2d/implicit_2d_domain_meshing.py
@@ -15,16 +15,16 @@ from pathlib import Path
 
 import pyvista as pv
 
-from mmgpy import mmg2d
+from mmgpy import SolPaths, mmg2d
 
 INPUT_FILE = Path(__file__).parent.parent.parent / "assets" / "multi-mat.mesh"
 SOL_FILE = Path(__file__).parent.parent.parent / "assets" / "multi-mat-ls.sol"
 OUTPUT_FILE = Path(__file__).parent / "output.vtk"
 
 mmg2d.remesh(
-    input_mesh=INPUT_FILE,
-    input_sol=SOL_FILE,
-    output_mesh=OUTPUT_FILE,
+    INPUT_FILE,
+    OUTPUT_FILE,
+    sol=SolPaths(input=SOL_FILE),
     options={"iso": 1, "ls": 0.0},
 )
 

--- a/examples/mmg2d/implicit_2d_domain_meshing.py
+++ b/examples/mmg2d/implicit_2d_domain_meshing.py
@@ -24,7 +24,7 @@ OUTPUT_FILE = Path(__file__).parent / "output.vtk"
 mmg2d.remesh(
     INPUT_FILE,
     OUTPUT_FILE,
-    sol=SolPaths(input=SOL_FILE),
+    sol=SolPaths(in_path=SOL_FILE),
     options={"iso": 1, "ls": 0.0},
 )
 

--- a/examples/mmgs/implicit_surface_domain_meshing.py
+++ b/examples/mmgs/implicit_surface_domain_meshing.py
@@ -24,7 +24,7 @@ OUTPUT_FILE = Path(__file__).parent / "output.vtk"
 mmgs.remesh(
     INPUT_FILE,
     OUTPUT_FILE,
-    sol=SolPaths(input=SOL_FILE),
+    sol=SolPaths(in_path=SOL_FILE),
     options={"iso": 1, "ls": 0.0},
 )
 

--- a/examples/mmgs/implicit_surface_domain_meshing.py
+++ b/examples/mmgs/implicit_surface_domain_meshing.py
@@ -15,16 +15,16 @@ from pathlib import Path
 
 import pyvista as pv
 
-from mmgpy import mmgs
+from mmgpy import SolPaths, mmgs
 
 INPUT_FILE = Path(__file__).parent.parent.parent / "assets" / "teapot.mesh"
 SOL_FILE = Path(__file__).parent.parent.parent / "assets" / "teapot-ls.sol"
 OUTPUT_FILE = Path(__file__).parent / "output.vtk"
 
 mmgs.remesh(
-    input_mesh=INPUT_FILE,
-    input_sol=SOL_FILE,
-    output_mesh=OUTPUT_FILE,
+    INPUT_FILE,
+    OUTPUT_FILE,
+    sol=SolPaths(input=SOL_FILE),
     options={"iso": 1, "ls": 0.0},
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,14 +178,12 @@ ignore = [
     "RUF027",                                # preview missing-f-string
 ]
 "src/mmgpy/_remesh.py" = [
-    "FBT002",  # transfer_fields has a boolean default for consistency with Mesh.remesh()
     "N801",    # class names match C++ API (mmg2d, mmg3d, mmgs)
-    "PLR0913", # _wrapped_remesh mirrors C++ function signatures
-    "PLR0917", # _wrapped_remesh mirrors C++ function signatures (positional)
+    "PLR0913", # _wrapped_remesh mirrors C++ function signatures (total arg count)
 ]
 "src/mmgpy/_mesh.py" = [
     "PLR0904", # Mesh exposes the full public API (auto-detected 2D/3D/surface)
-    "PLR0917", # _create_impl mirrors a C++ constructor (positional)
+    "PLR0913", # _create_impl mirrors a C++ constructor (total arg count)
 ]
 "src/mmgpy/_pv_plugin.py" = [
     "PLR0904", # PyVista accessor exposes the full public API surface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,11 +179,9 @@ ignore = [
 ]
 "src/mmgpy/_remesh.py" = [
     "N801",    # class names match C++ API (mmg2d, mmg3d, mmgs)
-    "PLR0913", # _wrapped_remesh mirrors C++ function signatures (total arg count)
 ]
 "src/mmgpy/_mesh.py" = [
     "PLR0904", # Mesh exposes the full public API (auto-detected 2D/3D/surface)
-    "PLR0913", # _create_impl mirrors a C++ constructor (total arg count)
 ]
 "src/mmgpy/_pv_plugin.py" = [
     "PLR0904", # PyVista accessor exposes the full public API surface

--- a/src/mmgpy/__init__.py
+++ b/src/mmgpy/__init__.py
@@ -29,7 +29,7 @@ from ._mmgpy import MMG_VERSION  # type: ignore[attr-defined]
 from ._options import Mmg2DOptions, Mmg3DOptions, MmgSOptions
 from ._progress import CancellationError, ProgressEvent, rich_progress
 from ._pyvista import from_pyvista, polydata_from_2d_triangles, to_pyvista
-from ._remesh import mmg2d, mmg3d, mmgs  # noqa: F401
+from ._remesh import SolPaths, mmg2d, mmg3d, mmgs  # noqa: F401
 from ._reorder import reorder_cuthill_mckee
 from ._result import RemeshResult
 from ._transfer import interpolate_field, transfer_fields

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -539,7 +539,7 @@ def _normalize_local_parameters(
 
     The binding raises a generic ``RuntimeError`` deep in MMG for malformed
     input; routing through this helper turns shape errors into a clear
-    ``ValueError`` before the C call.
+    ``ValueError``/``TypeError`` before the C call.
 
     Returns
     -------
@@ -548,9 +548,11 @@ def _normalize_local_parameters(
 
     Raises
     ------
+    TypeError
+        If an entry is not a mapping.
     ValueError
-        If an entry is not a mapping, is missing required keys, or has an
-        unsupported ``type`` for the mesh kind.
+        If an entry is missing required keys or has an unsupported ``type``
+        for the mesh kind.
 
     """
     valid_types = (
@@ -562,7 +564,7 @@ def _normalize_local_parameters(
     for i, raw in enumerate(parameters):
         if not isinstance(raw, Mapping):
             msg = f"parameters[{i}] must be a mapping, got {type(raw).__name__}"
-            raise ValueError(msg)  # noqa: TRY004
+            raise TypeError(msg)
         missing = [k for k in _LOCAL_PARAM_KEYS if k not in raw]
         if missing:
             msg = f"parameters[{i}] missing keys: {missing}"
@@ -598,15 +600,17 @@ def _normalize_multi_materials(
 
     Raises
     ------
+    TypeError
+        If an entry is not a mapping, or if ``split`` is not a bool or int.
     ValueError
-        If an entry is not a mapping or is missing required keys.
+        If an entry is missing required keys, or if ``split`` is not 0/1.
 
     """
     normalized: list[dict[str, Any]] = []
     for i, raw in enumerate(materials):
         if not isinstance(raw, Mapping):
             msg = f"materials[{i}] must be a mapping, got {type(raw).__name__}"
-            raise ValueError(msg)  # noqa: TRY004
+            raise TypeError(msg)
         missing = [k for k in _MULTI_MATERIAL_KEYS if k not in raw]
         if missing:
             msg = f"materials[{i}] missing keys: {missing}"
@@ -617,7 +621,7 @@ def _normalize_multi_materials(
                 f"materials[{i}]['split'] must be bool or int (0/1), "
                 f"got {type(split_raw).__name__}"
             )
-            raise ValueError(msg)  # noqa: TRY004
+            raise TypeError(msg)
         split = int(split_raw)
         if split not in {0, 1}:
             msg = f"materials[{i}]['split'] must be 0 or 1, got {split}"

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -26,6 +26,7 @@ from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable, Sequence
     from types import TracebackType
+    from typing import Self
 
     from numpy.typing import NDArray
 
@@ -58,7 +59,7 @@ _ALL_CHECKS: frozenset[ValidationCheck] = frozenset(
 )
 
 
-_RENUM_FUTURE_WARNED = False
+_RENUM_FUTURE_WARNED: list[bool] = [False]
 
 
 def _pop_renum_redirect(kwargs: dict[str, Any]) -> bool:
@@ -101,19 +102,17 @@ def _pop_renum_redirect(kwargs: dict[str, Any]) -> bool:
             raise ValueError(msg) from err
     else:
         do_rcm = bool(raw)
-    if do_rcm:
-        global _RENUM_FUTURE_WARNED  # noqa: PLW0603
-        if not _RENUM_FUTURE_WARNED:
-            _RENUM_FUTURE_WARNED = True
-            warnings.warn(
-                "renum=1 no longer invokes SCOTCH renumbering (the bundled "
-                "MMG is built without it); mmgpy now applies reverse "
-                "Cuthill-McKee instead. Call "
-                "mmgpy.reorder_cuthill_mckee() directly for explicit "
-                "control over the reordering.",
-                FutureWarning,
-                stacklevel=3,
-            )
+    if do_rcm and not _RENUM_FUTURE_WARNED[0]:
+        _RENUM_FUTURE_WARNED[0] = True
+        warnings.warn(
+            "renum=1 no longer invokes SCOTCH renumbering (the bundled "
+            "MMG is built without it); mmgpy now applies reverse "
+            "Cuthill-McKee instead. Call "
+            "mmgpy.reorder_cuthill_mckee() directly for explicit "
+            "control over the reordering.",
+            FutureWarning,
+            stacklevel=3,
+        )
     return do_rcm
 
 
@@ -2899,7 +2898,7 @@ class Mesh:
     # Context manager support
     # =========================================================================
 
-    def __enter__(self) -> Mesh:  # noqa: PYI034
+    def __enter__(self) -> Self:
         """Enter the context manager.
 
         Returns

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -59,7 +59,10 @@ _ALL_CHECKS: frozenset[ValidationCheck] = frozenset(
 )
 
 
-_RENUM_FUTURE_WARNED: list[bool] = [False]
+class _RenumWarning:
+    """Holds the one-shot ``FutureWarning`` flag for the ``renum`` kwarg."""
+
+    fired = False
 
 
 def _pop_renum_redirect(kwargs: dict[str, Any]) -> bool:
@@ -102,8 +105,8 @@ def _pop_renum_redirect(kwargs: dict[str, Any]) -> bool:
             raise ValueError(msg) from err
     else:
         do_rcm = bool(raw)
-    if do_rcm and not _RENUM_FUTURE_WARNED[0]:
-        _RENUM_FUTURE_WARNED[0] = True
+    if do_rcm and not _RenumWarning.fired:
+        _RenumWarning.fired = True
         warnings.warn(
             "renum=1 no longer invokes SCOTCH renumbering (the bundled "
             "MMG is built without it); mmgpy now applies reverse "

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 import numpy as np
 import pyvista as pv
@@ -24,7 +24,7 @@ import pyvista as pv
 from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Sequence
+    from collections.abc import Callable, Generator, Iterable, Sequence
     from types import TracebackType
 
     from numpy.typing import NDArray
@@ -51,6 +51,11 @@ _TETRA_VERTS = 4
 _TRI_VERTS = 3
 _EDGE_VERTS = 2
 _2D_DETECTION_TOLERANCE = 1e-8
+
+ValidationCheck = Literal["geometry", "topology", "quality"]
+_ALL_CHECKS: frozenset[ValidationCheck] = frozenset(
+    ("geometry", "topology", "quality"),
+)
 
 
 _RENUM_FUTURE_WARNED = False
@@ -377,45 +382,76 @@ def _validate_refs(
     return refs_arr
 
 
-def _validate_edges(
-    edges: NDArray[np.integer] | None,
-    edge_refs: NDArray[np.integer] | None,
-) -> tuple[NDArray[np.int32] | None, NDArray[np.int64] | None]:
-    """Coerce and validate edge connectivity and reference markers.
+class _EdgeData(NamedTuple):
+    """Edge connectivity paired with optional reference markers.
+
+    Used to keep ``_create_impl`` and ``Mesh.__init__`` under
+    ``PLR0913``'s arg budget by bundling the always-paired ``edges`` and
+    ``edge_refs`` arrays into a single parameter.
+    """
+
+    edges: NDArray[np.int32]
+    refs: NDArray[np.int64] | None = None
+
+
+def _build_edge_data(
+    edges: NDArray[np.int32] | None,
+    edge_refs: NDArray[np.int64] | None,
+) -> _EdgeData | None:
+    """Bundle ``edges`` and ``edge_refs`` into ``_EdgeData`` or ``None``.
 
     Returns
     -------
-    tuple of (ndarray of int32 or None, ndarray of int64 or None)
-        ``(edges, edge_refs)`` after coercion; both are ``None`` when
-        no edges were supplied.
+    _EdgeData or None
+        ``_EdgeData(edges, edge_refs)`` when ``edges`` is provided,
+        otherwise ``None``.
 
     Raises
     ------
     ValueError
-        If ``edge_refs`` is given without ``edges``, if ``edges`` is not
-        shape ``(n_edges, 2)``, or if the lengths of ``edges`` and
-        ``edge_refs`` differ.
+        If ``edge_refs`` is supplied without ``edges``.
 
     """
     if edges is None:
         if edge_refs is not None:
             msg = "edge_refs provided without edges"
             raise ValueError(msg)
-        return None, None
-    edges_arr = np.ascontiguousarray(edges, dtype=np.int32)
+        return None
+    return _EdgeData(edges, edge_refs)
+
+
+def _validate_edges(edges: _EdgeData | None) -> _EdgeData | None:
+    """Coerce and validate edge connectivity and reference markers.
+
+    Returns
+    -------
+    _EdgeData or None
+        Edge data with arrays pinned to the MMG-side dtypes, or ``None``
+        when no edges were supplied.
+
+    Raises
+    ------
+    ValueError
+        If ``edges`` is not shape ``(n_edges, 2)`` or if the lengths of
+        ``edges.edges`` and ``edges.refs`` differ.
+
+    """
+    if edges is None:
+        return None
+    edges_arr = np.ascontiguousarray(edges.edges, dtype=np.int32)
     if edges_arr.ndim != _DIMS_2D or edges_arr.shape[1] != _EDGE_VERTS:
         msg = f"edges must have shape (n_edges, 2), got {edges_arr.shape}"
         raise ValueError(msg)
-    if edge_refs is None:
-        return edges_arr, None
-    e_refs = np.ascontiguousarray(edge_refs, dtype=np.int64)
+    if edges.refs is None:
+        return _EdgeData(edges_arr, None)
+    e_refs = np.ascontiguousarray(edges.refs, dtype=np.int64)
     if len(e_refs) != len(edges_arr):
         msg = (
             f"edge_refs length ({len(e_refs)}) must match "
             f"edges length ({len(edges_arr)})"
         )
         raise ValueError(msg)
-    return edges_arr, e_refs
+    return _EdgeData(edges_arr, e_refs)
 
 
 _KIND_CONFIG: dict[
@@ -434,8 +470,7 @@ def _create_impl(
     kind: MeshKind,
     *,
     refs: NDArray[np.int64] | None = None,
-    edges: NDArray[np.int32] | None = None,
-    edge_refs: NDArray[np.int64] | None = None,
+    edges: _EdgeData | None = None,
 ) -> MmgMesh3D | MmgMesh2D | MmgMeshS:
     """Create the appropriate mesh implementation.
 
@@ -449,10 +484,9 @@ def _create_impl(
         Mesh kind to create.
     refs : ndarray, optional
         Reference markers for each cell.
-    edges : ndarray, optional
-        Edge connectivity, shape (n_edges, 2).
-    edge_refs : ndarray, optional
-        Reference markers for each edge.
+    edges : _EdgeData, optional
+        Edge connectivity ``(n_edges, 2)`` paired with optional reference
+        markers.
 
     Returns
     -------
@@ -472,7 +506,7 @@ def _create_impl(
     vertices = np.ascontiguousarray(vertices, dtype=np.float64)
     cells = np.ascontiguousarray(cells, dtype=np.int32)
     cell_refs = _validate_refs(refs, cells)
-    edges_arr, e_refs = _validate_edges(edges, edge_refs)
+    edge_data = _validate_edges(edges)
 
     if kind == MeshKind.TRIANGULAR_2D and vertices.shape[1] == _DIMS_3D:
         vertices = np.ascontiguousarray(vertices[:, :2])
@@ -481,14 +515,14 @@ def _create_impl(
     impl = impl_cls()
 
     size_kwargs: dict[str, int] = {"vertices": len(vertices), cell_kw: len(cells)}
-    if edges_arr is not None:
-        size_kwargs["edges"] = len(edges_arr)
+    if edge_data is not None:
+        size_kwargs["edges"] = len(edge_data.edges)
     impl.set_mesh_size(**size_kwargs)
 
     impl.set_vertices(vertices)
     getattr(impl, setter_name)(cells, cell_refs)
-    if edges_arr is not None:
-        impl.set_edges(edges_arr, e_refs)
+    if edge_data is not None:
+        impl.set_edges(edge_data.edges, edge_data.refs)
     return impl
 
 
@@ -764,8 +798,7 @@ class Mesh:
             cells,
             self._kind,
             refs=cell_refs,
-            edges=edges_arr,
-            edge_refs=e_refs,
+            edges=_build_edge_data(edges_arr, e_refs),
         )
 
     @classmethod
@@ -834,8 +867,7 @@ class Mesh:
             cells_arr,
             kind,
             refs=cell_refs,
-            edges=edges_arr,
-            edge_refs=e_refs,
+            edges=_build_edge_data(edges_arr, e_refs),
         )
         return cls._from_impl(impl, kind)
 
@@ -2722,28 +2754,23 @@ class Mesh:
     def validate(
         self,
         *,
+        checks: Iterable[ValidationCheck] = _ALL_CHECKS,
         detailed: bool = False,
         strict: bool = False,
-        check_geometry: bool = True,
-        check_topology: bool = True,
-        check_quality: bool = True,
         min_quality: float = 0.1,
     ) -> bool | ValidationReport:
         """Validate the mesh and check for issues.
 
         Parameters
         ----------
+        checks : iterable of {"geometry", "topology", "quality"}
+            Which check families to run. Defaults to all three. Pass a
+            subset (e.g. ``{"geometry"}``) to skip the others.
         detailed : bool
             If True, return a ValidationReport with detailed information.
             If False, return a simple boolean.
         strict : bool
             If True, raise ValidationError on any issue (including warnings).
-        check_geometry : bool
-            Check for geometric issues (inverted/degenerate elements).
-        check_topology : bool
-            Check for topological issues (orphan vertices, non-manifold edges).
-        check_quality : bool
-            Check element quality against threshold.
         min_quality : float
             Minimum acceptable element quality (0-1).
 
@@ -2767,6 +2794,8 @@ class Mesh:
         >>> report = mesh.validate(detailed=True)
         >>> print(f"Quality: {report.quality.mean:.3f}")
 
+        >>> mesh.validate(checks={"geometry"})
+
         """
         from mmgpy._validation import (  # noqa: PLC0415
             ValidationError,
@@ -2774,6 +2803,11 @@ class Mesh:
             validate_mesh_3d,
             validate_mesh_surface,
         )
+
+        checks_set = frozenset(checks)
+        check_geometry = "geometry" in checks_set
+        check_topology = "topology" in checks_set
+        check_quality = "quality" in checks_set
 
         # Dispatch to the correct validation function based on mesh kind
         if self._kind == MeshKind.TETRAHEDRAL:

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -2790,6 +2790,9 @@ class Mesh:
         ------
         ValidationError
             If strict=True and any issues are found.
+        ValueError
+            If ``checks`` contains a name outside ``{"geometry", "topology",
+            "quality"}``.
 
         Examples
         --------
@@ -2811,6 +2814,13 @@ class Mesh:
         )
 
         checks_set = frozenset(checks)
+        unknown = checks_set - _ALL_CHECKS
+        if unknown:
+            msg = (
+                f"unknown validation checks: {sorted(unknown)}; "
+                f"expected a subset of {sorted(_ALL_CHECKS)}"
+            )
+            raise ValueError(msg)
         check_geometry = "geometry" in checks_set
         check_topology = "topology" in checks_set
         check_quality = "quality" in checks_set

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -428,10 +428,11 @@ _KIND_CONFIG: dict[
 }
 
 
-def _create_impl(  # noqa: PLR0913
+def _create_impl(
     vertices: NDArray[np.floating],
     cells: NDArray[np.integer],
     kind: MeshKind,
+    *,
     refs: NDArray[np.int64] | None = None,
     edges: NDArray[np.int32] | None = None,
     edge_refs: NDArray[np.int64] | None = None,
@@ -2718,7 +2719,7 @@ class Mesh:
     # Validation
     # =========================================================================
 
-    def validate(  # noqa: PLR0913
+    def validate(
         self,
         *,
         detailed: bool = False,

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -15,6 +15,7 @@ import warnings
 from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
 from enum import Enum
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
@@ -59,10 +60,18 @@ _ALL_CHECKS: frozenset[ValidationCheck] = frozenset(
 )
 
 
-class _RenumWarning:
-    """Holds the one-shot ``FutureWarning`` flag for the ``renum`` kwarg."""
-
-    fired = False
+@cache
+def _emit_renum_future_warning() -> None:
+    """Emit the ``renum`` migration ``FutureWarning`` exactly once per process."""
+    warnings.warn(
+        "renum=1 no longer invokes SCOTCH renumbering (the bundled "
+        "MMG is built without it); mmgpy now applies reverse "
+        "Cuthill-McKee instead. Call "
+        "mmgpy.reorder_cuthill_mckee() directly for explicit "
+        "control over the reordering.",
+        FutureWarning,
+        stacklevel=4,
+    )
 
 
 def _pop_renum_redirect(kwargs: dict[str, Any]) -> bool:
@@ -105,17 +114,8 @@ def _pop_renum_redirect(kwargs: dict[str, Any]) -> bool:
             raise ValueError(msg) from err
     else:
         do_rcm = bool(raw)
-    if do_rcm and not _RenumWarning.fired:
-        _RenumWarning.fired = True
-        warnings.warn(
-            "renum=1 no longer invokes SCOTCH renumbering (the bundled "
-            "MMG is built without it); mmgpy now applies reverse "
-            "Cuthill-McKee instead. Call "
-            "mmgpy.reorder_cuthill_mckee() directly for explicit "
-            "control over the reordering.",
-            FutureWarning,
-            stacklevel=3,
-        )
+    if do_rcm:
+        _emit_renum_future_warning()
     return do_rcm
 
 

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -891,7 +891,7 @@ class MmgAccessor:
     Examples
     --------
     >>> import pyvista as pv
-    >>> import mmgpy  # noqa: F401  -- registers the accessor
+    >>> import mmgpy  # registers the accessor
     >>> mesh = pv.read("brain.mesh")
     >>> remeshed = mesh.mmg.remesh(hsiz=0.1)
     >>> remeshed.n_cells > 0

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -29,13 +29,13 @@ import numpy as np
 import pyvista as pv
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
     from typing import TypeGuard
 
     from numpy.typing import NDArray
 
     from mmgpy._mesh import Mesh as _Mesh
-    from mmgpy._mesh import MeshKind
+    from mmgpy._mesh import MeshKind, ValidationCheck
     from mmgpy._options import Mmg2DOptions, Mmg3DOptions, MmgSOptions
     from mmgpy._sol import Location as _SolLocation
     from mmgpy._validation import ValidationReport
@@ -1469,14 +1469,12 @@ class MmgAccessor:
         )
         write_sol_file(sol_path, fields, dim)
 
-    def validate(  # noqa: PLR0913
+    def validate(
         self,
         *,
+        checks: Iterable[ValidationCheck] | None = None,
         detailed: bool = False,
         strict: bool = False,
-        check_geometry: bool = True,
-        check_topology: bool = True,
-        check_quality: bool = True,
         min_quality: float = 0.1,
     ) -> bool | ValidationReport:
         """Validate the mesh and return either a bool or a detailed report.
@@ -1492,12 +1490,17 @@ class MmgAccessor:
         """
         from mmgpy._io import _read_mesh_internal as _read_mesh  # noqa: PLC0415
 
-        return _read_mesh(self._dataset).validate(
+        mesh = _read_mesh(self._dataset)
+        if checks is None:
+            return mesh.validate(
+                detailed=detailed,
+                strict=strict,
+                min_quality=min_quality,
+            )
+        return mesh.validate(
+            checks=checks,
             detailed=detailed,
             strict=strict,
-            check_geometry=check_geometry,
-            check_topology=check_topology,
-            check_quality=check_quality,
             min_quality=min_quality,
         )
 

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -1475,7 +1475,7 @@ class MmgAccessor:
     def validate(
         self,
         *,
-        checks: Iterable[ValidationCheck] | None = None,
+        checks: Iterable[ValidationCheck] = _ALL_CHECKS,
         detailed: bool = False,
         strict: bool = False,
         min_quality: float = 0.1,
@@ -1494,7 +1494,7 @@ class MmgAccessor:
         from mmgpy._io import _read_mesh_internal as _read_mesh  # noqa: PLC0415
 
         return _read_mesh(self._dataset).validate(
-            checks=_ALL_CHECKS if checks is None else checks,
+            checks=checks,
             detailed=detailed,
             strict=strict,
             min_quality=min_quality,

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -28,6 +28,8 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 import pyvista as pv
 
+from mmgpy._mesh import _ALL_CHECKS
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
     from typing import TypeGuard
@@ -46,6 +48,7 @@ logger = logging.getLogger("mmgpy")
 
 _MEDIT_EXTENSIONS = (".mesh", ".meshb")
 _SOL_EXTENSIONS = (".sol", ".solb")
+_NDIM_2D = 2
 
 
 def _find_companion_sol(mesh_path: Path) -> Path | None:
@@ -681,7 +684,7 @@ def _is_valid_sol_shape(arr: NDArray[Any], dim: int) -> bool:
     """
     if arr.ndim == 1:
         return True
-    if arr.ndim != 2:  # noqa: PLR2004  -- sol arrays are 1D scalar or 2D
+    if arr.ndim != _NDIM_2D:
         return False
     n_cols = arr.shape[1]
     tensor_size = dim * (dim + 1) // 2
@@ -854,7 +857,7 @@ def _coerce_metric_kwarg(
     arr = np.asarray(metric, dtype=np.float64)
     if arr.ndim == 1:
         arr = arr.reshape(-1, 1)
-    if arr.ndim != 2 or arr.shape[0] != n_points:  # noqa: PLR2004
+    if arr.ndim != _NDIM_2D or arr.shape[0] != n_points:
         msg = (
             f"metric must have shape (n_points,), (n_points, 1), "
             f"(n_points, 3) or (n_points, 6); got shape "
@@ -1490,15 +1493,8 @@ class MmgAccessor:
         """
         from mmgpy._io import _read_mesh_internal as _read_mesh  # noqa: PLC0415
 
-        mesh = _read_mesh(self._dataset)
-        if checks is None:
-            return mesh.validate(
-                detailed=detailed,
-                strict=strict,
-                min_quality=min_quality,
-            )
-        return mesh.validate(
-            checks=checks,
+        return _read_mesh(self._dataset).validate(
+            checks=_ALL_CHECKS if checks is None else checks,
             detailed=detailed,
             strict=strict,
             min_quality=min_quality,

--- a/src/mmgpy/_remesh.py
+++ b/src/mmgpy/_remesh.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from mmgpy._generate import generate as _generate_2d
 from mmgpy._mmgpy import mmg2d as _mmg2d_cpp
@@ -25,6 +25,13 @@ if TYPE_CHECKING:
 FieldTransferParam = bool | Sequence[str] | None
 
 NATIVE_MESH_EXTENSIONS = frozenset({".mesh", ".meshb"})
+
+
+class SolPaths(NamedTuple):
+    """Pair of input/output ``.sol`` paths consumed by the file-based remesh API."""
+
+    input: str | Path | None = None
+    output: str | Path | None = None
 
 
 def _is_native(path: str | Path | None) -> bool:
@@ -86,59 +93,82 @@ def _renum_is_truthy(raw: object) -> bool:
     return bool(raw)
 
 
-def _wrapped_remesh(
+def _make_wrapped_remesh(
     cpp_remesh: Callable[..., bool],
-    input_mesh: str | Path,
-    *,
-    input_sol: str | Path | None = None,
-    output_mesh: str | Path | None = None,
-    output_sol: str | Path | None = None,
-    options: dict[str, Any] | None = None,
-    transfer_fields: FieldTransferParam = False,
-) -> bool:
-    forwarded = dict(options or {})
-    do_rcm = _renum_is_truthy(forwarded.get("renum"))
+) -> Callable[..., bool]:
+    """Build a wrapper bound to a specific C++ remesh entry point.
 
-    input_native = _is_native(input_mesh)
-    output_native = _is_native(output_mesh)
+    Captures ``cpp_remesh`` in the closure so the returned callable stays
+    within the ``PLR0913`` arg-count budget while still sharing one
+    implementation across the three ``mmg{2d,3d,s}.remesh`` entry points.
 
-    # Native fast path is only safe when no RCM is requested. With RCM the
-    # reordering must run on the in-memory Mesh so the saved .sol stays
-    # consistent with the saved mesh and no MMG-specific data is lost via
-    # a pv.read round-trip.
-    if not do_rcm and input_native and output_native:
-        forwarded.pop("renum", None)  # cpp bindings do not accept renum
-        return cpp_remesh(
-            input_mesh=input_mesh,
-            input_sol=input_sol,
-            output_mesh=output_mesh,
-            output_sol=output_sol,
-            options=forwarded,
+    Returns
+    -------
+    Callable[..., bool]
+        Wrapper accepting ``(input_mesh, output_mesh=None, *, sol, options,
+        transfer_fields)`` and returning the C++ success flag.
+
+    """
+
+    def _wrapped(
+        input_mesh: str | Path,
+        output_mesh: str | Path | None = None,
+        *,
+        sol: SolPaths | None = None,
+        options: dict[str, Any] | None = None,
+        transfer_fields: FieldTransferParam = False,
+    ) -> bool:
+        sol = sol or SolPaths()
+        forwarded = dict(options or {})
+        do_rcm = _renum_is_truthy(forwarded.get("renum"))
+
+        input_native = _is_native(input_mesh)
+        output_native = _is_native(output_mesh)
+
+        # Native fast path is only safe when no RCM is requested. With RCM the
+        # reordering must run on the in-memory Mesh so the saved .sol stays
+        # consistent with the saved mesh and no MMG-specific data is lost via
+        # a pv.read round-trip.
+        if not do_rcm and input_native and output_native:
+            forwarded.pop("renum", None)  # cpp bindings do not accept renum
+            return cpp_remesh(
+                input_mesh=input_mesh,
+                input_sol=sol.input,
+                output_mesh=output_mesh,
+                output_sol=sol.output,
+                options=forwarded,
+            )
+
+        from mmgpy._io import _read_mesh_internal as _read  # noqa: PLC0415
+
+        mesh = _read(input_mesh)
+
+        if sol.input is not None:
+            channel = "levelset" if _is_iso_mode(options) else "metric"
+            _load_sol(mesh, sol.input, channel=channel)
+
+        # Leave ``renum`` in forwarded so Mesh.remesh pops it (and emits the
+        # one-time FutureWarning) and applies RCM in place.
+        result = mesh.remesh(
+            progress=False,
+            transfer_fields=transfer_fields,
+            **forwarded,
         )
 
-    from mmgpy._io import _read_mesh_internal as _read  # noqa: PLC0415
+        if output_mesh is not None:
+            mesh.save(output_mesh)
 
-    mesh = _read(input_mesh)
+        if sol.output is not None:
+            _save_sol(mesh, sol.output)
 
-    if input_sol is not None:
-        channel = "levelset" if _is_iso_mode(options) else "metric"
-        _load_sol(mesh, input_sol, channel=channel)
+        return result.success
 
-    # Leave ``renum`` in forwarded so Mesh.remesh pops it (and emits the
-    # one-time FutureWarning) and applies RCM in place.
-    result = mesh.remesh(
-        progress=False,
-        transfer_fields=transfer_fields,
-        **forwarded,
-    )
+    return _wrapped
 
-    if output_mesh is not None:
-        mesh.save(output_mesh)
 
-    if output_sol is not None:
-        _save_sol(mesh, output_sol)
-
-    return result.success
+_wrapped_3d = _make_wrapped_remesh(_mmg3d_cpp.remesh)
+_wrapped_2d = _make_wrapped_remesh(_mmg2d_cpp.remesh)
+_wrapped_s = _make_wrapped_remesh(_mmgs_cpp.remesh)
 
 
 class mmg3d:
@@ -147,10 +177,9 @@ class mmg3d:
     @staticmethod
     def remesh(
         input_mesh: str | Path,
-        *,
-        input_sol: str | Path | None = None,
         output_mesh: str | Path | None = None,
-        output_sol: str | Path | None = None,
+        *,
+        sol: SolPaths | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
     ) -> bool:
@@ -160,12 +189,10 @@ class mmg3d:
         ----------
         input_mesh : str or Path
             Input mesh file. Any format supported by PyVista.
-        input_sol : str or Path, optional
-            Input solution file (.sol/.solb).
         output_mesh : str or Path, optional
             Output mesh file. Any format supported by PyVista.
-        output_sol : str or Path, optional
-            Output solution file (.sol/.solb).
+        sol : SolPaths, optional
+            ``(input, output)`` solution file paths (.sol/.solb).
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -178,12 +205,10 @@ class mmg3d:
             True if remeshing succeeded.
 
         """
-        return _wrapped_remesh(
-            _mmg3d_cpp.remesh,
+        return _wrapped_3d(
             input_mesh,
-            input_sol=input_sol,
-            output_mesh=output_mesh,
-            output_sol=output_sol,
+            output_mesh,
+            sol=sol,
             options=options,
             transfer_fields=transfer_fields,
         )
@@ -197,10 +222,9 @@ class mmg2d:
     @staticmethod
     def remesh(
         input_mesh: str | Path,
-        *,
-        input_sol: str | Path | None = None,
         output_mesh: str | Path | None = None,
-        output_sol: str | Path | None = None,
+        *,
+        sol: SolPaths | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
     ) -> bool:
@@ -210,12 +234,10 @@ class mmg2d:
         ----------
         input_mesh : str or Path
             Input mesh file. Any format supported by PyVista.
-        input_sol : str or Path, optional
-            Input solution file (.sol/.solb).
         output_mesh : str or Path, optional
             Output mesh file. Any format supported by PyVista.
-        output_sol : str or Path, optional
-            Output solution file (.sol/.solb).
+        sol : SolPaths, optional
+            ``(input, output)`` solution file paths (.sol/.solb).
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -228,12 +250,10 @@ class mmg2d:
             True if remeshing succeeded.
 
         """
-        return _wrapped_remesh(
-            _mmg2d_cpp.remesh,
+        return _wrapped_2d(
             input_mesh,
-            input_sol=input_sol,
-            output_mesh=output_mesh,
-            output_sol=output_sol,
+            output_mesh,
+            sol=sol,
             options=options,
             transfer_fields=transfer_fields,
         )
@@ -245,10 +265,9 @@ class mmgs:
     @staticmethod
     def remesh(
         input_mesh: str | Path,
-        *,
-        input_sol: str | Path | None = None,
         output_mesh: str | Path | None = None,
-        output_sol: str | Path | None = None,
+        *,
+        sol: SolPaths | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
     ) -> bool:
@@ -258,12 +277,10 @@ class mmgs:
         ----------
         input_mesh : str or Path
             Input mesh file. Any format supported by PyVista.
-        input_sol : str or Path, optional
-            Input solution file (.sol/.solb).
         output_mesh : str or Path, optional
             Output mesh file. Any format supported by PyVista.
-        output_sol : str or Path, optional
-            Output solution file (.sol/.solb).
+        sol : SolPaths, optional
+            ``(input, output)`` solution file paths (.sol/.solb).
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -276,12 +293,10 @@ class mmgs:
             True if remeshing succeeded.
 
         """
-        return _wrapped_remesh(
-            _mmgs_cpp.remesh,
+        return _wrapped_s(
             input_mesh,
-            input_sol=input_sol,
-            output_mesh=output_mesh,
-            output_sol=output_sol,
+            output_mesh,
+            sol=sol,
             options=options,
             transfer_fields=transfer_fields,
         )

--- a/src/mmgpy/_remesh.py
+++ b/src/mmgpy/_remesh.py
@@ -89,6 +89,7 @@ def _renum_is_truthy(raw: object) -> bool:
 def _wrapped_remesh(
     cpp_remesh: Callable[..., bool],
     input_mesh: str | Path,
+    *,
     input_sol: str | Path | None = None,
     output_mesh: str | Path | None = None,
     output_sol: str | Path | None = None,
@@ -146,6 +147,7 @@ class mmg3d:
     @staticmethod
     def remesh(
         input_mesh: str | Path,
+        *,
         input_sol: str | Path | None = None,
         output_mesh: str | Path | None = None,
         output_sol: str | Path | None = None,
@@ -179,10 +181,10 @@ class mmg3d:
         return _wrapped_remesh(
             _mmg3d_cpp.remesh,
             input_mesh,
-            input_sol,
-            output_mesh,
-            output_sol,
-            options,
+            input_sol=input_sol,
+            output_mesh=output_mesh,
+            output_sol=output_sol,
+            options=options,
             transfer_fields=transfer_fields,
         )
 
@@ -195,6 +197,7 @@ class mmg2d:
     @staticmethod
     def remesh(
         input_mesh: str | Path,
+        *,
         input_sol: str | Path | None = None,
         output_mesh: str | Path | None = None,
         output_sol: str | Path | None = None,
@@ -228,10 +231,10 @@ class mmg2d:
         return _wrapped_remesh(
             _mmg2d_cpp.remesh,
             input_mesh,
-            input_sol,
-            output_mesh,
-            output_sol,
-            options,
+            input_sol=input_sol,
+            output_mesh=output_mesh,
+            output_sol=output_sol,
+            options=options,
             transfer_fields=transfer_fields,
         )
 
@@ -242,6 +245,7 @@ class mmgs:
     @staticmethod
     def remesh(
         input_mesh: str | Path,
+        *,
         input_sol: str | Path | None = None,
         output_mesh: str | Path | None = None,
         output_sol: str | Path | None = None,
@@ -275,9 +279,9 @@ class mmgs:
         return _wrapped_remesh(
             _mmgs_cpp.remesh,
             input_mesh,
-            input_sol,
-            output_mesh,
-            output_sol,
-            options,
+            input_sol=input_sol,
+            output_mesh=output_mesh,
+            output_sol=output_sol,
+            options=options,
             transfer_fields=transfer_fields,
         )

--- a/src/mmgpy/_remesh.py
+++ b/src/mmgpy/_remesh.py
@@ -30,8 +30,8 @@ NATIVE_MESH_EXTENSIONS = frozenset({".mesh", ".meshb"})
 class SolPaths(NamedTuple):
     """Pair of input/output ``.sol`` paths consumed by the file-based remesh API."""
 
-    input: str | Path | None = None
-    output: str | Path | None = None
+    in_path: str | Path | None = None
+    out_path: str | Path | None = None
 
 
 def _is_native(path: str | Path | None) -> bool:
@@ -133,9 +133,9 @@ def _make_wrapped_remesh(
             forwarded.pop("renum", None)  # cpp bindings do not accept renum
             return cpp_remesh(
                 input_mesh=input_mesh,
-                input_sol=sol.input,
+                input_sol=sol.in_path,
                 output_mesh=output_mesh,
-                output_sol=sol.output,
+                output_sol=sol.out_path,
                 options=forwarded,
             )
 
@@ -143,9 +143,9 @@ def _make_wrapped_remesh(
 
         mesh = _read(input_mesh)
 
-        if sol.input is not None:
+        if sol.in_path is not None:
             channel = "levelset" if _is_iso_mode(options) else "metric"
-            _load_sol(mesh, sol.input, channel=channel)
+            _load_sol(mesh, sol.in_path, channel=channel)
 
         # Leave ``renum`` in forwarded so Mesh.remesh pops it (and emits the
         # one-time FutureWarning) and applies RCM in place.
@@ -158,8 +158,8 @@ def _make_wrapped_remesh(
         if output_mesh is not None:
             mesh.save(output_mesh)
 
-        if sol.output is not None:
-            _save_sol(mesh, sol.output)
+        if sol.out_path is not None:
+            _save_sol(mesh, sol.out_path)
 
         return result.success
 
@@ -192,7 +192,7 @@ class mmg3d:
         output_mesh : str or Path, optional
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
-            ``(input, output)`` solution file paths (.sol/.solb).
+            ``(in_path, out_path)`` solution file paths (.sol/.solb).
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -237,7 +237,7 @@ class mmg2d:
         output_mesh : str or Path, optional
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
-            ``(input, output)`` solution file paths (.sol/.solb).
+            ``(in_path, out_path)`` solution file paths (.sol/.solb).
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -280,7 +280,7 @@ class mmgs:
         output_mesh : str or Path, optional
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
-            ``(input, output)`` solution file paths (.sol/.solb).
+            ``(in_path, out_path)`` solution file paths (.sol/.solb).
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False

--- a/tests/internal/mesh_unified_test.py
+++ b/tests/internal/mesh_unified_test.py
@@ -740,7 +740,7 @@ class TestNonNativeRemeshWithSol:
             result = mmg2d.remesh(
                 vtu_input,
                 vtu_output,
-                sol=SolPaths(input=input_sol),
+                sol=SolPaths(in_path=input_sol),
                 options={"verbose": -1},
             )
 
@@ -765,7 +765,7 @@ class TestNonNativeRemeshWithSol:
             mmg3d.remesh(
                 vtu_input,
                 vtu_output,
-                sol=SolPaths(output=output_sol),
+                sol=SolPaths(out_path=output_sol),
                 options={"verbose": -1},
             )
 
@@ -927,7 +927,7 @@ class TestLazyFieldLoading:
             mmg3d.remesh(
                 vtk_path,
                 out_path,
-                sol=SolPaths(output=sol_path),
+                sol=SolPaths(out_path=sol_path),
                 options={"verbose": -1},
             )
 

--- a/tests/internal/mesh_unified_test.py
+++ b/tests/internal/mesh_unified_test.py
@@ -725,7 +725,7 @@ class TestNonNativeRemeshWithSol:
 
     def test_remesh_vtk_with_input_sol(self) -> None:
         """Test remeshing a VTU file with an input .sol file."""
-        from mmgpy import mmg2d
+        from mmgpy import SolPaths, mmg2d
 
         input_mesh = _ASSETS / "hole.mesh"
         input_sol = _ASSETS / "hole.sol"
@@ -738,9 +738,9 @@ class TestNonNativeRemeshWithSol:
 
             vtu_output = Path(tmpdir) / "output.vtu"
             result = mmg2d.remesh(
-                input_mesh=vtu_input,
-                input_sol=input_sol,
-                output_mesh=vtu_output,
+                vtu_input,
+                vtu_output,
+                sol=SolPaths(input=input_sol),
                 options={"verbose": -1},
             )
 
@@ -750,7 +750,7 @@ class TestNonNativeRemeshWithSol:
 
     def test_remesh_vtk_with_output_sol(self) -> None:
         """Test remeshing a VTU file with output .sol saving."""
-        from mmgpy import mmg3d
+        from mmgpy import SolPaths, mmg3d
 
         input_mesh = _ASSETS / "cube.mesh"
 
@@ -763,9 +763,9 @@ class TestNonNativeRemeshWithSol:
             output_sol = Path(tmpdir) / "cube.sol"
 
             mmg3d.remesh(
-                input_mesh=vtu_input,
-                output_mesh=vtu_output,
-                output_sol=output_sol,
+                vtu_input,
+                vtu_output,
+                sol=SolPaths(output=output_sol),
                 options={"verbose": -1},
             )
 
@@ -917,7 +917,7 @@ class TestLazyFieldLoading:
 
     def test_non_native_remesh_with_output_sol(self) -> None:
         """Non-native path writes output .sol via C++ save_sol."""
-        from mmgpy import mmg3d
+        from mmgpy import SolPaths, mmg3d
 
         with TemporaryDirectory() as tmpdir:
             vtk_path = self._make_vtk_with_field(Path(tmpdir))
@@ -925,9 +925,9 @@ class TestLazyFieldLoading:
             sol_path = Path(tmpdir) / "cube.sol"
 
             mmg3d.remesh(
-                input_mesh=vtk_path,
-                output_mesh=out_path,
-                output_sol=sol_path,
+                vtk_path,
+                out_path,
+                sol=SolPaths(output=sol_path),
                 options={"verbose": -1},
             )
 

--- a/tests/internal/remesh_wrapper_test.py
+++ b/tests/internal/remesh_wrapper_test.py
@@ -193,7 +193,7 @@ class TestWrappedRemeshIsoRouting:
             ok = mmg2d.remesh(
                 _ASSETS / "multi-mat.mesh",
                 out,
-                sol=SolPaths(input=_ASSETS / "multi-mat-ls.sol"),
+                sol=SolPaths(in_path=_ASSETS / "multi-mat-ls.sol"),
                 options={"iso": 1, "ls": 0.0, "verbose": -1},
             )
             assert ok
@@ -212,7 +212,7 @@ class TestWrappedRemeshIsoRouting:
             ok = mmgs.remesh(
                 _ASSETS / "teapot.mesh",
                 out,
-                sol=SolPaths(input=_ASSETS / "teapot-ls.sol"),
+                sol=SolPaths(in_path=_ASSETS / "teapot-ls.sol"),
                 options={"iso": 1, "ls": 0.0, "verbose": -1},
             )
             assert ok
@@ -226,7 +226,7 @@ class TestWrappedRemeshIsoRouting:
             ok = mmg3d.remesh(
                 _ASSETS / "cube.mesh",
                 out,
-                sol=SolPaths(input=_ASSETS / "cube-ls.sol"),
+                sol=SolPaths(in_path=_ASSETS / "cube-ls.sol"),
                 options={"iso": 1, "ls": 0.0, "verbose": -1},
             )
             assert ok
@@ -270,7 +270,7 @@ class TestWrappedRemeshIsoRouting:
             ok = mmg3d.remesh(
                 _ASSETS / "cube.mesh",
                 out_mesh,
-                sol=SolPaths(output=out_sol),
+                sol=SolPaths(out_path=out_sol),
                 options={"hmax": 0.5, "verbose": -1},
             )
             assert ok
@@ -287,8 +287,28 @@ class TestWrappedRemeshIsoRouting:
             out_sol = Path(tmpdir) / "out.sol"
             ok = mmg3d.remesh(
                 input_vtk,
-                sol=SolPaths(output=out_sol),
+                sol=SolPaths(out_path=out_sol),
                 options={"hmax": 0.5, "verbose": -1},
             )
             assert ok
             assert out_sol.exists()
+
+    def test_empty_sol_paths_is_equivalent_to_none(self) -> None:
+        """``sol=SolPaths()`` (both fields ``None``) matches ``sol=None``."""
+        with TemporaryDirectory() as tmpdir:
+            out_a = Path(tmpdir) / "a.mesh"
+            out_b = Path(tmpdir) / "b.mesh"
+            ok_a = mmg3d.remesh(
+                _ASSETS / "cube.mesh",
+                out_a,
+                sol=SolPaths(),
+                options={"hmax": 0.5, "verbose": -1},
+            )
+            ok_b = mmg3d.remesh(
+                _ASSETS / "cube.mesh",
+                out_b,
+                options={"hmax": 0.5, "verbose": -1},
+            )
+            assert ok_a is ok_b is True
+            assert out_a.exists()
+            assert out_b.exists()

--- a/tests/internal/remesh_wrapper_test.py
+++ b/tests/internal/remesh_wrapper_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 import pyvista as pv
 
-from mmgpy import mmg2d, mmg3d, mmgs
+from mmgpy import SolPaths, mmg2d, mmg3d, mmgs
 from mmgpy._io import _read_mesh_internal as read
 from mmgpy._remesh import _is_iso_mode, _is_native, _load_sol, _save_sol
 
@@ -191,9 +191,9 @@ class TestWrappedRemeshIsoRouting:
         with TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / "out.vtk"
             ok = mmg2d.remesh(
-                input_mesh=_ASSETS / "multi-mat.mesh",
-                input_sol=_ASSETS / "multi-mat-ls.sol",
-                output_mesh=out,
+                _ASSETS / "multi-mat.mesh",
+                out,
+                sol=SolPaths(input=_ASSETS / "multi-mat-ls.sol"),
                 options={"iso": 1, "ls": 0.0, "verbose": -1},
             )
             assert ok
@@ -210,9 +210,9 @@ class TestWrappedRemeshIsoRouting:
         with TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / "out.vtk"
             ok = mmgs.remesh(
-                input_mesh=_ASSETS / "teapot.mesh",
-                input_sol=_ASSETS / "teapot-ls.sol",
-                output_mesh=out,
+                _ASSETS / "teapot.mesh",
+                out,
+                sol=SolPaths(input=_ASSETS / "teapot-ls.sol"),
                 options={"iso": 1, "ls": 0.0, "verbose": -1},
             )
             assert ok
@@ -224,9 +224,9 @@ class TestWrappedRemeshIsoRouting:
         with TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / "out.vtk"
             ok = mmg3d.remesh(
-                input_mesh=_ASSETS / "cube.mesh",
-                input_sol=_ASSETS / "cube-ls.sol",
-                output_mesh=out,
+                _ASSETS / "cube.mesh",
+                out,
+                sol=SolPaths(input=_ASSETS / "cube-ls.sol"),
                 options={"iso": 1, "ls": 0.0, "verbose": -1},
             )
             assert ok
@@ -268,9 +268,9 @@ class TestWrappedRemeshIsoRouting:
             out_mesh = Path(tmpdir) / "out.vtk"
             out_sol = Path(tmpdir) / "out.sol"
             ok = mmg3d.remesh(
-                input_mesh=_ASSETS / "cube.mesh",
-                output_mesh=out_mesh,
-                output_sol=out_sol,
+                _ASSETS / "cube.mesh",
+                out_mesh,
+                sol=SolPaths(output=out_sol),
                 options={"hmax": 0.5, "verbose": -1},
             )
             assert ok
@@ -286,8 +286,8 @@ class TestWrappedRemeshIsoRouting:
 
             out_sol = Path(tmpdir) / "out.sol"
             ok = mmg3d.remesh(
-                input_mesh=input_vtk,
-                output_sol=out_sol,
+                input_vtk,
+                sol=SolPaths(output=out_sol),
                 options={"hmax": 0.5, "verbose": -1},
             )
             assert ok

--- a/tests/internal/validation_test.py
+++ b/tests/internal/validation_test.py
@@ -214,6 +214,14 @@ class TestMmgMesh3DValidation:
         report = mesh.validate(detailed=True, checks={"geometry", "topology"})
         assert report.quality is None
 
+    def test_unknown_check_name_raises(self) -> None:
+        """A typo in ``checks`` is rejected up front, not silently dropped."""
+        vertices, tetrahedra = create_test_mesh_3d()
+        mesh = Mesh(vertices, tetrahedra)
+
+        with pytest.raises(ValueError, match="unknown validation checks"):
+            mesh.validate(checks={"geomerty"})  # type: ignore[arg-type]  # codespell:ignore geomerty
+
 
 # =============================================================================
 # Basic validation tests for MmgMesh2D

--- a/tests/internal/validation_test.py
+++ b/tests/internal/validation_test.py
@@ -197,7 +197,7 @@ class TestMmgMesh3DValidation:
         vertices, tetrahedra = create_test_mesh_3d()
         mesh = Mesh(vertices, tetrahedra)
 
-        report = mesh.validate(detailed=True, check_geometry=False)
+        report = mesh.validate(detailed=True, checks={"topology", "quality"})
         assert report.is_valid is True
         # No geometry-related issues should be reported
         geometry_check_names = ("inverted_elements", "degenerate_elements")
@@ -211,7 +211,7 @@ class TestMmgMesh3DValidation:
         vertices, tetrahedra = create_test_mesh_3d()
         mesh = Mesh(vertices, tetrahedra)
 
-        report = mesh.validate(detailed=True, check_quality=False)
+        report = mesh.validate(detailed=True, checks={"geometry", "topology"})
         assert report.quality is None
 
 

--- a/tests/multimat_test.py
+++ b/tests/multimat_test.py
@@ -222,28 +222,28 @@ class TestMeshMultiMaterials:
         with pytest.raises(ValueError, match="missing keys"):
             mesh.set_multi_materials([{"ref": 1, "split": True}])
 
-    def test_non_mapping_raises_value_error(
+    def test_non_mapping_raises_type_error(
         self,
         dense_3d_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
         """Non-mapping entries fail at the Python boundary."""
         vertices, elements = dense_3d_mesh
         mesh = Mesh(vertices, elements)
-        with pytest.raises(ValueError, match="must be a mapping"):
+        with pytest.raises(TypeError, match="must be a mapping"):
             mesh.set_multi_materials([(1, True, 10, 20)])  # type: ignore[list-item]
 
-    def test_invalid_split_type_raises_value_error(
+    def test_invalid_split_type_raises_type_error(
         self,
         dense_3d_mesh: tuple[np.ndarray, np.ndarray],
     ) -> None:
         """Non-bool/int ``split`` values are rejected upfront."""
         vertices, elements = dense_3d_mesh
         mesh = Mesh(vertices, elements)
-        with pytest.raises(ValueError, match="must be bool or int"):
+        with pytest.raises(TypeError, match="must be bool or int"):
             mesh.set_multi_materials(
                 [{"ref": 1, "split": "yes", "ref_minus": 10, "ref_plus": 20}],
             )
-        with pytest.raises(ValueError, match="must be bool or int"):
+        with pytest.raises(TypeError, match="must be bool or int"):
             mesh.set_multi_materials(
                 [{"ref": 1, "split": 1.5, "ref_minus": 10, "ref_plus": 20}],
             )

--- a/tests/pv_plugin_test.py
+++ b/tests/pv_plugin_test.py
@@ -381,6 +381,24 @@ def test_accessor_validate_detailed_returns_report() -> None:
     assert hasattr(report, "is_valid")
 
 
+def test_accessor_validate_checks_subset_skips_quality() -> None:
+    """validate(checks={...}) forwards the subset to Mesh.validate."""
+    surf = _make_surface_mesh()
+    report = surf.mmg.validate(detailed=True, checks={"geometry", "topology"})
+
+    assert isinstance(report, mmgpy.ValidationReport)
+    assert report.quality is None
+
+
+def test_accessor_validate_default_runs_all_checks() -> None:
+    """validate() without ``checks`` runs the full default check set."""
+    surf = _make_surface_mesh()
+    report = surf.mmg.validate(detailed=True)
+
+    assert isinstance(report, mmgpy.ValidationReport)
+    assert report.quality is not None
+
+
 def test_accessor_element_quality_and_qualities_agree() -> None:
     """Single-element quality is one of the values in the qualities array."""
     tets = _make_tet_mesh()

--- a/tests/reorder_test.py
+++ b/tests/reorder_test.py
@@ -143,7 +143,7 @@ def test_renum_kwarg_routes_to_rcm_with_future_warning() -> None:
     """``renum=1`` emits a one-time FutureWarning and actually reorders."""
     import mmgpy._mesh as _mesh_mod
 
-    _mesh_mod._RENUM_FUTURE_WARNED = False
+    _mesh_mod._RenumWarning.fired = False
 
     ug = _make_3d_grid(n=4)
     with warnings.catch_warnings(record=True) as caught:
@@ -172,7 +172,7 @@ def test_renum_warning_is_emitted_only_once() -> None:
     """The FutureWarning is gated by a process-wide flag."""
     import mmgpy._mesh as _mesh_mod
 
-    _mesh_mod._RENUM_FUTURE_WARNED = False
+    _mesh_mod._RenumWarning.fired = False
 
     ug = _make_3d_grid(n=4)
     with warnings.catch_warnings(record=True) as caught:
@@ -191,7 +191,7 @@ def test_renum_zero_is_a_noop() -> None:
     """``renum=0`` does not warn and produces no reordering."""
     import mmgpy._mesh as _mesh_mod
 
-    _mesh_mod._RENUM_FUTURE_WARNED = False
+    _mesh_mod._RenumWarning.fired = False
 
     ug = _make_3d_grid(n=4)
     with warnings.catch_warnings(record=True) as caught:

--- a/tests/reorder_test.py
+++ b/tests/reorder_test.py
@@ -143,7 +143,7 @@ def test_renum_kwarg_routes_to_rcm_with_future_warning() -> None:
     """``renum=1`` emits a one-time FutureWarning and actually reorders."""
     import mmgpy._mesh as _mesh_mod
 
-    _mesh_mod._RenumWarning.fired = False
+    _mesh_mod._emit_renum_future_warning.cache_clear()
 
     ug = _make_3d_grid(n=4)
     with warnings.catch_warnings(record=True) as caught:
@@ -172,7 +172,7 @@ def test_renum_warning_is_emitted_only_once() -> None:
     """The FutureWarning is gated by a process-wide flag."""
     import mmgpy._mesh as _mesh_mod
 
-    _mesh_mod._RenumWarning.fired = False
+    _mesh_mod._emit_renum_future_warning.cache_clear()
 
     ug = _make_3d_grid(n=4)
     with warnings.catch_warnings(record=True) as caught:
@@ -191,7 +191,7 @@ def test_renum_zero_is_a_noop() -> None:
     """``renum=0`` does not warn and produces no reordering."""
     import mmgpy._mesh as _mesh_mod
 
-    _mesh_mod._RenumWarning.fired = False
+    _mesh_mod._emit_renum_future_warning.cache_clear()
 
     ug = _make_3d_grid(n=4)
     with warnings.catch_warnings(record=True) as caught:


### PR DESCRIPTION
## Summary

Refactor ``_remesh.py``, ``_mesh.py`` (and the dependent ``_pv_plugin.py`` wrapper) so no function in either file trips ``PLR0913``. All file-level ``PLR0913`` ignores and inline ``# noqa: PLR0913`` markers are gone.

## Changes

### ``_remesh.py``
- New ``SolPaths`` ``NamedTuple`` (``in_path``, ``out_path``) bundling the optional sol-file pair.
- ``_wrapped_remesh`` -> ``_make_wrapped_remesh(cpp_remesh)`` closure factory; the ``cpp_remesh`` dispatch arg is captured rather than passed at every call, dropping 7 args -> 5.
- ``mmg{2d,3d,s}.remesh`` signature: ``(input_mesh, output_mesh=None, *, sol=None, options=None, transfer_fields=False)``. 6 args -> 5.
- ``SolPaths`` re-exported from ``mmgpy``.

### ``_mesh.py``
- New private ``_EdgeData`` ``NamedTuple`` bundling ``edges`` + ``edge_refs``. Helper ``_build_edge_data`` preserves the ``"edge_refs provided without edges"`` validation.
- ``_create_impl`` signature: ``(vertices, cells, kind, *, refs=None, edges=None)``. 6 args -> 5.
- ``Mesh.validate`` signature: ``(*, checks=_ALL_CHECKS, detailed=False, strict=False, min_quality=0.1)`` where ``checks`` is an iterable of ``"geometry"|"topology"|"quality"``. 6 args -> 4. Unknown names in ``checks`` raise ``ValueError`` instead of being silently dropped.
- ``ValidationCheck`` literal exposed for typing.
- The one-shot ``renum`` ``FutureWarning`` now lives behind ``@functools.cache`` (``_emit_renum_future_warning``) instead of a module-level flag, dropping the ``PLW0603`` ignore without resurrecting a hand-rolled class-as-namespace.

### ``_pv_plugin.py``
- ``MmgAccessor.validate`` mirrors the new ``Mesh.validate`` shape.

### ``pyproject.toml``
- Drop the ``PLR0913`` file-level ignore from ``_remesh.py`` and ``_mesh.py``; only ``N801`` / ``PLR0904`` remain.

### Tests / examples
- Updated 4 internal tests and 2 examples for the new ``sol=SolPaths(...)`` and ``checks=...`` shapes.
- New ``test_empty_sol_paths_is_equivalent_to_none`` covering ``sol=SolPaths()`` with both fields ``None``.
- New ``test_unknown_check_name_raises`` covering the ``checks={"geomerty"}`` typo case.

## Notes

Public API breaks:
- ``mmg{2d,3d,s}.remesh(..., input_sol=..., output_sol=...)`` -> ``...remesh(..., sol=SolPaths(in_path=..., out_path=...))``.
- ``Mesh.validate(check_geometry=False, ...)`` -> ``Mesh.validate(checks={"topology", "quality"}, ...)``.
- ``set_multi_materials`` / ``set_local_parameters``: type-mismatch errors (non-mapping entry, non-bool/int ``split``) now raise ``TypeError`` instead of ``ValueError``. Value-range errors (missing keys, ``split`` not in ``{0, 1}``) still raise ``ValueError``.

``output_mesh`` remains the second positional; the kwarg-only fence kicks in just after.