### PR TITLE
lint: drop 15 noqa markers across 5 src/mmgpy modules

### DIFF
--- a/src/mmgpy/_logging.py
+++ b/src/mmgpy/_logging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
+from dataclasses import dataclass
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,11 +17,14 @@ if TYPE_CHECKING:
 
     LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
-# Module-level state for file handler
-_file_handler: RotatingFileHandler | None = None
 
-# Track whether console handler is enabled
-_console_enabled: bool = True
+@dataclass
+class _LoggingState:
+    file_handler: RotatingFileHandler | None = None
+    console_enabled: bool = True
+
+
+_state = _LoggingState()
 
 
 @functools.lru_cache(maxsize=1)
@@ -65,7 +69,7 @@ def get_logger() -> logging.Logger:
 
 def _configure_logger(logger: logging.Logger) -> None:
     """Configure the logger with RichHandler."""
-    if _console_enabled:
+    if _state.console_enabled:
         handler = RichHandler(
             rich_tracebacks=True,
             show_path=False,
@@ -122,11 +126,10 @@ def configure_logging(*, enable_console: bool = True) -> None:
     >>> # mmgpy logs will go to the "mmgpy" logger namespace
 
     """
-    global _console_enabled  # noqa: PLW0603
     logger = logging.getLogger("mmgpy")
 
     if not enable_console:
-        _console_enabled = False
+        _state.console_enabled = False
         # Remove existing Rich handlers if logger already initialized
         for handler in logger.handlers[:]:
             if isinstance(handler, RichHandler):
@@ -185,14 +188,13 @@ def set_log_file(
     >>> mmgpy.set_log_file(None)
 
     """
-    global _file_handler  # noqa: PLW0603
     logger = get_logger()
 
     # Remove existing file handler
-    if _file_handler is not None:
-        logger.removeHandler(_file_handler)
-        _file_handler.close()
-        _file_handler = None
+    if _state.file_handler is not None:
+        logger.removeHandler(_state.file_handler)
+        _state.file_handler.close()
+        _state.file_handler = None
 
     if path is None:
         return
@@ -202,7 +204,7 @@ def set_log_file(
     path.parent.mkdir(parents=True, exist_ok=True)
 
     # Create new file handler with rotation
-    _file_handler = RotatingFileHandler(
+    file_handler = RotatingFileHandler(
         path,
         maxBytes=max_bytes,
         backupCount=backup_count,
@@ -212,18 +214,19 @@ def set_log_file(
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
-    _file_handler.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
 
     # Set level for file handler
     # Use NOTSET (0) by default so handler defers to logger's level
     if level is not None:
         if isinstance(level, str):
             level = getattr(logging, level.upper())
-        _file_handler.setLevel(level)
+        file_handler.setLevel(level)
     else:
-        _file_handler.setLevel(logging.NOTSET)
+        file_handler.setLevel(logging.NOTSET)
 
-    logger.addHandler(_file_handler)
+    logger.addHandler(file_handler)
+    _state.file_handler = file_handler
 
 
 def get_log_file() -> Path | None:
@@ -245,9 +248,9 @@ def get_log_file() -> Path | None:
     None
 
     """
-    if _file_handler is None:
+    if _state.file_handler is None:
         return None
-    return Path(_file_handler.baseFilename)
+    return Path(_state.file_handler.baseFilename)
 
 
 def set_log_level(level: LogLevel | int) -> None:

--- a/src/mmgpy/_reorder.py
+++ b/src/mmgpy/_reorder.py
@@ -14,13 +14,15 @@ import numpy as np
 import pyvista as pv
 from scipy.sparse import csgraph, csr_matrix
 
-from mmgpy._topology import vertex_adjacency
+from mmgpy._topology import MIN_VERTICES_FOR_EDGE, vertex_adjacency
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from mmgpy._mesh import Mesh
     from mmgpy._mmgpy import MmgMesh3D
+
+_CONNECTIVITY_NDIM = 2
 
 
 def _split_legacy_cells(
@@ -41,7 +43,7 @@ def _split_legacy_cells(
     i = 0
     while i < arr.size:
         n = int(arr[i])
-        if n >= 2:  # noqa: PLR2004
+        if n >= MIN_VERTICES_FOR_EDGE:
             row = arr[i + 1 : i + 1 + n].astype(np.int32, copy=False)
             blocks_by_width.setdefault(n, []).append(row)
         i += 1 + n
@@ -70,7 +72,7 @@ def _collect_element_blocks(
     out: list[NDArray[np.int32]] = []
     for conn in dataset.cells_dict.values():
         arr = np.asarray(conn, dtype=np.int32)
-        if arr.ndim == 2 and arr.shape[1] >= 2:  # noqa: PLR2004
+        if arr.ndim == _CONNECTIVITY_NDIM and arr.shape[1] >= MIN_VERTICES_FOR_EDGE:
             out.append(arr)
     return out
 

--- a/src/mmgpy/_topology.py
+++ b/src/mmgpy/_topology.py
@@ -10,6 +10,8 @@ from scipy import sparse
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
+MIN_VERTICES_FOR_EDGE = 2
+
 
 def vertex_adjacency(
     n_vertices: int,
@@ -41,7 +43,7 @@ def vertex_adjacency(
 
     """
     n_per_elm = int(elements.shape[1])
-    if n_per_elm < 2:  # noqa: PLR2004 - lone vertices have no edges
+    if n_per_elm < MIN_VERTICES_FOR_EDGE:
         return sparse.csr_matrix((n_vertices, n_vertices), dtype=np.float64)
 
     ii, jj = np.triu_indices(n_per_elm, k=1)

--- a/src/mmgpy/_transfer.py
+++ b/src/mmgpy/_transfer.py
@@ -178,6 +178,11 @@ def interpolate_field(
         Shape matches input field shape with n_target_points replacing
         n_source_vertices.
 
+    Raises
+    ------
+    RuntimeError
+        If the internal KDTree fails to build when one is required.
+
     """
     field = np.atleast_2d(field)
     if field.shape[0] == 1 and field.shape[1] == len(source_vertices):
@@ -195,7 +200,9 @@ def interpolate_field(
         tree = cKDTree(source_vertices)
 
     if method == "nearest":
-        assert tree is not None  # noqa: S101
+        if tree is None:
+            msg = "KDTree was not built for nearest-neighbor query"
+            raise RuntimeError(msg)
         _, nearest_idx = tree.query(target_points)
         return field[nearest_idx].reshape(len(target_points), n_components).squeeze()
 
@@ -218,7 +225,9 @@ def interpolate_field(
         )
 
     if np.any(outside_mask):
-        assert tree is not None  # noqa: S101
+        if tree is None:
+            msg = "KDTree was not built for outside-point fallback"
+            raise RuntimeError(msg)
         outside_indices = np.where(outside_mask)[0]
         _, nearest_idx = tree.query(target_points[outside_indices])
         result[outside_indices] = field[nearest_idx]

--- a/src/mmgpy/sizing.py
+++ b/src/mmgpy/sizing.py
@@ -96,7 +96,15 @@ class SphereSize(SizingConstraint):
     radius: float
     size: float
 
-    def __post_init__(self) -> None:  # noqa: D105
+    def __post_init__(self) -> None:
+        """Coerce ``center`` to ``float64`` and validate positive radius/size.
+
+        Raises
+        ------
+        ValueError
+            If ``radius`` or ``size`` is not strictly positive.
+
+        """
         self.center = np.asarray(self.center, dtype=np.float64)
         if self.radius <= 0:
             msg = f"radius must be positive, got {self.radius}"
@@ -105,10 +113,18 @@ class SphereSize(SizingConstraint):
             msg = f"size must be positive, got {self.size}"
             raise ValueError(msg)
 
-    def compute_sizes(  # noqa: D102
+    def compute_sizes(
         self,
         vertices: NDArray[np.float64],
     ) -> NDArray[np.float64]:
+        """Return ``self.size`` inside the sphere, ``np.inf`` elsewhere.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Per-vertex target size, shape ``(n_vertices,)``.
+
+        """
         distances = np.linalg.norm(vertices - self.center, axis=1)
 
         sizes = np.full(len(vertices), np.inf, dtype=np.float64)
@@ -136,7 +152,16 @@ class BoxSize(SizingConstraint):
     bounds: NDArray[np.float64]
     size: float
 
-    def __post_init__(self) -> None:  # noqa: D105
+    def __post_init__(self) -> None:
+        """Coerce ``bounds`` to ``float64`` and validate shape/size.
+
+        Raises
+        ------
+        ValueError
+            If ``bounds`` does not have shape ``(2, dim)`` or ``size`` is not
+            strictly positive.
+
+        """
         self.bounds = np.asarray(self.bounds, dtype=np.float64)
         if self.bounds.shape[0] != _BOUNDS_DIM_COUNT:
             msg = f"bounds must have shape (2, dim), got {self.bounds.shape}"
@@ -145,10 +170,18 @@ class BoxSize(SizingConstraint):
             msg = f"size must be positive, got {self.size}"
             raise ValueError(msg)
 
-    def compute_sizes(  # noqa: D102
+    def compute_sizes(
         self,
         vertices: NDArray[np.float64],
     ) -> NDArray[np.float64]:
+        """Return ``self.size`` inside the box, ``np.inf`` elsewhere.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Per-vertex target size, shape ``(n_vertices,)``.
+
+        """
         min_corner = self.bounds[0]
         max_corner = self.bounds[1]
 
@@ -185,7 +218,15 @@ class CylinderSize(SizingConstraint):
     radius: float
     size: float
 
-    def __post_init__(self) -> None:  # noqa: D105
+    def __post_init__(self) -> None:
+        """Coerce endpoints to ``float64`` and validate positive radius/size.
+
+        Raises
+        ------
+        ValueError
+            If ``radius`` or ``size`` is not strictly positive.
+
+        """
         self.point1 = np.asarray(self.point1, dtype=np.float64)
         self.point2 = np.asarray(self.point2, dtype=np.float64)
         if self.radius <= 0:
@@ -195,10 +236,23 @@ class CylinderSize(SizingConstraint):
             msg = f"size must be positive, got {self.size}"
             raise ValueError(msg)
 
-    def compute_sizes(  # noqa: D102
+    def compute_sizes(
         self,
         vertices: NDArray[np.float64],
     ) -> NDArray[np.float64]:
+        """Return ``self.size`` inside the cylinder, ``np.inf`` elsewhere.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Per-vertex target size, shape ``(n_vertices,)``.
+
+        Raises
+        ------
+        ValueError
+            If the cylinder axis (``point2 - point1``) has zero length.
+
+        """
         axis = self.point2 - self.point1
         axis_length = np.linalg.norm(axis)
         if axis_length < _ZERO_LENGTH_THRESHOLD:
@@ -247,7 +301,16 @@ class PointSize(SizingConstraint):
     far_size: float
     influence_radius: float
 
-    def __post_init__(self) -> None:  # noqa: D105
+    def __post_init__(self) -> None:
+        """Coerce ``point`` to ``float64`` and validate positive sizes/radius.
+
+        Raises
+        ------
+        ValueError
+            If ``near_size``, ``far_size``, or ``influence_radius`` is not
+            strictly positive.
+
+        """
         self.point = np.asarray(self.point, dtype=np.float64)
         if self.near_size <= 0:
             msg = f"near_size must be positive, got {self.near_size}"
@@ -259,10 +322,18 @@ class PointSize(SizingConstraint):
             msg = f"influence_radius must be positive, got {self.influence_radius}"
             raise ValueError(msg)
 
-    def compute_sizes(  # noqa: D102
+    def compute_sizes(
         self,
         vertices: NDArray[np.float64],
     ) -> NDArray[np.float64]:
+        """Linearly interpolate from ``near_size`` to ``far_size`` by distance.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Per-vertex target size, shape ``(n_vertices,)``.
+
+        """
         distances = np.linalg.norm(vertices - self.point, axis=1)
         t = np.clip(distances / self.influence_radius, 0.0, 1.0)
         return self.near_size + t * (self.far_size - self.near_size)

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -161,10 +161,10 @@ class TestFileLogging:
 
         try:
             # Verify handler has correct level
-            from mmgpy._logging import _file_handler
+            from mmgpy._logging import _state
 
-            assert _file_handler is not None
-            assert _file_handler.level == logging.INFO
+            assert _state.file_handler is not None
+            assert _state.file_handler.level == logging.INFO
         finally:
             mmgpy.set_log_file(None)
 
@@ -174,10 +174,10 @@ class TestFileLogging:
         mmgpy.set_log_file(log_file, level=logging.ERROR)
 
         try:
-            from mmgpy._logging import _file_handler
+            from mmgpy._logging import _state
 
-            assert _file_handler is not None
-            assert _file_handler.level == logging.ERROR
+            assert _state.file_handler is not None
+            assert _state.file_handler.level == logging.ERROR
         finally:
             mmgpy.set_log_file(None)
 
@@ -213,11 +213,11 @@ class TestFileLogging:
         mmgpy.set_log_file(log_file, max_bytes=1000, backup_count=3)
 
         try:
-            from mmgpy._logging import _file_handler
+            from mmgpy._logging import _state
 
-            assert isinstance(_file_handler, RotatingFileHandler)
-            assert _file_handler.maxBytes == 1000
-            assert _file_handler.backupCount == 3
+            assert isinstance(_state.file_handler, RotatingFileHandler)
+            assert _state.file_handler.maxBytes == 1000
+            assert _state.file_handler.backupCount == 3
         finally:
             mmgpy.set_log_file(None)
 


### PR DESCRIPTION
## Summary

Tier 1 of a multi-step effort to reduce ignored lint rules in `src/mmgpy/`. Replaces 15 inline `# noqa` markers with real fixes, no consolidation into per-file ignores.

## Changes

- `sizing.py`: real docstrings on `__post_init__` / `compute_sizes` (drops 8 `D102`/`D105`)
- `_topology.py`, `_reorder.py`: name `2` as `MIN_VERTICES_FOR_EDGE` + `_CONNECTIVITY_NDIM` (drops 3 `PLR2004`)
- `_logging.py`: wrap module flags in `_LoggingState` dataclass (drops 2 `PLW0603`)
- `_transfer.py`: replace runtime-invariant `assert` with explicit `RuntimeError` (drops 2 `S101`)

## Notes

Behavior preserved: `_LoggingState` carries the same two fields previously held as `global`s; consumers (`configure_logging`, `set_log_file`, `get_log_file`) keep their signatures.