### PR TITLE
docs(deps): unpin pygments, bump mkdocstrings-python/zensical/mike (closes #305)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,14 +127,12 @@ dev = [
     "pyvista>=0.48,<1",
 ]
 docs = [
-    "mike @ git+https://github.com/squidfunk/mike.git@0f62791256ebeba60d20d2f1d8fe6ec3b7d1e2b3",
-    "mkdocstrings-python>=0.24.0",
-    # Pygments 2.20 strictened html.escape to reject None; pymdownx 10.20 still
-    # passes filename=None for separate-signature blocks rendered by
-    # mkdocstrings, which silently kills the build. Pin until pymdownx
-    # ships a fix.
-    "pygments<2.21",
-    "zensical>=0.0.28",
+    "mike @ git+https://github.com/squidfunk/mike.git@2d4ad799442f4592db8ad53b179bfb33db8c69ac",
+    "mkdocstrings-python>=2.0.0,<3",
+    # Belt-and-braces: pymdown-extensions 10.21.2 fixed the html.escape(None)
+    # crash that previously forced a `pygments<2.20` cap (see git history).
+    "pymdown-extensions>=10.21.2",
+    "zensical>=0.0.41,<0.1",
 ]
 ui = [
     "pywebview>=6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1344,7 +1344,7 @@ wheels = [
 [[package]]
 name = "mike"
 version = "2.2.0+zensical.0.1.0"
-source = { git = "https://github.com/squidfunk/mike.git?rev=0f62791256ebeba60d20d2f1d8fe6ec3b7d1e2b3#0f62791256ebeba60d20d2f1d8fe6ec3b7d1e2b3" }
+source = { git = "https://github.com/squidfunk/mike.git?rev=2d4ad799442f4592db8ad53b179bfb33db8c69ac#2d4ad799442f4592db8ad53b179bfb33db8c69ac" }
 dependencies = [
     { name = "jinja2" },
     { name = "pyparsing" },
@@ -1488,7 +1488,7 @@ dev = [
 docs = [
     { name = "mike" },
     { name = "mkdocstrings-python" },
-    { name = "pygments" },
+    { name = "pymdown-extensions" },
     { name = "zensical" },
 ]
 ui = [
@@ -1536,10 +1536,10 @@ dev = [
     { name = "scikit-build-core", specifier = ">=0.12.2" },
 ]
 docs = [
-    { name = "mike", git = "https://github.com/squidfunk/mike.git?rev=0f62791256ebeba60d20d2f1d8fe6ec3b7d1e2b3" },
-    { name = "mkdocstrings-python", specifier = ">=0.24.0" },
-    { name = "pygments", specifier = "<2.21" },
-    { name = "zensical", specifier = ">=0.0.28" },
+    { name = "mike", git = "https://github.com/squidfunk/mike.git?rev=2d4ad799442f4592db8ad53b179bfb33db8c69ac" },
+    { name = "mkdocstrings-python", specifier = ">=2.0.0,<3" },
+    { name = "pymdown-extensions", specifier = ">=10.21.2" },
+    { name = "zensical", specifier = ">=0.0.41,<0.1" },
 ]
 ui = [
     { name = "pywebview", specifier = ">=6.1" },


### PR DESCRIPTION
Closes #305. From the dependency audit (\`dependency-audit.md\` §10, PR C).

## Summary
- Remove `pygments<2.21` cap entirely — the upstream issue (pymdownx html.escape(None) crash) was fixed in pymdown-extensions 10.21.2
- Add `pymdown-extensions>=10.21.2` as belt-and-braces in case a future docs dep pulls in an older version
- Bump `mkdocstrings-python` floor `>=0.24.0` → `>=2.0.0,<3` (currently lock had 2.0.1; major-line bump captures 25+ releases of features and the v2 deprecation cleanup)
- Bump `zensical` floor `>=0.0.28` → `>=0.0.41,<0.1` (macros + table-reader parity; pre-1.0 so the upper cap prevents surprise breakage)
- Bump mike git pin `0f62791` → `2d4ad79` (latest fork head — 2 commits: \`Fix config with defaults\` + \`Add to defaults\`)

## Why now
Dependabot's #316 + #318 had already widened the pygments cap from \`<2.20\` → \`<2.21\` and refreshed the lock, but couldn't:
- Make the judgment call to remove the cap entirely
- Bump pyproject floors (only refreshes \`uv.lock\`)
- Update the git+sha mike pin

This PR finishes what Dependabot started, per the audit's plan.

## Verification
- \`uv run zensical build\` succeeds locally with the new deps (same 8 pre-existing warnings about broken anchors/links — none introduced by this PR)
- \`uv lock --check\` clean