### PR TITLE
ci: harden action pins (closes #303)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+# Dependabot keeps mechanical churn off our plates; manual audits still
+# handle judgment calls (upper-bound caps, stale workarounds, breaking
+# majors). See dependency-audit.md §11 for the rationale behind the
+# groups and ignore rules below.
+
+version: 2
+updates:
+  # ---- GitHub Actions ---------------------------------------------------
+  # SHA-pinned third-party actions get auto-PRs with a fresh SHA + version
+  # comment so we never silently track a mutable tag. First-party
+  # actions/* use floating majors so most weeks there is nothing to do.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions-core:
+        patterns:
+          - "actions/*"
+      actions-third-party:
+        patterns:
+          - "*/*"
+        exclude-patterns:
+          - "actions/*"
+    ignore:
+      # cibuildwheel majors will drop Python 3.x build targets and change
+      # default Windows repair tool defaults — staged migration, not auto.
+      - dependency-name: "pypa/cibuildwheel"
+        update-types: ["version-update:semver-major"]
+
+  # ---- Python (uv) ------------------------------------------------------
+  # Dependabot's uv support refreshes uv.lock (security advisories,
+  # transitive pins). It does not edit pyproject.toml floors today, so
+  # this slot mostly catches CVE-driven lock bumps; manual floor bumps
+  # stay with the maintainer.
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "mypy"
+          - "pytest-cov"
+          - "mkdocstrings-python"
+          - "ruff"
+    ignore:
+      # `build` 1.5+ drops Python 3.9; hold until we drop 3.9 too.
+      - dependency-name: "build"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
+      # mypy is being replaced by ty — see issue #309.
+      - dependency-name: "mypy"
+      # Majors need staged migration PRs (see issues #308 / #305).
+      - dependency-name: "pytest-cov"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mkdocstrings-python"
+        update-types: ["version-update:semver-major"]
+      # ruff ships rule churn in patch releases; humans triage.
+      - dependency-name: "ruff"
+        update-types: ["version-update:semver-patch"]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: qtbase5-dev qt5-qmake libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev
           version: 1.0
 
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.12"
           enable-cache: true
@@ -46,7 +46,7 @@ jobs:
             --benchmark-disable-gc
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: "pytest"
           output-file-path: benchmark-results.json
@@ -76,12 +76,12 @@ jobs:
           fetch-depth: 0
 
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: qtbase5-dev qt5-qmake libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev
           version: 1.0
 
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.12"
           enable-cache: true
@@ -179,7 +179,7 @@ jobs:
           EOF
 
       - name: Comment benchmark summary on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml

--- a/.github/workflows/build-blender-extension.yml
+++ b/.github/workflows/build-blender-extension.yml
@@ -116,7 +116,7 @@ jobs:
       # and embed the wrong version in the extension zip name and manifest.
       # Pin to the upstream run's head_branch (e.g. ``v0.14.0``) so the
       # version matches the wheels we are bundling.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: >-
             ${{ github.event_name == 'workflow_run'
@@ -124,18 +124,18 @@ jobs:
                 || github.ref }}
 
       - name: Set up Python ${{ matrix.py }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Sync version + dependency pin from pyproject.toml
         run: uv run --no-project python .github/scripts/sync_versions.py
 
       - name: Download wheels artifact from build-wheels run
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.wheels_artifact }}
           path: blender_mmgpy/wheels/
@@ -359,7 +359,7 @@ jobs:
           PY
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: blender-extension-${{ matrix.platform }}-py${{ matrix.py }}
           path: blender_mmgpy/${{ steps.zip.outputs.path }}
@@ -394,7 +394,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: >-
             ${{ github.event_name == 'workflow_run'
@@ -402,12 +402,12 @@ jobs:
                 || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Download per-(OS, Python) artifacts for this OS
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: blender-extension-${{ matrix.os }}-py*
           path: intermediates/
@@ -557,7 +557,7 @@ jobs:
           PY
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: blender-extension-release-${{ matrix.os }}
           path: ${{ steps.per_os.outputs.path }}
@@ -591,7 +591,7 @@ jobs:
 
     steps:
       - name: Download per-OS extension artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: blender-extension-release-*
           merge-multiple: true
@@ -667,7 +667,7 @@ jobs:
       # Need the manifest at the release ref so the extension id matches
       # the version we are publishing (see the ``upload-to-release`` ref
       # logic for why we cannot use the default checkout on workflow_run).
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: >-
             ${{ github.event_name == 'workflow_run'
@@ -682,7 +682,7 @@ jobs:
           echo "Extension id: $ext_id"
 
       - name: Download per-OS extension artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: blender-extension-release-*
           merge-multiple: true

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build manylinux_2_28 x86_64 wheels
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           CIBW_ARCHS_LINUX: x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3.4.1
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -60,13 +60,13 @@ jobs:
     runs-on: ubuntu-24.04-arm # Native ARM runner (no QEMU needed)
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build manylinux_2_28 aarch64 wheels
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3.4.1
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -94,7 +94,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       # ``repair-wheel-command`` is overridden in pyproject.toml so that
       # delvewheel vendors the MSVC runtime into ``mmgpy.libs/`` (see #299).
       # Overriding the default also disables cibuildwheel's auto-install of
@@ -108,7 +108,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3.4.1
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -136,11 +136,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build wheels
         env:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@v3.4.1
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install build dependencies
         run: |
@@ -208,7 +208,7 @@ jobs:
           # examples_test.py discovers examples via `git ls-files`, so the
           # checkout must include the .git directory.
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
       - name: Install GL and start Xvfb
@@ -344,7 +344,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Wait for TestPyPI to index package
         shell: bash
@@ -438,11 +438,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
       - run: uv python install 3.12
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libvtk9-dev qtbase5-dev qt5-qmake libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev
           version: 1.0

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Build conda package
-        uses: prefix-dev/rattler-build-action@v0.2.36
+        uses: prefix-dev/rattler-build-action@ca874f064b8716c9da7cb420cf9affa13a5899d8 # v0.2.38
         with:
           recipe-path: conda/recipe.yaml
           artifact-name: conda-package-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -32,7 +32,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libvtk9-dev qtbase5-dev qt5-qmake libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev
           version: 1.0
@@ -65,7 +65,7 @@ jobs:
 
       - name: Comment PR preview link
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const previewUrl = `https://kmarchais.github.io/mmgpy/pr-${{ github.event.pull_request.number }}/`;

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -9,6 +9,6 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: astral-sh/setup-uv@v8.1.0
-      - uses: j178/prek-action@v2.0.3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.github/workflows/redeploy-docs.yml
+++ b/.github/workflows/redeploy-docs.yml
@@ -43,13 +43,13 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
       - run: uv python install 3.12
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libvtk9-dev qtbase5-dev qt5-qmake libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev
           version: 1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Compute target + next dev versions
         id: compute
@@ -220,7 +220,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Stage release commit (+ bump for minor/major)
         run: |

--- a/.github/workflows/update-image-baselines.yml
+++ b/.github/workflows/update-image-baselines.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: astral-sh/setup-uv@v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
           enable-cache: true


### PR DESCRIPTION
Closes #303. From the dependency audit, `dependency-audit.md` §10 (PR A).

## Summary
- All third-party actions pinned to full-length commit SHA (with `# vX.Y.Z` comment); first-party `actions/*` and `pypa/*` keep floating refs
- `codecov-action` v5 → v6.0.1 (patches template-injection VULN-1652)
- `awalsh128/cache-apt-pkgs-action@latest` → SHA pin (was mutable tag — supply-chain risk, see tj-actions Mar 2025)
- Five `actions/*` standardized across all workflows (drift removed)
- `.github/dependabot.yml` added to keep both ecosystems current going forward

## Pinning policy
| Tier | Examples | Pin style |
|---|---|---|
| First-party GitHub | `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `actions/download-artifact`, `actions/github-script` | Floating major (`@v6`) |
| PyPA | `pypa/cibuildwheel`, `pypa/gh-action-pypi-publish` | Exact (`@v3.4.1`) / maintainer-recommended (`@release/v1`) |
| Third-party | `astral-sh/*`, `codecov/*`, `awalsh128/*`, `benchmark-action/*`, `j178/*`, `prefix-dev/*` | SHA pin + `# vX.Y.Z` comment |

`astral-sh/setup-uv` requires non-floating refs since v8.0.0; the maintainer cites the tj-actions compromise as the precedent. Applying the same logic to all third-party actions follows GitHub's hardening guidance and OpenSSF Scorecard recommendations.

## Changes
- Standardized: `checkout@v6`, `setup-python@v6`, `upload-artifact@v7`, `download-artifact@v8`, `github-script@v9`
- SHA-pinned: `setup-uv` (v8.1.0), `cache-apt-pkgs-action` (v1.6.0), `github-action-benchmark` (v1.22.1), `codecov-action` (v6.0.1), `test-results-action` (v1.2.1), `prek-action` (v2.0.4), `rattler-build-action` (v0.2.38)
- Version bump: `cibuildwheel@v3.4` → `@v3.4.1`
- New: `.github/dependabot.yml` with grouped weekly PRs for both `github-actions` and `uv` ecosystems, with ignores tuned to the open issues (#308, #309, #305)

## Notes
- `download-artifact@v4` → `@v8` changed artifact path semantics in v5; release/publish chain should be exercised end-to-end before relying on it.
- `codecov/test-results-action` is being deprecated in favor of `codecov-action@v6+`; keeping it pinned for now, migration tracked separately.