### PR TITLE
fix(windows): vendor MSVC runtime so wheels load in Blender 4.2/4.5/5.0 (#299)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -95,6 +95,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.0.0
+      # ``repair-wheel-command`` is overridden in pyproject.toml so that
+      # delvewheel vendors the MSVC runtime into ``mmgpy.libs/`` (see #299).
+      # Overriding the default also disables cibuildwheel's auto-install of
+      # delvewheel, so we put it on PATH ourselves. ``uv tool install``
+      # links the entry-point into uv's tool bin dir, which setup-uv has
+      # already added to PATH for the rest of the job (cibuildwheel
+      # subprocesses inherit it).
+      - name: Install delvewheel for the override repair-wheel-command
+        shell: bash
+        run: uv tool install delvewheel
       - name: Build wheels
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows wheels now vendor the MSVC runtime (MSVCP140 / VCRUNTIME140 / Concrt140 family) into `mmgpy.libs/` with mangled names via `delvewheel --add-dll`. Without this, hosts that preload an older MSVC runtime — notably Blender 4.2 LTS / 4.5 / 5.0, which ship `MSVCP140.dll 14.29` in `blender.crt` — would hand our wheel that older copy via the Windows loader's basename cache, and the first call into a 14.40+-only stdlib symbol (e.g. inside `std::this_thread::yield`) crashed Blender on add-on enable ([#299](https://github.com/kmarchais/mmgpy/issues/299)).
+
 ## [0.12.0] - 2026-05-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,17 @@ repair-wheel-command = "cp {wheel} {dest_dir}/"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
+# Force delvewheel to vendor the MSVC runtime into ``mmgpy.libs/`` with
+# mangled names. Without ``--add-dll``, delvewheel treats MSVCP140 /
+# VCRUNTIME140 as "system" DLLs and leaves the .pyd importing them by
+# basename. That breaks inside hosts that preload an older MSVC runtime —
+# notably Blender 4.2 LTS / 4.5 / 5.0, which ship MSVCP140 14.29 in
+# ``blender.crt``; the Windows loader's basename cache then hands our
+# wheel that older copy and we crash on the first stdlib call that
+# requires 14.40+ symbols (issue #299). Mangled, vendored copies cannot
+# collide and are guaranteed to match what the binaries were built
+# against.
+repair-wheel-command = "delvewheel repair --add-dll \"msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;msvcp140_atomic_wait.dll;msvcp140_codecvt_ids.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll\" -w {dest_dir} {wheel}"
 
 [tool.coverage.run]
 source = ["src/mmgpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,7 +392,12 @@ archs = ["AMD64"]
 # requires 14.40+ symbols (issue #299). Mangled, vendored copies cannot
 # collide and are guaranteed to match what the binaries were built
 # against.
-repair-wheel-command = "delvewheel repair --add-dll \"msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;msvcp140_atomic_wait.dll;msvcp140_codecvt_ids.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll\" -w {dest_dir} {wheel}"
+# ``--exclude`` the mmg DLLs because they already sit in ``mmgpy/`` next
+# to the .pyd (the loader's ``LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`` finds
+# them there at runtime). Without ``--exclude`` delvewheel tries to
+# resolve them via the Windows DLL search path, doesn't find them, and
+# aborts with ``FileNotFoundError: Unable to find library: mmg2d.dll``.
+repair-wheel-command = "delvewheel repair --add-dll \"msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;msvcp140_atomic_wait.dll;msvcp140_codecvt_ids.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll\" --exclude \"mmg2d.dll;mmg3d.dll;mmgs.dll\" -w {dest_dir} {wheel}"
 
 [tool.coverage.run]
 source = ["src/mmgpy"]


### PR DESCRIPTION
## Summary

Fixes [#299](https://github.com/kmarchais/mmgpy/issues/299). The Windows wheel's `_mmgpy.<abi>-win_amd64.pyd` imports `MSVCP140.dll` by basename. Blender 4.2 LTS, 4.5 LTS, and 5.0 ship **MSVCP140 14.29.30139.0** in `blender.crt` and load it at startup. When the add-on imports `mmgpy._mmgpy`, the Windows loader's basename cache hands our wheel that 14.29 copy, but the wheel was built against MSVCP140 14.40+. The first stdlib call that needs a newer symbol (crash seen near `std::this_thread::yield`) takes Blender down. Blender 5.1 ships MSVCP140 14.44, which is forward-compatible, so it was unaffected — matching the issue exactly.

The wheel already shipped a newer MSVCP140 in `bin/msvcp140.dll`, but `cibuildwheel`'s default `delvewheel` invocation treats MSVCP140 / VCRUNTIME140 as "system DLLs" and leaves the .pyd importing them by basename. With the basename matching Blender's preloaded copy, our bundled DLL is never picked up.

## Fix

`pyproject.toml [tool.cibuildwheel.windows]` now overrides `repair-wheel-command` to pass `--add-dll msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;msvcp140_atomic_wait.dll;msvcp140_codecvt_ids.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll` to delvewheel. This vendors those DLLs into `mmgpy.libs/` with hash-mangled names and rewrites the `.pyd` import table to reference the mangled names, so the loader's basename cache can never substitute the host's older copy.

## Reproduction

Tested locally by running the same `delvewheel repair --add-dll ...` command on the currently-shipped `mmgpy-0.15.1-cp311-cp311-win_amd64.whl` and importing the result inside each Blender:

| Blender   | MSVCP140 (in blender.crt) | Before fix | After fix |
|-----------|---------------------------|------------|-----------|
| 4.2.21 LTS | 14.29.30139.0 | `EXCEPTION_ACCESS_VIOLATION` in MSVCP140.dll | `import mmgpy` OK, `MmgMeshS()` constructs |
| 4.5.10 LTS | 14.29.30139.0 | `EXCEPTION_ACCESS_VIOLATION` in MSVCP140.dll | `import mmgpy` OK, `MmgMeshS()` constructs |
| 5.0.1     | 14.29.30139.0 | `EXCEPTION_ACCESS_VIOLATION` in MSVCP140.dll | `import mmgpy` OK, `MmgMeshS()` constructs |
| 5.1.2     | 14.44.35211.0 | already worked (forward compat) | still works |

## Impact on the Python library

- Wheel size grows by ~1.5 MB on Windows (MSVC runtime DLLs).
- No source code changes; the patch is applied post-build by delvewheel. Editable installs and `pip install -e .` are unaffected.
- PyPI users also benefit: anyone running mmgpy inside a process that preloads an older MSVCP140 (other VFX hosts, embedded Python, exotic CI images) was vulnerable to the same crash and now gets our vendored copy.

## Test plan

- [ ] Build Wheels CI succeeds on Windows
- [ ] Resulting `mmgpy-*-cp{311,313}-*-win_amd64.whl` contains a `mmgpy.libs/` folder with `msvcp140-<hash>.dll` and friends, and `_mmgpy.*.pyd`'s import table references the mangled name
- [ ] Build Blender Extension CI succeeds and bundles the repaired wheel
- [ ] Manual install of the resulting extension zip in Blender 4.2 / 4.5 / 5.0 / 5.1 successfully enables the add-on