### PR TITLE
build: bump pybind11, scikit-build-core, CMake floor (closes #304)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25)
 
 # Set CMP0177 policy
 if(POLICY CMP0177)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - C++17 compiler (GCC 9+, Clang 10+, MSVC 2019+)
 - CMake 3.25+
 - Git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 
 - Python 3.9+
 - C++17 compiler (GCC 9+, Clang 10+, MSVC 2019+)
-- CMake 3.18+
+- CMake 3.25+
 - Git
 
 ### Quick Start

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -90,10 +90,10 @@ pip install git+https://github.com/kmarchais/mmgpy.git
 
 Building from source requires:
 
-- CMake >= 3.15
+- CMake >= 3.25
 - C++ compiler with C++17 support
-- pybind11 >= 3.0.0
-- scikit-build-core >= 0.11.5
+- pybind11 >= 3.0.4
+- scikit-build-core >= 0.12.2
 
 ## Verifying Installation
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25)
 
 include(FetchContent)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "scikit-build-core>=0.11.5",
-    "pybind11>=3.0.0",
+    "scikit-build-core>=0.12.2",
+    "pybind11>=3.0.4",
     # Add numpy to build requirements for headers
     "numpy>=2.0.2",
     # patchelf is needed during install to set RPATH on Linux
@@ -64,7 +64,7 @@ no-build-isolation-package = ["mmgpy"]
 [tool.scikit-build]
 # Build configuration
 build.verbose = true
-cmake.version = ">=3.15"
+cmake.version = ">=3.25"
 cmake.args = ["-DCMAKE_BUILD_TYPE=Release"]
 cmake.define = { BUILD_TESTING = "OFF", BUILD_SHARED_LIBS = "ON", MMGPY_SKIP_EXECUTABLES = "OFF" }
 
@@ -109,8 +109,8 @@ mmgpy-ui = "mmgpy.ui.__main__:main"
 [dependency-groups]
 dev = [
     # Build dependencies (needed for editable installs without build isolation)
-    "scikit-build-core>=0.11.5",
-    "pybind11>=3.0.0",
+    "scikit-build-core>=0.12.2",
+    "pybind11>=3.0.4",
     "numpy>=2.0.2",
     # Dev tools
     "build>=1.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1525,7 +1525,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "prek", specifier = ">=0.4" },
-    { name = "pybind11", specifier = ">=3.0.0" },
+    { name = "pybind11", specifier = ">=3.0.4" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-benchmark", specifier = ">=5.0.0" },
     { name = "pytest-codeblocks", specifier = ">=0.17.0" },
@@ -1533,7 +1533,7 @@ dev = [
     { name = "pytest-pyvista", specifier = ">=0.2" },
     { name = "pyvista", specifier = ">=0.48,<1" },
     { name = "ruff", specifier = ">=0.15" },
-    { name = "scikit-build-core", specifier = ">=0.11.5" },
+    { name = "scikit-build-core", specifier = ">=0.12.2" },
 ]
 docs = [
     { name = "mike", git = "https://github.com/squidfunk/mike.git?rev=0f62791256ebeba60d20d2f1d8fe6ec3b7d1e2b3" },


### PR DESCRIPTION
Closes #304. From the dependency audit (`dependency-audit.md` §10, PR B).

## Summary
- `pybind11` 3.0.0 → **3.0.4** in both `[build-system.requires]` and `[dependency-groups].dev`
- `scikit-build-core` 0.11.5 → **0.12.2** in both
- CMake floor 3.15 → **3.25** in `CMakeLists.txt`, `extern/CMakeLists.txt`, and `[tool.scikit-build].cmake.version`
- `uv.lock` refreshed (pybind11 3.0.1 → 3.0.4, scikit-build-core 0.11.6 → 0.12.2)

## Why
- **pybind11 3.0.2-3.0.4**: free-threaded Python (3.13t / 3.14t) hardening directly relevant to our `cp314t-*` cibuildwheel targets; 10 stability fixes (TSS key exhaustion, `pythonbuf` heap-buffer-overflow, virtual-inheritance crashes); Eigen 5 compat. ABI-compatible with 3.0.0.
- **scikit-build-core 0.12.0-0.12.2**: 32-bit Windows wheel regression fix, `_PYTHON_HOST_PLATFORM` env-var support for cibuildwheel cross-builds, Python 3.14 testing.
- **CMake 3.25** (Nov 2022): `block()` scope, `FetchContent` `SYSTEM`/`EXCLUDE_FROM_ALL` ergonomics, modern policy defaults. 3.15 is from July 2019. 3.25 is ubiquitous in CI runners.

Note: `pypa/cibuildwheel` → `v3.4.1` was already shipped in #311.