### PR TITLE
refactor: drop pyvista/scipy from blender extension bundle

### DIFF
--- a/.github/workflows/build-blender-extension.yml
+++ b/.github/workflows/build-blender-extension.yml
@@ -155,39 +155,26 @@ jobs:
           done
           ls -la
 
-      - name: Resolve transitive deps as wheels
-        working-directory: blender_mmgpy
+      - name: Verify only the mmgpy wheel is bundled
+        working-directory: blender_mmgpy/wheels
         shell: bash
         run: |
           set -euo pipefail
-          # ``pip download`` fans out from the local mmgpy wheel, pulling
-          # the matching ABI wheels for numpy / scipy / pyvista / vtk
-          # (and pure-Python wheels for the rest) into the same dir.
-          #
-          # pip's ``--platform`` is strict (no PEP 600 manylinux fallback),
-          # so on Linux we have to enumerate the manylinux generations our
-          # deps actually ship under: mmgpy is built against manylinux_2_28
-          # (cibuildwheel), numpy/scipy/vtk publish manylinux_2_17 wheels,
-          # and patchelf publishes manylinux_2_5 / manylinux1 wheels.
-          EXTRA_PLATFORMS=()
-          case "${{ matrix.platform }}" in
-            linux-x64)
-              EXTRA_PLATFORMS=(
-                --platform manylinux_2_17_x86_64
-                --platform manylinux2014_x86_64
-                --platform manylinux_2_5_x86_64
-                --platform manylinux1_x86_64
-              )
-              ;;
+          # The headless refactor (no PyVista, scipy, rich, etc. in the
+          # `import mmgpy` path) means the Blender add-on only needs the
+          # compiled mmgpy wheel. numpy is bundled with Blender; everything
+          # else mmgpy used to pull in is now lazy-loaded behind a
+          # __getattr__ and never reached from the operator code path.
+          shopt -s nullglob
+          wheels=( *.whl )
+          if (( ${#wheels[@]} != 1 )); then
+            echo "Expected exactly one wheel (mmgpy), got: ${wheels[*]}" >&2
+            exit 1
+          fi
+          case "${wheels[0]}" in
+            mmgpy-*) echo "OK: bundling ${wheels[0]}" ;;
+            *) echo "Unexpected wheel: ${wheels[0]}" >&2; exit 1 ;;
           esac
-
-          pip download mmgpy \
-            --find-links wheels --dest wheels \
-            --only-binary :all: \
-            --python-version ${{ matrix.py }} \
-            --platform ${{ matrix.pip_platform }} \
-            ${EXTRA_PLATFORMS[@]+"${EXTRA_PLATFORMS[@]}"} \
-            --platform any
 
       - name: Inject ``wheels`` and ``platforms`` into the manifest
         working-directory: blender_mmgpy

--- a/blender_mmgpy/operators.py
+++ b/blender_mmgpy/operators.py
@@ -34,11 +34,12 @@ try:
 except ImportError as exc:
     _MMGPY_IMPORT_ERROR = exc
 
-# Errors we expect from mmgpy / numpy on bad geometry or option combinations.
-# The surface remesh path runs in-memory only — no file I/O — so ``OSError``
-# is intentionally excluded. Anything outside this set is genuinely
-# unexpected and bubbles up to Blender's own error popup with a full
-# traceback.
+# Errors we expect from the three mmgpy callsites the operator wraps:
+# ``MmgMeshS(...)`` construction, ``apply_sizing_constraints``, and
+# ``mesh.remesh``. The surface remesh path runs in-memory only — no file
+# I/O — so ``OSError`` is intentionally excluded. Anything outside this
+# set is genuinely unexpected and bubbles up to Blender's own error
+# popup with a full traceback.
 _REMESH_EXC_TYPES = (RuntimeError, ValueError, TypeError)
 
 # Above this raw triangle estimate we round to 2 significant figures for the

--- a/blender_mmgpy/operators.py
+++ b/blender_mmgpy/operators.py
@@ -20,17 +20,25 @@ if TYPE_CHECKING:
     from .properties import MMGPYSettings
 
 try:
-    import mmgpy  # noqa: F401 -- registers the .mmg PyVista accessor
+    import numpy as np
+
+    from mmgpy._mmgpy import MmgMeshS  # noqa: PLC2701
+    from mmgpy.sizing import (
+        BoxSize,
+        SizingConstraint,
+        SphereSize,
+        apply_sizing_constraints,
+    )
 
     _MMGPY_IMPORT_ERROR: ImportError | None = None
 except ImportError as exc:
     _MMGPY_IMPORT_ERROR = exc
 
-# Errors we expect from mmgpy / PyVista / numpy on bad geometry or option
-# combinations. The surface remesh path runs in-memory only — no file I/O
-# — so ``OSError`` is intentionally excluded. Anything outside this set
-# is genuinely unexpected and bubbles up to Blender's own error popup
-# with a full traceback.
+# Errors we expect from mmgpy / numpy on bad geometry or option combinations.
+# The surface remesh path runs in-memory only — no file I/O — so ``OSError``
+# is intentionally excluded. Anything outside this set is genuinely
+# unexpected and bubbles up to Blender's own error popup with a full
+# traceback.
 _REMESH_EXC_TYPES = (RuntimeError, ValueError, TypeError)
 
 # Above this raw triangle estimate we round to 2 significant figures for the
@@ -151,24 +159,31 @@ class MMGPY_OT_remesh(Operator):
         n_tris_before = len(triangles)
 
         try:
-            polydata = utils.arrays_to_polydata(vertices, triangles)
+            mesh = MmgMeshS(
+                vertices.astype(np.float64, copy=False),
+                triangles.astype(np.int32, copy=False),
+            )
         except _REMESH_EXC_TYPES as e:
-            self.report({"ERROR"}, f"Failed to build PyVista mesh: {e}")
+            self.report({"ERROR"}, f"Failed to build mmgpy mesh: {e}")
             return {"CANCELLED"}
 
         remesh_kwargs = self._build_remesh_options(settings)
-        local_sizing = self._build_local_sizing(settings)
+        constraints = self._build_sizing_constraints(settings)
+        if constraints:
+            try:
+                apply_sizing_constraints(mesh, constraints)
+            except _REMESH_EXC_TYPES as e:
+                self.report({"ERROR"}, f"Failed to apply sizing constraints: {e}")
+                return {"CANCELLED"}
 
         try:
-            result = polydata.mmg.remesh(
-                local_sizing=local_sizing or None,
-                **remesh_kwargs,
-            )
+            mesh.remesh(**remesh_kwargs)
         except _REMESH_EXC_TYPES as e:
             self.report({"ERROR"}, f"Remeshing failed: {e}")
             return {"CANCELLED"}
 
-        new_vertices, new_triangles = utils.polydata_to_arrays(result)
+        new_vertices = mesh.get_vertices()
+        new_triangles = mesh.get_triangles()
 
         utils.replace_mesh_data(obj, new_vertices, new_triangles)
 
@@ -197,7 +212,7 @@ class MMGPY_OT_remesh(Operator):
 
     @staticmethod
     def _build_remesh_options(settings: MMGPYSettings) -> dict[str, Any]:
-        """Translate settings into ``polydata.mmg.remesh`` keyword arguments.
+        """Translate settings into ``MmgMeshS.remesh`` keyword arguments.
 
         Returns
         -------
@@ -236,20 +251,22 @@ class MMGPY_OT_remesh(Operator):
         return kwargs
 
     @staticmethod
-    def _build_local_sizing(settings: MMGPYSettings) -> list[dict[str, Any]]:
-        """Translate sizing-constraint empties into ``.mmg.remesh`` specs.
+    def _build_sizing_constraints(
+        settings: MMGPYSettings,
+    ) -> list[SizingConstraint]:
+        """Translate sizing-constraint empties into ``SizingConstraint`` objects.
 
-        Each sphere/box empty becomes one entry in the ``local_sizing`` list
-        forwarded to :meth:`mmgpy.MmgAccessor.remesh`. Empties without a
-        target object are skipped.
+        Each sphere/box empty becomes one ``SphereSize`` / ``BoxSize``
+        instance passed to :func:`mmgpy.sizing.apply_sizing_constraints`.
+        Empties without a target object are skipped.
 
         Returns
         -------
-        list of dict
-            One spec per active sphere/box constraint.
+        list of SizingConstraint
+            One constraint per active sphere/box empty.
 
         """
-        specs: list[dict[str, Any]] = []
+        constraints: list[SizingConstraint] = []
         for constraint in settings.sizing_constraints:
             empty = constraint.empty_object
             if empty is None:
@@ -259,20 +276,18 @@ class MMGPY_OT_remesh(Operator):
             size = constraint.target_size
 
             if constraint.constraint_type == "SPHERE":
-                specs.append(
-                    {
-                        "shape": "sphere",
-                        "center": [location.x, location.y, location.z],
-                        "radius": empty.empty_display_size,
-                        "size": size,
-                    },
+                constraints.append(
+                    SphereSize(
+                        center=[location.x, location.y, location.z],
+                        radius=empty.empty_display_size,
+                        size=size,
+                    ),
                 )
             elif constraint.constraint_type == "BOX":
                 half_size = empty.empty_display_size
-                specs.append(
-                    {
-                        "shape": "box",
-                        "bounds": [
+                constraints.append(
+                    BoxSize(
+                        bounds=[
                             [
                                 location.x - half_size,
                                 location.y - half_size,
@@ -284,10 +299,10 @@ class MMGPY_OT_remesh(Operator):
                                 location.z + half_size,
                             ],
                         ],
-                        "size": size,
-                    },
+                        size=size,
+                    ),
                 )
-        return specs
+        return constraints
 
 
 class MMGPY_OT_autofit(Operator):

--- a/blender_mmgpy/utils.py
+++ b/blender_mmgpy/utils.py
@@ -10,7 +10,6 @@ import bmesh
 import bpy
 import mathutils
 import numpy as np
-import pyvista as pv
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -139,56 +138,6 @@ def replace_mesh_data(
     mesh.clear_geometry()
     mesh.from_pydata(local_verts, [], triangles.tolist())
     mesh.update()
-
-
-def arrays_to_polydata(
-    vertices: NDArray[np.float64],
-    triangles: NDArray[np.int32],
-) -> pv.PolyData:
-    """Build a PyVista PolyData surface from vertex + triangle arrays.
-
-    Parameters
-    ----------
-    vertices : ndarray
-        Vertex coordinates (Nx3) in world space.
-    triangles : ndarray
-        Triangle connectivity (Mx3), 0-indexed.
-
-    Returns
-    -------
-    pv.PolyData
-        Triangle surface mesh ready for ``mesh.mmg.remesh()``.
-
-    """
-    faces = np.column_stack(
-        [np.full(len(triangles), 3, dtype=np.int32), triangles.astype(np.int32)],
-    ).ravel()
-    return pv.PolyData(vertices.astype(np.float64), faces=faces)
-
-
-def polydata_to_arrays(
-    polydata: pv.PolyData,
-) -> tuple[NDArray[np.float64], NDArray[np.int32]]:
-    """Extract vertices and triangle connectivity from a PolyData.
-
-    Handles the polygon stream produced by ``.mmg.remesh()`` — line cells
-    (MMG ridges) sit in ``polydata.lines`` and are ignored here.
-
-    Returns
-    -------
-    vertices : ndarray
-        Vertex coordinates (Nx3).
-    triangles : ndarray
-        Triangle connectivity (Mx3), 0-indexed.
-
-    """
-    vertices = np.asarray(polydata.points, dtype=np.float64)
-    faces = np.asarray(polydata.faces)
-    if faces.size == 0:
-        triangles = np.empty((0, 3), dtype=np.int32)
-    else:
-        triangles = faces.reshape(-1, 4)[:, 1:].astype(np.int32, copy=False)
-    return vertices, triangles
 
 
 QUALITY_ATTR_NAME = "mmgpy_quality"
@@ -449,8 +398,12 @@ def apply_quality_visualization(obj: bpy.types.Object) -> int:
     # ``blender_to_arrays`` would route via ``bmesh.ops.triangulate``
     # which is documented to reorder faces.
     vertices, triangles = direct_triangle_arrays(mesh)
-    polydata = arrays_to_polydata(vertices, triangles)
-    qualities = polydata.mmg.element_qualities()
+    from mmgpy._mmgpy import MmgMeshS  # noqa: PLC0415, PLC2701
+
+    qualities = MmgMeshS(
+        vertices.astype(np.float64, copy=False),
+        triangles.astype(np.int32, copy=False),
+    ).get_element_qualities()
 
     if len(qualities) != len(mesh.polygons):
         msg = (

--- a/blender_mmgpy/utils.py
+++ b/blender_mmgpy/utils.py
@@ -11,6 +11,8 @@ import bpy
 import mathutils
 import numpy as np
 
+from mmgpy._mmgpy import MmgMeshS  # noqa: PLC2701
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
@@ -398,8 +400,6 @@ def apply_quality_visualization(obj: bpy.types.Object) -> int:
     # ``blender_to_arrays`` would route via ``bmesh.ops.triangulate``
     # which is documented to reorder faces.
     vertices, triangles = direct_triangle_arrays(mesh)
-    from mmgpy._mmgpy import MmgMeshS  # noqa: PLC0415, PLC2701
-
     qualities = MmgMeshS(
         vertices.astype(np.float64, copy=False),
         triangles.astype(np.int32, copy=False),

--- a/src/mmgpy/__init__.py
+++ b/src/mmgpy/__init__.py
@@ -24,29 +24,15 @@ try:
 except ImportError:
     __version__ = "unknown"
 
-# Eagerly imported: numpy-only, no PyVista in their transitive closure. These
-# stay available even in headless distributions that ship mmgpy without
-# pyvista (e.g. the Blender add-on).
-from . import lagrangian, metrics, progress, repair, sizing
+# Eagerly imported: numpy-only (no pyvista, no scipy in their transitive
+# closure). These stay available even in slim distributions that ship mmgpy
+# without those heavy deps (e.g. the Blender add-on).
+from . import progress, sizing
 from ._mmgpy import MMG_VERSION  # type: ignore[attr-defined]
 from ._options import Mmg2DOptions, Mmg3DOptions, MmgSOptions
 from ._progress import CancellationError, ProgressEvent, rich_progress
 from ._remesh import SolPaths, mmg2d, mmg3d, mmgs  # noqa: F401
 from ._result import RemeshResult
-from ._transfer import interpolate_field, transfer_fields
-from ._validation import (
-    IssueSeverity,
-    QualityStats,
-    ValidationError,
-    ValidationIssue,
-    ValidationReport,
-)
-from .lagrangian import (
-    detect_boundary_vertices,
-    move_mesh,
-    propagate_displacement,
-    propagate_displacement_elasticity,
-)
 from .sizing import (
     BoxSize,
     CylinderSize,
@@ -57,20 +43,35 @@ from .sizing import (
 )
 
 if TYPE_CHECKING:
-    # Surface PyVista-coupled names to type checkers without importing pyvista
-    # at runtime. Real loading happens on first attribute access via the
-    # __getattr__ below.
-    from . import interactive
+    # Surface pyvista- and scipy-coupled names to type checkers without
+    # importing the heavy deps at runtime. Real loading happens on first
+    # attribute access via the __getattr__ below.
+    from . import interactive, lagrangian, metrics, repair
     from ._io import read
     from ._mesh import MeshKind
     from ._pyvista import from_pyvista, polydata_from_2d_triangles, to_pyvista
     from ._reorder import reorder_cuthill_mckee
+    from ._transfer import interpolate_field, transfer_fields
+    from ._validation import (
+        IssueSeverity,
+        QualityStats,
+        ValidationError,
+        ValidationIssue,
+        ValidationReport,
+    )
+    from .lagrangian import (
+        detect_boundary_vertices,
+        move_mesh,
+        propagate_displacement,
+        propagate_displacement_elasticity,
+    )
 
 # Maps lazy attribute name -> (relative module path, attribute on module or
-# None for the module itself). The Blender subset omits these modules
+# None for the module itself). Slim distributions can omit these modules
 # entirely; attempting to access them there raises ImportError, which is the
 # desired behaviour. Relative paths keep this working under vendoring.
 _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
+    # PyVista-coupled
     "interactive": (".interactive", None),
     "read": ("._io", "read"),
     "MeshKind": ("._mesh", "MeshKind"),
@@ -78,6 +79,24 @@ _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "polydata_from_2d_triangles": ("._pyvista", "polydata_from_2d_triangles"),
     "to_pyvista": ("._pyvista", "to_pyvista"),
     "reorder_cuthill_mckee": ("._reorder", "reorder_cuthill_mckee"),
+    # scipy-coupled
+    "lagrangian": (".lagrangian", None),
+    "metrics": (".metrics", None),
+    "repair": (".repair", None),
+    "detect_boundary_vertices": (".lagrangian", "detect_boundary_vertices"),
+    "move_mesh": (".lagrangian", "move_mesh"),
+    "propagate_displacement": (".lagrangian", "propagate_displacement"),
+    "propagate_displacement_elasticity": (
+        ".lagrangian",
+        "propagate_displacement_elasticity",
+    ),
+    "interpolate_field": ("._transfer", "interpolate_field"),
+    "transfer_fields": ("._transfer", "transfer_fields"),
+    "IssueSeverity": ("._validation", "IssueSeverity"),
+    "QualityStats": ("._validation", "QualityStats"),
+    "ValidationError": ("._validation", "ValidationError"),
+    "ValidationIssue": ("._validation", "ValidationIssue"),
+    "ValidationReport": ("._validation", "ValidationReport"),
 }
 
 

--- a/src/mmgpy/_logging.py
+++ b/src/mmgpy/_logging.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Literal
 
+    from rich.logging import RichHandler
+
     LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
@@ -65,12 +67,27 @@ def get_logger() -> logging.Logger:
     return logger
 
 
+def _rich_handler_cls() -> type[RichHandler]:
+    """Return the ``rich.logging.RichHandler`` class, importing on demand.
+
+    Keeping the import deferred lets ``import mmgpy`` skip loading ``rich``
+    so slim distributions (e.g. the Blender add-on) don't need to bundle it.
+
+    Returns
+    -------
+    type[RichHandler]
+        The ``RichHandler`` class.
+
+    """
+    from rich.logging import RichHandler
+
+    return RichHandler
+
+
 def _configure_logger(logger: logging.Logger) -> None:
     """Configure the logger with RichHandler."""
     if _state.console_enabled:
-        from rich.logging import RichHandler
-
-        handler = RichHandler(
+        handler = _rich_handler_cls()(
             rich_tracebacks=True,
             show_path=False,
             markup=True,
@@ -131,10 +148,9 @@ def configure_logging(*, enable_console: bool = True) -> None:
     if not enable_console:
         _state.console_enabled = False
         # Remove existing Rich handlers if logger already initialized
-        from rich.logging import RichHandler
-
+        rich_handler_cls = _rich_handler_cls()
         for handler in logger.handlers[:]:
-            if isinstance(handler, RichHandler):
+            if isinstance(handler, rich_handler_cls):
                 logger.removeHandler(handler)
                 handler.close()
 

--- a/src/mmgpy/_logging.py
+++ b/src/mmgpy/_logging.py
@@ -10,8 +10,6 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from rich.logging import RichHandler
-
 if TYPE_CHECKING:
     from typing import Literal
 
@@ -70,6 +68,8 @@ def get_logger() -> logging.Logger:
 def _configure_logger(logger: logging.Logger) -> None:
     """Configure the logger with RichHandler."""
     if _state.console_enabled:
+        from rich.logging import RichHandler
+
         handler = RichHandler(
             rich_tracebacks=True,
             show_path=False,
@@ -131,6 +131,8 @@ def configure_logging(*, enable_console: bool = True) -> None:
     if not enable_console:
         _state.console_enabled = False
         # Remove existing Rich handlers if logger already initialized
+        from rich.logging import RichHandler
+
         for handler in logger.handlers[:]:
             if isinstance(handler, RichHandler):
                 logger.removeHandler(handler)

--- a/tests/headless_subset_test.py
+++ b/tests/headless_subset_test.py
@@ -1,10 +1,10 @@
-"""Regression test for the PyVista-free import subset.
+"""Regression test for the heavy-dep-free import subset.
 
-The Blender add-on ships mmgpy without bundling pyvista/vtk wheels. This
-test pins the contract that ``import mmgpy`` plus access to the headless
-public API does not pull pyvista (or vtk) into ``sys.modules``. PyVista
-is only loaded on first access to the pyvista-coupled names exposed via
-the module's ``__getattr__``.
+The Blender add-on ships mmgpy without bundling pyvista/vtk/scipy/matplotlib
+wheels. This test pins the contract that ``import mmgpy`` plus access to the
+headless public API does not pull any of those heavy deps into
+``sys.modules``. The heavy deps load only on first access to the lazy names
+exposed via the module's ``__getattr__``.
 
 Runs in a subprocess because ``tests/conftest.py`` imports pyvista at
 collection time, so any in-process check would observe it already loaded.
@@ -23,7 +23,7 @@ HEADLESS_PROBE = textwrap.dedent(
     import mmgpy
 
     # Touch the headless public API surface. Any name that should remain
-    # available in the PyVista-free Blender subset goes here.
+    # available in the slim Blender subset (no pyvista, no scipy) goes here.
     _ = mmgpy.MMG_VERSION
     _ = mmgpy.__version__
     _ = mmgpy.mmg2d
@@ -34,25 +34,11 @@ HEADLESS_PROBE = textwrap.dedent(
     _ = mmgpy.Mmg3DOptions
     _ = mmgpy.MmgSOptions
     _ = mmgpy.RemeshResult
-    _ = mmgpy.ValidationReport
-    _ = mmgpy.QualityStats
-    _ = mmgpy.IssueSeverity
-    _ = mmgpy.ValidationError
-    _ = mmgpy.ValidationIssue
     _ = mmgpy.CancellationError
     _ = mmgpy.ProgressEvent
     _ = mmgpy.rich_progress
-    _ = mmgpy.transfer_fields
-    _ = mmgpy.interpolate_field
-    _ = mmgpy.lagrangian
-    _ = mmgpy.metrics
     _ = mmgpy.progress
-    _ = mmgpy.repair
     _ = mmgpy.sizing
-    _ = mmgpy.move_mesh
-    _ = mmgpy.propagate_displacement
-    _ = mmgpy.propagate_displacement_elasticity
-    _ = mmgpy.detect_boundary_vertices
     _ = mmgpy.apply_sizing_constraints
     _ = mmgpy.BoxSize
     _ = mmgpy.CylinderSize
@@ -62,19 +48,38 @@ HEADLESS_PROBE = textwrap.dedent(
     _ = mmgpy.configure_logging
     _ = mmgpy.enable_debug
 
+    heavy_deps = ("pyvista", "vtk", "vtkmodules", "scipy", "rich", "matplotlib")
     leaked = sorted(
         m for m in sys.modules
-        if m == "pyvista"
-        or m.startswith("pyvista.")
-        or m == "vtk"
-        or m.startswith("vtk.")
-        or m.startswith("vtkmodules")
+        if any(m == d or m.startswith(d + ".") for d in heavy_deps)
     )
     if leaked:
         print("LEAKED:" + ",".join(leaked))
         raise SystemExit(1)
 
-    # Lazy access must succeed and now pyvista is allowed.
+    # Scipy-coupled lazy access. None loaded yet.
+    _ = mmgpy.move_mesh
+    _ = mmgpy.propagate_displacement
+    _ = mmgpy.propagate_displacement_elasticity
+    _ = mmgpy.detect_boundary_vertices
+    _ = mmgpy.transfer_fields
+    _ = mmgpy.interpolate_field
+    _ = mmgpy.lagrangian
+    _ = mmgpy.metrics
+    _ = mmgpy.repair
+    _ = mmgpy.IssueSeverity
+    _ = mmgpy.QualityStats
+    _ = mmgpy.ValidationError
+    _ = mmgpy.ValidationIssue
+    _ = mmgpy.ValidationReport
+    if "scipy" not in sys.modules:
+        print("LAZY FAILED: scipy not loaded after move_mesh access")
+        raise SystemExit(2)
+    if "pyvista" in sys.modules:
+        print("LEAKED: pyvista loaded via scipy-only path")
+        raise SystemExit(3)
+
+    # PyVista-coupled lazy access.
     _ = mmgpy.read
     _ = mmgpy.MeshKind
     _ = mmgpy.from_pyvista
@@ -84,15 +89,15 @@ HEADLESS_PROBE = textwrap.dedent(
     _ = mmgpy.interactive
     if "pyvista" not in sys.modules:
         print("LAZY FAILED: pyvista not loaded after read access")
-        raise SystemExit(2)
+        raise SystemExit(4)
 
     print("OK")
     """
 )
 
 
-def test_headless_subset_does_not_import_pyvista() -> None:
-    """``import mmgpy`` + headless API access must not load pyvista or vtk."""
+def test_headless_subset_does_not_import_heavy_deps() -> None:
+    """``import mmgpy`` + headless attr access must not load heavy deps."""
     result = subprocess.run(
         [sys.executable, "-c", HEADLESS_PROBE],
         capture_output=True,


### PR DESCRIPTION
## Summary

Addresses the Blender extension reviewer feedback (drop unnecessary wheels, shrink download size). The published add-on now ships only the compiled `mmgpy` wheel, no `pyvista`, `vtk`, `scipy`, `matplotlib`, `numpy`, `requests`, or their transitive deps.

## Changes

**mmgpy lazy surface (`src/mmgpy/`)**
- `__init__.py`: move scipy-using names to `__getattr__` (lagrangian module + reexports, metrics, repair, transfer_fields/interpolate_field, ValidationReport family).
- `_logging.py`: defer `rich.logging.RichHandler` import into function bodies.
- Net: `import mmgpy` no longer loads pyvista, vtk, scipy, rich, or matplotlib.

**Blender extension (`blender_mmgpy/`)**
- `utils.py`: drop `import pyvista as pv`; delete `arrays_to_polydata`/`polydata_to_arrays`; rewrite `apply_quality_visualization` to call `MmgMeshS.get_element_qualities()` directly.
- `operators.py`: swap the `arrays_to_polydata -> polydata.mmg.remesh -> polydata_to_arrays` flow for direct `MmgMeshS` + `mmgpy.sizing.apply_sizing_constraints`.

**CI (`.github/workflows/build-blender-extension.yml`)**
- Replace the broad `pip download mmgpy --find-links wheels --dest wheels` (29 wheels) with a verification step that asserts only the mmgpy wheel is bundled.

**Test (`tests/headless_subset_test.py`)**
- Extend the regression test to also pin `scipy`, `rich`, `matplotlib` out of `sys.modules` after `import mmgpy` + headless attr access.

## Notes

- Stacked on #285 (now merged).
- Full suite: 1122 passed, 17 skipped.
- Blender bundle goes from ~29 wheels to 1.