### PR TITLE
ci(benchmark): serialize gh-pages push with mike deploys

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,13 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
+    # Share the gh-pages mutex with mike deploys (docs.yml, redeploy-docs.yml,
+    # build-wheels.yml deploy-versioned-docs). Without this, the benchmark
+    # auto-push step can interleave with a mike push and reject it with a
+    # non-fast-forward error.
+    concurrency:
+      group: docs-deploy
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add \`concurrency: docs-deploy\` to the \`benchmark\` job so its \`auto-push\` to gh-pages serializes with mike deploys

## Why
PR #314's docs deploy failed with \`! [rejected] gh-pages -> gh-pages (fetch first)\`. Root cause: the \`benchmark.yml\` job pushes to gh-pages but was the only gh-pages-touching workflow NOT in the \`docs-deploy\` concurrency group. Timeline of that incident:

- 12:41:26 — PR #314's mike fetched gh-pages
- 12:42:13 — \`benchmark.yml\` pushed a benchmark result to gh-pages
- 12:42:41 — PR #314's mike push rejected (remote moved)

Adding the same concurrency gate the other three workflows already use (\`docs.yml\`, \`redeploy-docs.yml\`, \`build-wheels.yml deploy-versioned-docs\`) fixes the race.

## Notes
- Only the \`benchmark\` job (push events) needs the gate — \`benchmark-pr\` doesn't push to gh-pages.
- \`cancel-in-progress: false\` matches the other docs-deploy jobs (queue, don't kill).