### PR TITLE
ci(blender): strip pyvista/scipy/rich from bundled wheel METADATA

### DIFF
--- a/.github/scripts/strip_blender_wheel_metadata.py
+++ b/.github/scripts/strip_blender_wheel_metadata.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2026 Kevin Marchais
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Derive a slim "core" variant of an mmgpy wheel for the Blender bundle.
+
+Rewrites the wheel's ``*.dist-info/METADATA`` in place to drop runtime deps
+the Blender extension code path does not reach (``pyvista``, ``scipy``,
+``rich``, ``patchelf``, ``typing-extensions``) and to widen the ``numpy``
+floor so Blender 4.2 LTS (numpy 1.26) is covered alongside Blender 5.0
+(numpy 2.x). The compiled ``_mmgpy.so`` and every Python module in the
+wheel are left untouched — this is a METADATA-only strip.
+
+The PyPI ``mmgpy`` wheel keeps its full ``Requires-Dist``; only the copy
+that ends up inside the Blender extension zip is rewritten.
+
+Usage::
+
+    python .github/scripts/strip_blender_wheel_metadata.py path/to/mmgpy-X.whl
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import re
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+# Hard-coded by design: this script encodes the Blender add-on's contract
+# with mmgpy, not a general-purpose wheel surgery tool.
+STRIP_DEPS: frozenset[str] = frozenset(
+    {"pyvista", "scipy", "rich", "patchelf", "typing-extensions"},
+)
+# Blender 4.2 LTS ships numpy 1.26.x; Blender 5.0 ships numpy 2.x.
+# mmgpy's compiled extension is built against numpy's stable ABI so both
+# work at runtime; the bundled METADATA just needs to advertise that.
+NUMPY_REQUIREMENT = "numpy>=1.26,<3"
+
+
+def _normalize(name: str) -> str:
+    """Lower-case + dash-canonicalise a PEP 503 distribution name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _b64_sha256(data: bytes) -> str:
+    """Format a sha256 digest as ``sha256=<urlsafe_b64 no padding>``."""
+    digest = hashlib.sha256(data).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+def rewrite_metadata(text: str) -> str:
+    """Return ``text`` with stripped ``Requires-Dist`` lines and a loose numpy.
+
+    Lines are matched on the leading PEP 503-normalised distribution name;
+    environment markers and version specifiers on the right-hand side are
+    not parsed. The ``numpy`` line (if present) is replaced wholesale with
+    ``NUMPY_REQUIREMENT``; other lines in ``STRIP_DEPS`` are removed.
+    """
+    out: list[str] = []
+    saw_numpy = False
+    for line in text.splitlines(keepends=True):
+        match = re.match(r"^Requires-Dist:\s*([A-Za-z0-9_.\-]+)", line)
+        if match is None:
+            out.append(line)
+            continue
+        pkg = _normalize(match.group(1))
+        if pkg in STRIP_DEPS:
+            continue
+        if pkg == "numpy":
+            saw_numpy = True
+            out.append(f"Requires-Dist: {NUMPY_REQUIREMENT}\n")
+            continue
+        out.append(line)
+
+    if not saw_numpy:
+        msg = (
+            "no Requires-Dist: numpy line found in METADATA; refusing to "
+            "produce a wheel that does not declare its numpy dependency"
+        )
+        raise SystemExit(msg)
+    return "".join(out)
+
+
+def rewrite_record(
+    record_text: str,
+    metadata_path_in_record: str,
+    new_metadata: bytes,
+) -> str:
+    """Return ``record_text`` with the METADATA line updated to match ``new_metadata``.
+
+    ``RECORD`` is comma-separated ``path,hash,size`` per line; the line for
+    ``RECORD`` itself has empty hash and size by convention and is left
+    alone.
+    """
+    new_hash = _b64_sha256(new_metadata)
+    new_size = str(len(new_metadata))
+
+    updated = False
+    out_lines: list[str] = []
+    for line in record_text.splitlines():
+        parts = line.split(",")
+        # Tolerate a literal comma in any field by reassembling on the
+        # known structure: path is everything before the last two commas.
+        if len(parts) >= 3 and parts[0] == metadata_path_in_record:
+            out_lines.append(f"{metadata_path_in_record},{new_hash},{new_size}")
+            updated = True
+        else:
+            out_lines.append(line)
+
+    if not updated:
+        msg = f"RECORD has no entry for {metadata_path_in_record!r}"
+        raise SystemExit(msg)
+    return "\n".join(out_lines) + "\n"
+
+
+def strip_wheel(wheel_path: Path) -> None:
+    """Rewrite ``wheel_path`` in place so its METADATA matches the slim contract."""
+    if not wheel_path.is_file() or wheel_path.suffix != ".whl":
+        msg = f"not a wheel file: {wheel_path}"
+        raise SystemExit(msg)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        with zipfile.ZipFile(wheel_path) as zf:
+            zf.extractall(work)
+
+        dist_info_dirs = [p for p in work.iterdir() if p.name.endswith(".dist-info")]
+        if len(dist_info_dirs) != 1:
+            msg = f"expected exactly one *.dist-info dir, found {dist_info_dirs}"
+            raise SystemExit(msg)
+        dist_info = dist_info_dirs[0]
+
+        metadata_path = dist_info / "METADATA"
+        record_path = dist_info / "RECORD"
+        if not metadata_path.exists() or not record_path.exists():
+            msg = "wheel is missing METADATA or RECORD"
+            raise SystemExit(msg)
+
+        original_metadata = metadata_path.read_text(encoding="utf-8")
+        rewritten_metadata = rewrite_metadata(original_metadata)
+        metadata_bytes = rewritten_metadata.encode("utf-8")
+        metadata_path.write_bytes(metadata_bytes)
+
+        metadata_record_key = f"{dist_info.name}/METADATA"
+        rewritten_record = rewrite_record(
+            record_path.read_text(encoding="utf-8"),
+            metadata_record_key,
+            metadata_bytes,
+        )
+        record_path.write_text(rewritten_record, encoding="utf-8")
+
+        tmp_wheel = wheel_path.with_suffix(".whl.tmp")
+        with zipfile.ZipFile(tmp_wheel, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in sorted(work.rglob("*")):
+                if path.is_file():
+                    zf.write(path, path.relative_to(work).as_posix())
+        shutil.move(tmp_wheel, wheel_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse ``argv`` and rewrite the requested wheel; return the exit code."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Rewrite an mmgpy wheel's METADATA to the slim contract used "
+            "by the Blender extension bundle (drop pyvista/scipy/rich, "
+            "loosen numpy)."
+        ),
+    )
+    parser.add_argument(
+        "wheel",
+        type=Path,
+        help="Path to the mmgpy .whl to rewrite in place.",
+    )
+    args = parser.parse_args(argv)
+
+    strip_wheel(args.wheel)
+    sys.stdout.write(f"Rewrote {args.wheel}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/strip_blender_wheel_metadata.py
+++ b/.github/scripts/strip_blender_wheel_metadata.py
@@ -102,8 +102,6 @@ def rewrite_record(
     out_lines: list[str] = []
     for line in record_text.splitlines():
         parts = line.split(",")
-        # Tolerate a literal comma in any field by reassembling on the
-        # known structure: path is everything before the last two commas.
         if len(parts) >= 3 and parts[0] == metadata_path_in_record:
             out_lines.append(f"{metadata_path_in_record},{new_hash},{new_size}")
             updated = True
@@ -117,7 +115,15 @@ def rewrite_record(
 
 
 def strip_wheel(wheel_path: Path) -> None:
-    """Rewrite ``wheel_path`` in place so its METADATA matches the slim contract."""
+    """Rewrite ``wheel_path`` in place so its METADATA matches the slim contract.
+
+    Only the METADATA entry of RECORD is recomputed; sha256+size for every
+    other file in RECORD is carried over verbatim. That stays correct
+    because we extract and repack the wheel byte-for-byte for those files
+    (the round trip leaves them untouched on disk). If a future change
+    were to rewrite a second file in the wheel, RECORD would need to be
+    refreshed for that file too.
+    """
     if not wheel_path.is_file() or wheel_path.suffix != ".whl":
         msg = f"not a wheel file: {wheel_path}"
         raise SystemExit(msg)

--- a/.github/workflows/build-blender-extension.yml
+++ b/.github/workflows/build-blender-extension.yml
@@ -199,7 +199,11 @@ jobs:
         run: |
           set -euo pipefail
           for wheel in mmgpy-*.whl; do
-            metadata=$(unzip -p "$wheel" '*/METADATA')
+            metadata=$(unzip -p "$wheel" '*.dist-info/METADATA')
+            if [[ -z "$metadata" ]]; then
+              echo "FAIL: no METADATA found in $wheel" >&2
+              exit 1
+            fi
             for forbidden in pyvista scipy rich patchelf typing-extensions; do
               if echo "$metadata" | grep -qE "^Requires-Dist:\\s*${forbidden}(\\W|$)"; then
                 echo "FAIL: $wheel still requires $forbidden" >&2

--- a/.github/workflows/build-blender-extension.yml
+++ b/.github/workflows/build-blender-extension.yml
@@ -176,6 +176,45 @@ jobs:
             *) echo "Unexpected wheel: ${wheels[0]}" >&2; exit 1 ;;
           esac
 
+      - name: Strip pyvista/scipy/rich from the bundled wheel METADATA
+        working-directory: blender_mmgpy/wheels
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The Blender extension never imports the lazy pyvista- or
+          # scipy-coupled paths, so the bundled mmgpy wheel's METADATA
+          # ``Requires-Dist`` is rewritten to drop those deps. The numpy
+          # floor is also widened from ``>=2.0.2`` to ``>=1.26`` so the
+          # extension can install on Blender 4.2 LTS (which ships numpy
+          # 1.26.x) as well as Blender 5.0 (numpy 2.x). The compiled
+          # ``_mmgpy.so`` and every Python module in the wheel are left
+          # untouched -- this is a METADATA-only strip.
+          for wheel in mmgpy-*.whl; do
+            python ../../.github/scripts/strip_blender_wheel_metadata.py "$wheel"
+          done
+
+      - name: Verify the stripped METADATA matches the slim contract
+        working-directory: blender_mmgpy/wheels
+        shell: bash
+        run: |
+          set -euo pipefail
+          for wheel in mmgpy-*.whl; do
+            metadata=$(unzip -p "$wheel" '*/METADATA')
+            for forbidden in pyvista scipy rich patchelf typing-extensions; do
+              if echo "$metadata" | grep -qE "^Requires-Dist:\\s*${forbidden}(\\W|$)"; then
+                echo "FAIL: $wheel still requires $forbidden" >&2
+                echo "$metadata" | grep -E "^Requires-Dist:" >&2
+                exit 1
+              fi
+            done
+            if ! echo "$metadata" | grep -qE "^Requires-Dist:\\s*numpy>=1\\.26"; then
+              echo "FAIL: $wheel does not declare loosened numpy floor" >&2
+              echo "$metadata" | grep -E "^Requires-Dist:\\s*numpy" >&2
+              exit 1
+            fi
+            echo "OK: $wheel METADATA matches the slim contract"
+          done
+
       - name: Inject ``wheels`` and ``platforms`` into the manifest
         working-directory: blender_mmgpy
         shell: bash

--- a/blender_mmgpy/blender_manifest.toml
+++ b/blender_mmgpy/blender_manifest.toml
@@ -29,5 +29,5 @@ tags = ["Mesh", "Modeling"]
 # hard-coded list here because the right set depends on the target.
 
 # No ``[permissions]`` block: the remesh path is fully in-memory
-# (Blender mesh -> NumPy -> PyVista -> MMG -> Blender mesh). MMG runs in
+# (Blender mesh -> NumPy -> MmgMeshS -> Blender mesh). MMG runs in
 # the process; no filesystem, network or clipboard access is taken.

--- a/tests/strip_blender_wheel_metadata_test.py
+++ b/tests/strip_blender_wheel_metadata_test.py
@@ -1,0 +1,172 @@
+"""Unit tests for ``.github/scripts/strip_blender_wheel_metadata.py``.
+
+The script lives outside the package import path, so it is loaded by file
+location. The tests cover the pure functions (METADATA rewrite, RECORD
+rewrite, PEP 503 normalisation) without going through a real wheel
+round-trip; the CI workflow's "verify slim contract" step already
+exercises the integration path.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / ".github"
+    / "scripts"
+    / "strip_blender_wheel_metadata.py"
+)
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "strip_blender_wheel_metadata",
+        _SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+strip_mod = _load_module()
+
+
+# Real METADATA stanza taken from an actual mmgpy wheel, plus extras at the
+# bottom that should survive the rewrite unchanged. Keeping this realistic
+# (Metadata-Version, mixed pkg name normalisations, environment markers)
+# protects against regex regressions on punctuation we'd otherwise miss.
+METADATA_INPUT = """\
+Metadata-Version: 2.4
+Name: mmgpy
+Version: 0.15.0
+Summary: Adaptive surface remeshing via the MMG library
+Requires-Python: >=3.10
+Requires-Dist: numpy<3,>=2.0.2
+Requires-Dist: patchelf<1,>=0.17.2.4; sys_platform == "linux"
+Requires-Dist: pyvista<1,>=0.48
+Requires-Dist: rich<15,>=13.0.0
+Requires-Dist: scipy<2,>=1.11.0
+Requires-Dist: typing-extensions<5,>=4.0.0; python_version < "3.11"
+Requires-Dist: trame<4,>=3.12.0; extra == "ui"
+Requires-Dist: pywebview<7,>=6.1; extra == "ui"
+"""
+
+
+def test_rewrite_metadata_strips_heavy_deps() -> None:
+    """Each forbidden dep is removed from ``Requires-Dist``."""
+    result = strip_mod.rewrite_metadata(METADATA_INPUT)
+    for forbidden in ("pyvista", "scipy", "rich", "patchelf", "typing-extensions"):
+        assert f"Requires-Dist: {forbidden}" not in result, forbidden
+
+
+def test_rewrite_metadata_loosens_numpy() -> None:
+    """The numpy pin is replaced with the Blender-friendly ``>=1.26,<3`` range."""
+    result = strip_mod.rewrite_metadata(METADATA_INPUT)
+    assert "Requires-Dist: numpy<3,>=2.0.2" not in result
+    assert "Requires-Dist: numpy>=1.26,<3\n" in result
+
+
+def test_rewrite_metadata_preserves_extras() -> None:
+    """``extra == "..."`` lines are untouched (not installed by Blender anyway)."""
+    result = strip_mod.rewrite_metadata(METADATA_INPUT)
+    assert 'Requires-Dist: trame<4,>=3.12.0; extra == "ui"' in result
+    assert 'Requires-Dist: pywebview<7,>=6.1; extra == "ui"' in result
+
+
+def test_rewrite_metadata_preserves_headers() -> None:
+    """Non-``Requires-Dist`` headers (Name, Version, etc.) pass through verbatim."""
+    result = strip_mod.rewrite_metadata(METADATA_INPUT)
+    for header in (
+        "Metadata-Version: 2.4",
+        "Name: mmgpy",
+        "Version: 0.15.0",
+        "Requires-Python: >=3.10",
+    ):
+        assert header in result, header
+
+
+def test_rewrite_metadata_raises_when_numpy_missing() -> None:
+    """Refuse to silently drop numpy from a wheel that depends on it."""
+    no_numpy = "\n".join(
+        line
+        for line in METADATA_INPUT.splitlines()
+        if not line.startswith("Requires-Dist: numpy")
+    )
+    with pytest.raises(SystemExit, match="numpy"):
+        strip_mod.rewrite_metadata(no_numpy + "\n")
+
+
+def test_rewrite_metadata_normalises_underscores() -> None:
+    """``typing_extensions`` is matched against the canonical PEP 503 spelling."""
+    input_text = METADATA_INPUT.replace("typing-extensions", "typing_extensions")
+    result = strip_mod.rewrite_metadata(input_text)
+    assert "typing_extensions" not in result
+    assert "typing-extensions" not in result
+
+
+def _b64_sha256(data: bytes) -> str:
+    return (
+        "sha256="
+        + base64
+        .urlsafe_b64encode(
+            hashlib.sha256(data).digest(),
+        )
+        .rstrip(b"=")
+        .decode()
+    )
+
+
+def test_rewrite_record_updates_metadata_entry() -> None:
+    """The METADATA line's hash and size are refreshed; other lines pass through."""
+    new_metadata = b"a fresh metadata body"
+    record = (
+        "mmgpy/__init__.py,sha256=abc,123\n"
+        "mmgpy-0.15.0.dist-info/METADATA,sha256=oldhash,999\n"
+        "mmgpy-0.15.0.dist-info/RECORD,,\n"
+    )
+    result = strip_mod.rewrite_record(
+        record,
+        "mmgpy-0.15.0.dist-info/METADATA",
+        new_metadata,
+    )
+    expected_hash = _b64_sha256(new_metadata)
+    expected_size = str(len(new_metadata))
+    assert f"mmgpy-0.15.0.dist-info/METADATA,{expected_hash},{expected_size}" in result
+    # Other lines untouched.
+    assert "mmgpy/__init__.py,sha256=abc,123" in result
+    assert "mmgpy-0.15.0.dist-info/RECORD,," in result
+
+
+def test_rewrite_record_raises_when_metadata_path_missing() -> None:
+    """Refuse to silently produce a RECORD without an updated METADATA entry."""
+    record = "mmgpy/__init__.py,sha256=abc,123\n"
+    with pytest.raises(SystemExit, match="no entry"):
+        strip_mod.rewrite_record(
+            record,
+            "mmgpy-0.15.0.dist-info/METADATA",
+            b"body",
+        )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("typing_extensions", "typing-extensions"),
+        ("typing-extensions", "typing-extensions"),
+        ("Typing.Extensions", "typing-extensions"),
+        ("PyVista", "pyvista"),
+        ("numpy", "numpy"),
+    ],
+)
+def test_normalize_pep503(raw: str, expected: str) -> None:
+    """Names match PEP 503: lower-case, with ``-``/``_``/``.`` collapsed to ``-``."""
+    assert strip_mod._normalize(raw) == expected


### PR DESCRIPTION
## Summary

Derives a slim "core" variant of the mmgpy wheel for the Blender bundle by rewriting the wheel's METADATA at CI time. The PyPI mmgpy wheel keeps its full ``Requires-Dist``; only the copy inside the Blender extension zip is rewritten.

After this PR, the bundled wheel:
- Drops ``pyvista``, ``scipy``, ``rich``, ``patchelf``, ``typing-extensions`` from ``Requires-Dist``.
- Loosens ``numpy>=2.0.2,<3`` to ``numpy>=1.26,<3`` so Blender 4.2 LTS (numpy 1.26) is covered alongside Blender 5.0 (numpy 2.x).
- Keeps the compiled ``_mmgpy.so`` and every Python module untouched.

## Changes

- ``.github/scripts/strip_blender_wheel_metadata.py``: stdlib-only script that unpacks the wheel, rewrites METADATA, recomputes the METADATA entry in RECORD, repacks.
- ``.github/workflows/build-blender-extension.yml``: invokes the script on the bundled wheel after the matching-ABI filter, then verifies the resulting METADATA no longer contains the stripped deps and that numpy is loosened.

## Notes

- Tested locally on a real mmgpy wheel: METADATA + RECORD stay consistent, ``pip install --no-deps`` succeeds.
- Runtime safety relies on the lazy ``__getattr__`` in ``mmgpy/__init__.py`` (shipped in #285/#286): ``import mmgpy`` doesn't touch pyvista/scipy/rich, so the Blender path never reaches them.