### PR TITLE
refactor: lazy-load pyvista-coupled imports in mmgpy.__init__

### DIFF
--- a/src/mmgpy/__init__.py
+++ b/src/mmgpy/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
+from typing import TYPE_CHECKING, Any
+
 from ._cli import _find_mmg_executable  # noqa: F401  # Used by tests
 from ._logging import (
     configure_logging,
@@ -21,16 +24,14 @@ try:
 except ImportError:
     __version__ = "unknown"
 
-# Core C++ bindings
-from . import interactive, lagrangian, metrics, progress, repair, sizing
-from ._io import read
-from ._mesh import MeshKind
+# Eagerly imported: numpy-only, no PyVista in their transitive closure. These
+# stay available even in headless distributions that ship mmgpy without
+# pyvista (e.g. the Blender add-on).
+from . import lagrangian, metrics, progress, repair, sizing
 from ._mmgpy import MMG_VERSION  # type: ignore[attr-defined]
 from ._options import Mmg2DOptions, Mmg3DOptions, MmgSOptions
 from ._progress import CancellationError, ProgressEvent, rich_progress
-from ._pyvista import from_pyvista, polydata_from_2d_triangles, to_pyvista
 from ._remesh import SolPaths, mmg2d, mmg3d, mmgs  # noqa: F401
-from ._reorder import reorder_cuthill_mckee
 from ._result import RemeshResult
 from ._transfer import interpolate_field, transfer_fields
 from ._validation import (
@@ -54,6 +55,42 @@ from .sizing import (
     SphereSize,
     apply_sizing_constraints,
 )
+
+if TYPE_CHECKING:
+    # Surface PyVista-coupled names to type checkers without importing pyvista
+    # at runtime. Real loading happens on first attribute access via the
+    # __getattr__ below.
+    from . import interactive
+    from ._io import read
+    from ._mesh import MeshKind
+    from ._pyvista import from_pyvista, polydata_from_2d_triangles, to_pyvista
+    from ._reorder import reorder_cuthill_mckee
+
+# Maps lazy attribute name -> (module path, attribute on module or None for the
+# module itself). The Blender subset omits these modules entirely; attempting
+# to access them there will raise ImportError, which is the desired behaviour.
+_LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
+    "interactive": ("mmgpy.interactive", None),
+    "read": ("mmgpy._io", "read"),
+    "MeshKind": ("mmgpy._mesh", "MeshKind"),
+    "from_pyvista": ("mmgpy._pyvista", "from_pyvista"),
+    "polydata_from_2d_triangles": ("mmgpy._pyvista", "polydata_from_2d_triangles"),
+    "to_pyvista": ("mmgpy._pyvista", "to_pyvista"),
+    "reorder_cuthill_mckee": ("mmgpy._reorder", "reorder_cuthill_mckee"),
+}
+
+
+def __getattr__(name: str) -> Any:  # noqa: ANN401  -- value is a module or attribute
+    target = _LAZY_IMPORTS.get(name)
+    if target is None:
+        msg = f"module 'mmgpy' has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr_name = target
+    module = importlib.import_module(module_name)
+    value = module if attr_name is None else getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "MMG_VERSION",

--- a/src/mmgpy/__init__.py
+++ b/src/mmgpy/__init__.py
@@ -66,27 +66,28 @@ if TYPE_CHECKING:
     from ._pyvista import from_pyvista, polydata_from_2d_triangles, to_pyvista
     from ._reorder import reorder_cuthill_mckee
 
-# Maps lazy attribute name -> (module path, attribute on module or None for the
-# module itself). The Blender subset omits these modules entirely; attempting
-# to access them there will raise ImportError, which is the desired behaviour.
+# Maps lazy attribute name -> (relative module path, attribute on module or
+# None for the module itself). The Blender subset omits these modules
+# entirely; attempting to access them there raises ImportError, which is the
+# desired behaviour. Relative paths keep this working under vendoring.
 _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
-    "interactive": ("mmgpy.interactive", None),
-    "read": ("mmgpy._io", "read"),
-    "MeshKind": ("mmgpy._mesh", "MeshKind"),
-    "from_pyvista": ("mmgpy._pyvista", "from_pyvista"),
-    "polydata_from_2d_triangles": ("mmgpy._pyvista", "polydata_from_2d_triangles"),
-    "to_pyvista": ("mmgpy._pyvista", "to_pyvista"),
-    "reorder_cuthill_mckee": ("mmgpy._reorder", "reorder_cuthill_mckee"),
+    "interactive": (".interactive", None),
+    "read": ("._io", "read"),
+    "MeshKind": ("._mesh", "MeshKind"),
+    "from_pyvista": ("._pyvista", "from_pyvista"),
+    "polydata_from_2d_triangles": ("._pyvista", "polydata_from_2d_triangles"),
+    "to_pyvista": ("._pyvista", "to_pyvista"),
+    "reorder_cuthill_mckee": ("._reorder", "reorder_cuthill_mckee"),
 }
 
 
 def __getattr__(name: str) -> Any:  # noqa: ANN401  -- value is a module or attribute
     target = _LAZY_IMPORTS.get(name)
     if target is None:
-        msg = f"module 'mmgpy' has no attribute {name!r}"
+        msg = f"module {__name__!r} has no attribute {name!r}"
         raise AttributeError(msg)
     module_name, attr_name = target
-    module = importlib.import_module(module_name)
+    module = importlib.import_module(module_name, package=__name__)
     value = module if attr_name is None else getattr(module, attr_name)
     globals()[name] = value
     return value

--- a/src/mmgpy/_generate.py
+++ b/src/mmgpy/_generate.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from mmgpy._mmgpy import MmgMesh2D
-from mmgpy._pyvista import to_pyvista
 
 if TYPE_CHECKING:
     import pyvista as pv
@@ -129,6 +128,8 @@ def generate(  # noqa: PLR0913  -- the standard MMG sizing knobs are explicit by
             options.setdefault(name, value)
 
     mesh.remesh(**options)
+    from mmgpy._pyvista import to_pyvista  # noqa: PLC0415
+
     return to_pyvista(mesh, include_refs=True, include_edges=True)
 
 

--- a/tests/headless_subset_test.py
+++ b/tests/headless_subset_test.py
@@ -1,0 +1,107 @@
+"""Regression test for the PyVista-free import subset.
+
+The Blender add-on ships mmgpy without bundling pyvista/vtk wheels. This
+test pins the contract that ``import mmgpy`` plus access to the headless
+public API does not pull pyvista (or vtk) into ``sys.modules``. PyVista
+is only loaded on first access to the pyvista-coupled names exposed via
+the module's ``__getattr__``.
+
+Runs in a subprocess because ``tests/conftest.py`` imports pyvista at
+collection time, so any in-process check would observe it already loaded.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+HEADLESS_PROBE = textwrap.dedent(
+    """
+    import sys
+
+    import mmgpy
+
+    # Touch the headless public API surface. Any name that should remain
+    # available in the PyVista-free Blender subset goes here.
+    _ = mmgpy.MMG_VERSION
+    _ = mmgpy.__version__
+    _ = mmgpy.mmg2d
+    _ = mmgpy.mmg3d
+    _ = mmgpy.mmgs
+    _ = mmgpy.SolPaths
+    _ = mmgpy.Mmg2DOptions
+    _ = mmgpy.Mmg3DOptions
+    _ = mmgpy.MmgSOptions
+    _ = mmgpy.RemeshResult
+    _ = mmgpy.ValidationReport
+    _ = mmgpy.QualityStats
+    _ = mmgpy.IssueSeverity
+    _ = mmgpy.ValidationError
+    _ = mmgpy.ValidationIssue
+    _ = mmgpy.CancellationError
+    _ = mmgpy.ProgressEvent
+    _ = mmgpy.rich_progress
+    _ = mmgpy.transfer_fields
+    _ = mmgpy.interpolate_field
+    _ = mmgpy.lagrangian
+    _ = mmgpy.metrics
+    _ = mmgpy.progress
+    _ = mmgpy.repair
+    _ = mmgpy.sizing
+    _ = mmgpy.move_mesh
+    _ = mmgpy.propagate_displacement
+    _ = mmgpy.propagate_displacement_elasticity
+    _ = mmgpy.detect_boundary_vertices
+    _ = mmgpy.apply_sizing_constraints
+    _ = mmgpy.BoxSize
+    _ = mmgpy.CylinderSize
+    _ = mmgpy.PointSize
+    _ = mmgpy.SphereSize
+    _ = mmgpy.SizingConstraint
+    _ = mmgpy.configure_logging
+    _ = mmgpy.enable_debug
+
+    leaked = sorted(
+        m for m in sys.modules
+        if m == "pyvista"
+        or m.startswith("pyvista.")
+        or m == "vtk"
+        or m.startswith("vtk.")
+        or m.startswith("vtkmodules")
+    )
+    if leaked:
+        print("LEAKED:" + ",".join(leaked))
+        raise SystemExit(1)
+
+    # Lazy access must succeed and now pyvista is allowed.
+    _ = mmgpy.read
+    _ = mmgpy.MeshKind
+    _ = mmgpy.from_pyvista
+    _ = mmgpy.to_pyvista
+    _ = mmgpy.polydata_from_2d_triangles
+    _ = mmgpy.reorder_cuthill_mckee
+    _ = mmgpy.interactive
+    if "pyvista" not in sys.modules:
+        print("LAZY FAILED: pyvista not loaded after read access")
+        raise SystemExit(2)
+
+    print("OK")
+    """
+)
+
+
+def test_headless_subset_does_not_import_pyvista() -> None:
+    """``import mmgpy`` + headless API access must not load pyvista or vtk."""
+    result = subprocess.run(
+        [sys.executable, "-c", HEADLESS_PROBE],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"headless probe failed (rc={result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert result.stdout.strip().endswith("OK"), result.stdout


### PR DESCRIPTION
## Summary

- `import mmgpy` no longer loads `pyvista`/`vtk` into `sys.modules`
- Enables shipping mmgpy in PyVista-free distributions (Blender add-on)
- No public API change, pip users are unaffected

## Changes

- `mmgpy.__init__`: PEP 562 `__getattr__` lazy-loads `read`, `MeshKind`, `from_pyvista`, `to_pyvista`, `polydata_from_2d_triangles`, `reorder_cuthill_mckee`, `interactive`
- `_generate.py`: move `to_pyvista` import inside `generate()` to plug `_remesh -> _generate -> _pyvista` leak
- `tests/headless_subset_test.py`: subprocess regression test pinning the contract

## Notes

- `TYPE_CHECKING` block preserves mypy/IDE autocomplete for lazy names
- `__all__` unchanged
- Full suite: 1121 passed, 17 skipped