### PR TITLE
fix(release): keep uv.lock in sync with version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,8 @@ jobs:
           git checkout -b "$RELEASE_BRANCH"
 
           uv run --no-project python .github/scripts/sync_versions.py --set "${TARGET}"
-          git add pyproject.toml conda/recipe.yaml blender_mmgpy/blender_manifest.toml
+          uv lock
+          git add pyproject.toml conda/recipe.yaml blender_mmgpy/blender_manifest.toml uv.lock
           git commit -m "release: v${TARGET}"
 
           # Tag the release commit before stacking any bump on top, so the
@@ -237,7 +238,8 @@ jobs:
 
           if [ "$BUMP_MAIN" = "true" ]; then
             uv run --no-project python .github/scripts/sync_versions.py --set "${NEXT_DEV}"
-            git add pyproject.toml conda/recipe.yaml blender_mmgpy/blender_manifest.toml
+            uv lock
+            git add pyproject.toml conda/recipe.yaml blender_mmgpy/blender_manifest.toml uv.lock
             git commit -m "chore: bump to ${NEXT_DEV}"
             git push origin "$RELEASE_BRANCH"
           fi

--- a/uv.lock
+++ b/uv.lock
@@ -1441,7 +1441,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.16.0.dev0"
+version = "0.17.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Release workflow rewrote `pyproject.toml` but left `uv.lock` stale, so `uv sync` on main resolves with a version mismatch and the benchmark CI fails.

## Changes

- `release.yml`: run `uv lock` after each `sync_versions.py --set`, stage `uv.lock` in both the release commit and the dev-bump commit
- `uv.lock`: regenerate against current main (`mmgpy 0.16.0.dev0 -> 0.17.0.dev0`) to clear the existing drift