### PR TITLE
deps: migrate pytest-codeblocks → pytest-examples for doc code blocks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,14 +38,14 @@ jobs:
       - run: uv sync --extra fem -v
       - run: uv run python -c "import mmgpy"
       - name: Run tests with coverage
-        run: uv run pytest --ignore=tests/examples_test.py --cov=src/mmgpy --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+        run: uv run pytest --ignore=tests/examples_test.py --ignore=tests/docs_test.py --cov=src/mmgpy --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Test documentation code blocks
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         env:
           PYVISTA_OFF_SCREEN: "true"
           MPLBACKEND: Agg
-        run: uv run pytest --codeblocks docs/ -v
+        run: uv run pytest tests/docs_test.py -v
 
       - name: Run examples
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -236,7 +236,7 @@ jobs:
           # pytest-pyvista's plugin import at module load time.
           uv pip install --python .venv/bin/python --find-links wheelhouse 'mmgpy[pyvista]'
           # fedoo is needed for the elasticity_propagation example.
-          uv pip install --python .venv/bin/python pytest pytest-codeblocks pytest-pyvista fedoo
+          uv pip install --python .venv/bin/python pytest pytest-examples pytest-pyvista fedoo
       - name: Verify the installed mmgpy is the wheel
         run: |
           .venv/bin/python -c "import mmgpy; print(mmgpy.__version__, mmgpy.__file__); assert 'site-packages' in mmgpy.__file__"
@@ -244,7 +244,7 @@ jobs:
         env:
           PYVISTA_OFF_SCREEN: "true"
           MPLBACKEND: Agg
-        run: .venv/bin/pytest --codeblocks docs/ -v
+        run: .venv/bin/pytest tests/docs_test.py -v
       - name: Run examples (smoke; image-regression diffs are a build-and-test concern)
         env:
           PYVISTA_OFF_SCREEN: "true"

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -83,8 +83,6 @@ remeshed_plane = plane.mmg.remesh(hsiz=0.1)
 
 Use PyVista's `save()`:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 # MMG native (registered reader/writer)
 remeshed_volume.save("output.mesh")

--- a/docs/api/lagrangian.md
+++ b/docs/api/lagrangian.md
@@ -75,7 +75,7 @@ should call the `move`/`move_mesh` API directly.
 
 ## Accessor Method
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import numpy as np
@@ -95,7 +95,7 @@ moved = mesh.mmg.move(displacement)
 
 ### Basic Lagrangian Remeshing
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import numpy as np
@@ -120,7 +120,7 @@ print(f"Cells: {mesh.n_cells} -> {remeshed.n_cells}")
 
 Move only boundary vertices and let `move()` propagate the displacement into the interior. PyVista's `extract_surface` gives the boundary vertex set for any mesh kind:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import numpy as np
@@ -147,7 +147,7 @@ moved = mesh.mmg.move(
 
 For large deformations, use multiple sub-steps via the `n_steps` argument:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 moved = mesh.mmg.move(total_displacement, n_steps=10, hmax=0.1, verbose=-1)
@@ -157,7 +157,7 @@ moved = mesh.mmg.move(total_displacement, n_steps=10, hmax=0.1, verbose=-1)
 
 Combine with remeshing parameters:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 remeshed = mesh.mmg.move(
@@ -173,7 +173,7 @@ remeshed = mesh.mmg.move(
 
 Deform a sphere into an ellipsoid:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import numpy as np

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -89,8 +89,6 @@ remeshed = mesh.mmg.remesh()
 
 Size varying with position:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 import numpy as np
 
@@ -108,8 +106,6 @@ remeshed = mesh.mmg.remesh()
 
 Different sizes in different directions:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 import numpy as np
 
@@ -126,7 +122,7 @@ remeshed = mesh.mmg.remesh()
 
 Adapt mesh to solution curvature:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 from mmgpy.metrics import compute_hessian, create_metric_from_hessian
@@ -148,8 +144,6 @@ adapted = mesh.mmg.remesh(hgrad=2.0)
 
 Combine multiple metrics (minimum size wins):
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 sizes1 = np.ones(mesh.n_points) * 0.05
 sizes2 = np.ones(mesh.n_points) * 0.08
@@ -161,8 +155,6 @@ mesh.point_data["metric"] = combined
 ```
 
 ### Extracting Metric Information
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 metric = np.asarray(mesh.point_data["metric"])
@@ -178,8 +170,6 @@ print(f"Size range: {sizes.min():.4f} to {sizes.max():.4f}")
 ### Tensor Format Conversion
 
 MMG uses symmetric tensors in Voigt notation:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 # 3D: 6 components per vertex
@@ -198,8 +188,6 @@ tensor_back = metrics.matrix_to_tensor(matrix)
 ### Validation
 
 Check metric tensor validity:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 metric = np.asarray(mesh.point_data["metric"])

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -134,7 +134,7 @@ opt_opts = Mmg3DOptions.optimize_only()
 
 ### Converting to Dictionary
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 opts = Mmg3DOptions(hmax=0.1, hausd=0.001)
@@ -149,8 +149,6 @@ remeshed = mesh.mmg.remesh(**opts.to_dict())
 
 ### Customizing Presets
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 # Start with fine preset values, then customize
 custom = Mmg3DOptions(hmax=0.05, hausd=0.01, hgrad=1.2, verbose=1)
@@ -160,7 +158,7 @@ custom = Mmg3DOptions(hmax=0.05, hausd=0.01, hgrad=1.2, verbose=1)
 
 Options objects and keyword arguments cannot be mixed:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 # Correct: use options object
@@ -177,8 +175,6 @@ remeshed = mesh.mmg.remesh(opts, verbose=1)  # TypeError!
 
 ### For Quality Optimization
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 opts = Mmg3DOptions(
     optim=1,       # Enable optimization mode
@@ -189,8 +185,6 @@ opts = Mmg3DOptions(
 
 ### For Surface Preservation
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 opts = Mmg3DOptions(
     hmax=0.1,
@@ -200,8 +194,6 @@ opts = Mmg3DOptions(
 ```
 
 ### For CFD Meshes
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 opts = Mmg3DOptions(
@@ -214,8 +206,6 @@ opts = Mmg3DOptions(
 ```
 
 ### For FEM Meshes
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 opts = Mmg3DOptions(

--- a/docs/api/results-validation.md
+++ b/docs/api/results-validation.md
@@ -32,7 +32,7 @@ print(f"Mean quality: {q_before.mean():.3f} -> {q_after.mean():.3f}")
 
 If you need the structured `RemeshResult` (return code, MMG warnings, duration), reach for the underlying module-level entry points:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 from mmgpy import mmg3d
@@ -94,8 +94,6 @@ else:
 
 ### Detailed Validation
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 report = mesh.mmg.validate(detailed=True)
 
@@ -111,8 +109,6 @@ for issue in report.issues:
 
 ### Strict Validation
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 from mmgpy import ValidationError
 
@@ -126,8 +122,6 @@ except ValidationError as e:
 ```
 
 ### Selective Validation
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 # Only check geometry

--- a/docs/api/sizing.md
+++ b/docs/api/sizing.md
@@ -116,8 +116,6 @@ remeshed = mesh.mmg.remesh(
 
 ### Multiple Regions
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmax=0.1,

--- a/docs/blender-extension.md
+++ b/docs/blender-extension.md
@@ -170,7 +170,7 @@ against an unreleased mmgpy version, the canonical pipeline lives in
 
 In short:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 # 1. Build the mmgpy wheel into ./blender_mmgpy/wheels

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,12 +1,9 @@
-"""Pytest-codeblocks fixtures for documentation code snippets.
+"""Module-level fixtures for documentation code snippets run by pytest-examples.
 
 Monkeypatches mmgpy I/O so that code blocks referencing files like
-``mmgpy.read("input.mesh")`` work without real files on disk.
-
-Since pytest-codeblocks' TestBlock inherits from pytest.Item (not
-pytest.Function), autouse fixtures are not applied. Instead, we apply
-patches at module level when this conftest is loaded, and use
-pytest_runtest_setup/teardown hooks for per-test tmp_path management.
+``mmgpy.read("input.mesh")`` work without real files on disk. Patches are
+applied at module load time and apply to every code block exec'd by the
+pytest-examples runner in ``tests/test_docs.py``.
 """
 
 from __future__ import annotations
@@ -31,7 +28,7 @@ pv.OFF_SCREEN = True
 
 # ---------------------------------------------------------------------------
 # Mesh factories — use scipy/numpy only (no VTK objects) to avoid segfaults
-# when pytest-codeblocks runs code via exec() with PyPI VTK wheels.
+# when pytest-examples runs code via exec() with PyPI VTK wheels.
 # ---------------------------------------------------------------------------
 
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -31,7 +31,7 @@ os.environ["PYVISTA_OFF_SCREEN"] = "true"
 pv.OFF_SCREEN = True
 
 # ---------------------------------------------------------------------------
-# Mesh factories — use scipy/numpy only (no VTK objects) to avoid segfaults
+# Mesh factories: use scipy/numpy only (no VTK objects) to avoid segfaults
 # when pytest-examples runs code via exec() with PyPI VTK wheels.
 # ---------------------------------------------------------------------------
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,9 +1,13 @@
-"""Module-level fixtures for documentation code snippets run by pytest-examples.
+"""Helpers for documentation code-snippet tests.
 
-Monkeypatches mmgpy I/O so that code blocks referencing files like
-``mmgpy.read("input.mesh")`` work without real files on disk. Patches are
-applied at module load time and apply to every code block exec'd by the
-pytest-examples runner in ``tests/test_docs.py``.
+Monkeypatches mmgpy / PyVista I/O so doc code blocks that reference files
+like ``mmgpy.read("input.mesh")`` work without real files on disk.
+
+Patches are NOT applied at import time. The runner in
+``tests/docs_test.py`` calls :func:`apply_patches` and
+:func:`restore_patches` from a session-scoped autouse fixture so the
+patches are reverted at session teardown and cannot leak into other test
+files sharing the same pytest process.
 """
 
 from __future__ import annotations
@@ -133,15 +137,19 @@ def _classify_filename(name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Module-level monkeypatches (applied once at import time)
+# Monkeypatch installers (NO side effects at import; called by the runner)
 # ---------------------------------------------------------------------------
 
 import mmgpy  # noqa: E402
 import mmgpy._io as _io_mod  # noqa: E402
 from mmgpy._mesh import Mesh  # noqa: E402
 
+# Originals captured ONCE at import, before any patching can occur.
 _real_read = _io_mod.read
 _real_save = Mesh.save
+_real_pv_read = pv.read
+_real_pv_polydata_save = pv.PolyData.save
+_real_pv_unstructured_save = pv.UnstructuredGrid.save
 
 # Temp dir for save redirects (cleaned up at process exit)
 _tmp_dir = tempfile.mkdtemp(prefix="mmgpy_docs_")
@@ -167,14 +175,6 @@ def _fake_read(
 def _patched_save(self: MeshType, filename: str | Path) -> None:
     dest = Path(_tmp_dir) / Path(filename).name
     _real_save(self, str(dest))
-
-
-_io_mod.read = _fake_read
-mmgpy.read = _fake_read
-Mesh.save = _patched_save
-
-# Also patch pv.read so docs like `pv.read("mesh.vtk")` work
-_real_pv_read = pv.read
 
 
 def _fake_pv_read(
@@ -209,13 +209,6 @@ def _fake_pv_read(
     )
 
 
-pv.read = _fake_pv_read  # type: ignore[assignment]
-
-# Patch pv.PolyData.save and pv.UnstructuredGrid.save to redirect to tmp_dir
-_real_pv_polydata_save = pv.PolyData.save
-_real_pv_unstructured_save = pv.UnstructuredGrid.save
-
-
 def _patched_pv_save(
     self: pv.PolyData | pv.UnstructuredGrid,
     filename: str,
@@ -228,21 +221,26 @@ def _patched_pv_save(
         _real_pv_unstructured_save(self, dest, **kwargs)
 
 
-pv.PolyData.save = _patched_pv_save  # type: ignore[assignment]
-pv.UnstructuredGrid.save = _patched_pv_save  # type: ignore[assignment]
+def apply_patches() -> None:
+    """Install all docs I/O monkeypatches. Idempotent."""
+    _io_mod.read = _fake_read
+    mmgpy.read = _fake_read
+    Mesh.save = _patched_save
+    pv.read = _fake_pv_read  # type: ignore[assignment]
+    pv.PolyData.save = _patched_pv_save  # type: ignore[assignment]
+    pv.UnstructuredGrid.save = _patched_pv_save  # type: ignore[assignment]
 
 
-# ---------------------------------------------------------------------------
-# Restore originals on pytest teardown (avoids polluting other test suites
-# when running `pytest tests/ docs/` in a single invocation)
-# ---------------------------------------------------------------------------
-
-
-def pytest_unconfigure() -> None:
-    """Restore all monkeypatched functions."""
+def restore_patches() -> None:
+    """Revert all docs I/O monkeypatches to their originals."""
     _io_mod.read = _real_read
     mmgpy.read = _real_read
     Mesh.save = _real_save
     pv.read = _real_pv_read  # type: ignore[assignment]
     pv.PolyData.save = _real_pv_polydata_save  # type: ignore[assignment]
     pv.UnstructuredGrid.save = _real_pv_unstructured_save  # type: ignore[assignment]
+
+
+def pytest_unconfigure() -> None:
+    """Legacy safety net if pytest ever loads this file as a real conftest."""
+    restore_patches()

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -52,7 +52,7 @@ remeshed = mesh.mmg.remesh(
 
 Remesh while applying mesh displacement.
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 """Lagrangian mesh motion remeshing."""
@@ -164,7 +164,7 @@ walkthrough.
 
 ![2D Hessian adaptation](../assets/hessian_adaptation_2d.png)
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 from mmgpy.metrics import compute_hessian, create_metric_from_hessian
@@ -192,7 +192,7 @@ demo on an L-bracket cantilever.
 
 ![Laplacian vs elasticity on a 2D L-bracket](../assets/elasticity_propagation_2d.gif)
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 from mmgpy.lagrangian import propagate_displacement_elasticity
@@ -336,7 +336,7 @@ discretized = mesh.mmg.remesh_levelset(levelset)
 
 Clone the repository and run examples:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 git clone https://github.com/kmarchais/mmgpy.git

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -88,8 +88,6 @@ print(mesh_2d.mmg.kind)  # MeshKind.TRIANGULAR_2D
 
 The default `remesh()` operation modifies the mesh topology to achieve target element sizes:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh_3d.mmg.remesh(
     hmin=0.01,
@@ -161,7 +159,7 @@ discretized = mesh.mmg.remesh_levelset(levelset)
 
 Remesh while preserving a displacement field (useful for moving meshes):
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 displacement = np.zeros((mesh.n_points, 3))
@@ -186,8 +184,6 @@ Control edge lengths globally:
 ### Local Sizing
 
 Refine specific regions with sizing constraints passed to `remesh()`:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(
@@ -249,8 +245,6 @@ mmgpy uses normalized quality measures:
 
 Per-element quality is available via the accessor:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 qualities = remeshed.mmg.element_qualities()
 
@@ -273,8 +267,6 @@ mmgpy supports 40+ file formats through PyVista. VTK-native formats (`.vtk`, `.v
 
 Use `pv.read` and `dataset.save` for everything:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 mesh = pv.read("model.stl")
 mesh.save("output.vtk")
@@ -290,8 +282,6 @@ Control output verbosity:
 | `0`   | Errors only        |
 | `1`   | Standard info      |
 | `2+`  | Debug output       |
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 silent = mesh.mmg.remesh(hmax=0.1, verbose=-1)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ The fastest way to install mmgpy:
 
 === "pip"
 
-    <!-- pytest-codeblocks:skip -->
+    <!-- mmgpy-test:skip -->
 
     ```bash
     pip install mmgpy
@@ -43,7 +43,7 @@ PyPI wheels bundle all native libraries (MMG, VTK), so no compiler or system pac
 
 If you use conda or mamba for scientific computing:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 conda install -c conda-forge mmgpy
@@ -51,7 +51,7 @@ conda install -c conda-forge mmgpy
 
 or with [pixi](https://pixi.sh/):
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 pixi add mmgpy
@@ -70,7 +70,7 @@ Use **PyPI** for the fastest, most portable setup. Use **conda-forge** when you 
 
 Lagrangian motion is available on every install channel via `mmgpy.move_mesh`. The default Laplacian propagator has no extra dependencies; the elasticity propagator requires the optional [`fedoo`](https://github.com/3MAH/fedoo) extra:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 uv pip install "mmgpy[fem]"
@@ -80,7 +80,7 @@ uv pip install "mmgpy[fem]"
 
 To install the latest development version:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 pip install git+https://github.com/kmarchais/mmgpy.git

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -147,8 +147,6 @@ remeshed.plot(color="lightblue", opacity=0.8)
 
 For custom plotters, use the dataset directly:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 plotter = pv.Plotter()
 plotter.add_mesh(remeshed, show_edges=True)

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ remeshed.save("output.vtk")
 
 === "pip"
 
-    <!-- pytest-codeblocks:skip -->
+    <!-- mmgpy-test:skip -->
 
     ```bash
     pip install mmgpy

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,7 +13,7 @@ Installing mmgpy gives you access to the MMG command-line executables:
 
 The executables are included with mmgpy:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 pip install mmgpy
@@ -21,7 +21,7 @@ pip install mmgpy
 
 If you only need the CLI tools (no Python API):
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 uv tool install mmgpy
@@ -31,7 +31,7 @@ uv tool install mmgpy
 
 The `mmg` command automatically detects the mesh type and delegates to the appropriate executable:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 mmg input.mesh -o output.mesh -hmax 0.1
@@ -45,7 +45,7 @@ This is equivalent to running `mmg3d`, `mmg2d`, or `mmgs` depending on the input
 
 ### Version Information
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 mmg --version
@@ -57,7 +57,7 @@ mmg --help
 
 ## Quick Examples
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 # Auto-detect mesh type

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -80,8 +80,6 @@ mesh = pv.read("input.mesh")
 
 Use `.mesh` format:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 mesh.save("output.mesh")
 ```
@@ -93,8 +91,6 @@ mesh.save("output.mesh")
 ### For Visualization (ParaView)
 
 Use VTK formats:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh.save("output.vtk")   # Legacy
@@ -179,8 +175,6 @@ if "temperature" in mesh.point_data:
 | Human readable | Yes                 | No              |
 | Precision      | Text representation | Full precision  |
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 # ASCII
 mesh.save("output.mesh")
@@ -229,8 +223,6 @@ Some formats do not support all features:
 ### Large Files
 
 For large meshes:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 # Use binary format

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -20,8 +20,6 @@ Minimum edge length.
 | Default  | Auto-computed |
 | Range    | > 0           |
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(hmin=0.01)
 ```
@@ -39,8 +37,6 @@ Maximum edge length.
 | Type     | `float`       |
 | Default  | Auto-computed |
 | Range    | > hmin        |
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(hmax=0.1)
@@ -60,8 +56,6 @@ Uniform target edge size.
 | Default  | None    |
 | Range    | > 0     |
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(hsiz=0.05)
 ```
@@ -79,8 +73,6 @@ Gradation parameter controlling size transition.
 | Type     | `float` |
 | Default  | 1.3     |
 | Range    | >= 1.0  |
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(hgrad=1.2)
@@ -104,8 +96,6 @@ Hausdorff distance, maximum distance between input and output geometry.
 | Default  | 0.01 \* bounding box diagonal |
 | Range    | > 0                           |
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(hausd=0.001)
 ```
@@ -123,8 +113,6 @@ Ridge detection angle (degrees).
 | Type     | `float` |
 | Default  | 45.0    |
 | Range    | 0 - 180 |
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(ar=30)
@@ -147,8 +135,6 @@ Enable optimization mode (no topology changes).
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(optim=1)
 ```
@@ -167,8 +153,6 @@ Disable vertex insertion.
 | Default  | 0               |
 | Values   | 0 (off), 1 (on) |
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(noinsert=1)
 ```
@@ -180,8 +164,6 @@ Prevents adding new vertices during remeshing.
 ### noswap
 
 Disable edge/face swapping.
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(noswap=1)
@@ -195,8 +177,6 @@ Prevents topology changes via edge/face swaps.
 
 Disable vertex movement.
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(nomove=1)
 ```
@@ -208,8 +188,6 @@ Keeps vertices at their original positions.
 ### nosurf
 
 Preserve surface vertices.
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(nosurf=1)
@@ -231,8 +209,6 @@ Verbosity level.
 | Default  | 1        |
 | Range    | -1 to 10 |
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 silent = mesh.mmg.remesh(verbose=-1)  # Silent
 errors = mesh.mmg.remesh(verbose=0)   # Errors only
@@ -246,15 +222,11 @@ debug = mesh.mmg.remesh(verbose=5)    # Debug output
 
 ### Quality optimization only
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 optimized = mesh.mmg.remesh(optim=1, noinsert=1)
 ```
 
 Or use the convenience method:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 optimized = mesh.mmg.remesh_optimize()
@@ -264,15 +236,11 @@ optimized = mesh.mmg.remesh_optimize()
 
 ### Uniform remeshing
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 uniform = mesh.mmg.remesh(hsiz=0.05)
 ```
 
 Or use the convenience method:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 uniform = mesh.mmg.remesh_uniform(size=0.05)
@@ -281,8 +249,6 @@ uniform = mesh.mmg.remesh_uniform(size=0.05)
 ---
 
 ### High-quality surface approximation
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(
@@ -296,8 +262,6 @@ remeshed = mesh.mmg.remesh(
 
 ### Preserve sharp features
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmax=0.1,
@@ -310,8 +274,6 @@ remeshed = mesh.mmg.remesh(
 
 ### Fast coarse remeshing
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmax=0.5,
@@ -323,8 +285,6 @@ remeshed = mesh.mmg.remesh(
 ---
 
 ### Volume interior only
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 remeshed = mesh.mmg.remesh(

--- a/docs/tutorials/adaptive-sizing.md
+++ b/docs/tutorials/adaptive-sizing.md
@@ -39,8 +39,6 @@ remeshed = mesh.mmg.remesh(
 
 Multiple spheres can be combined; where they overlap, the minimum size wins:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmax=0.1,
@@ -85,7 +83,7 @@ remeshed = mesh.mmg.remesh(
 
 For 2D meshes pass 2D bounds:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 remeshed = mesh.mmg.remesh(
@@ -188,8 +186,6 @@ remeshed = mesh.mmg.remesh(
 ## Custom Metric Fields
 
 For total control, compute the per-vertex sizing metric yourself and place it on `point_data["metric"]`. The accessor will pick it up:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 import numpy as np

--- a/docs/tutorials/basic-remeshing.md
+++ b/docs/tutorials/basic-remeshing.md
@@ -41,8 +41,6 @@ print(f"Cells:    {mesh.n_cells} -> {remeshed.n_cells}")
 
 `dataset.mmg.remesh(...)` returns a fresh PyVista dataset. Stats come from the dataset itself plus the accessor's quality helpers:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 qualities_before = mesh.mmg.element_qualities()
 qualities_after = remeshed.mmg.element_qualities()
@@ -57,8 +55,6 @@ print(f"Mean quality: {qualities_before.mean():.3f} -> {qualities_after.mean():.
 
 Control the range of edge lengths in the output mesh:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmin=0.01,  # Minimum edge length (prevents over-refinement)
@@ -67,8 +63,6 @@ remeshed = mesh.mmg.remesh(
 ```
 
 For a uniform mesh with a single target size:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 # Using hsiz parameter
@@ -84,8 +78,6 @@ uniform = mesh.mmg.remesh_uniform(size=0.05)
 
 The `hausd` parameter controls how closely the output mesh approximates the input geometry:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmax=0.1,
@@ -98,8 +90,6 @@ remeshed = mesh.mmg.remesh(
 ## Using Options Objects
 
 For complex configurations, use typed options objects:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import Mmg3DOptions
@@ -118,8 +108,6 @@ remeshed = mesh.mmg.remesh(opts)
 
 Options can also be unpacked as kwargs:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(**opts.to_dict())
 ```
@@ -127,8 +115,6 @@ remeshed = mesh.mmg.remesh(**opts.to_dict())
 ## Optimization Without Topology Changes
 
 To improve quality without inserting/removing vertices:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 mesh = pv.read("input.mesh")
@@ -144,8 +130,6 @@ This only moves existing vertices to improve element quality.
 ## Factory Presets
 
 Options classes provide factory methods for common scenarios:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import Mmg3DOptions
@@ -166,8 +150,6 @@ optimized = mesh.mmg.remesh(opt_opts)
 ## Saving Results
 
 Save the remeshed output to any supported format:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 # Save to MMG native format

--- a/docs/tutorials/elasticity-propagation.md
+++ b/docs/tutorials/elasticity-propagation.md
@@ -34,7 +34,7 @@ re-entrant corner and the foot bows visibly.
 
 ![Laplacian vs elasticity on a 2D L-bracket](../assets/elasticity_propagation_2d.gif)
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 from mmgpy.lagrangian import (
@@ -73,7 +73,7 @@ Full script:
 The accessor's `move()` method exposes the propagator via the
 `propagation_method` keyword:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import numpy as np
@@ -97,7 +97,7 @@ moved_ela = mesh.mmg.move(
 
 ## Installing the `fedoo` extra
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 uv sync --extra fem
@@ -115,7 +115,7 @@ and `propagation_method="elasticity"` need it.
 isn't reachable via `conda install mmgpy`. Install fedoo separately into
 the same environment:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```bash
 conda install -c conda-forge mmgpy

--- a/docs/tutorials/hessian-adaptation.md
+++ b/docs/tutorials/hessian-adaptation.md
@@ -36,7 +36,7 @@ in a thin ring around the front and stay coarse elsewhere.
 
 ![Uniform vs Hessian-adapted 2D mesh](../assets/hessian_adaptation_2d.png)
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import mmgpy  # noqa: F401  -- registers the .mmg accessor

--- a/docs/tutorials/levelset-extraction.md
+++ b/docs/tutorials/levelset-extraction.md
@@ -55,8 +55,6 @@ mesh = pv.read("unit_cube.mesh")
 
 ### Sphere
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 def sphere_levelset(coords, center=(0.5, 0.5, 0.5), radius=0.3):
     return (np.linalg.norm(coords - np.array(center), axis=1) - radius).reshape(-1, 1)
@@ -66,8 +64,6 @@ levelset = sphere_levelset(np.asarray(mesh.points))
 ```
 
 ### Torus
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 def torus_levelset(coords, R=0.5, r=0.15):
@@ -81,8 +77,6 @@ levelset = torus_levelset(np.asarray(mesh.points))
 ```
 
 ### Gyroid
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 def gyroid_levelset(coords, scale=2 * np.pi):
@@ -101,7 +95,7 @@ levelset = gyroid_levelset(np.asarray(mesh.points))
 
 Combine shapes using min/max operations:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 def union(ls1, ls2):
@@ -163,7 +157,7 @@ discretized = mesh.mmg.remesh_levelset(levelset)
 
 Combine level-set extraction with size parameters:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 discretized = mesh.mmg.remesh_levelset(
@@ -177,7 +171,7 @@ discretized = mesh.mmg.remesh_levelset(
 
 ## Complete Example: Implicit Domain Meshing
 
-<!--pytest-codeblocks:skip-->
+<!-- mmgpy-test:skip -->
 
 ```python
 import numpy as np
@@ -213,8 +207,6 @@ discretized.save("double_sphere.vtk")
 
 ## Visualization
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 discretized.plot(show_edges=True)
 ```
@@ -226,7 +218,7 @@ discretized.plot(show_edges=True)
 3. **Narrow band**: If your level-set is only valid near the surface, ensure the background mesh is refined in that region
 4. **Validation**: After extraction, validate the mesh to ensure quality:
 
-   <!-- pytest-codeblocks:skip -->
+   <!-- mmgpy-test:skip -->
 
    ```python
    assert discretized.mmg.validate(), "Extracted mesh has quality issues"

--- a/docs/tutorials/pyvista-integration.md
+++ b/docs/tutorials/pyvista-integration.md
@@ -172,7 +172,7 @@ print(f"Elevation range: {elevation.min():.2f} to {elevation.max():.2f}")
 
 ### Interactive Refinement
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import pyvista as pv
@@ -202,7 +202,7 @@ pl.show()
 
 ### Picking Points for Refinement
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import pyvista as pv
@@ -270,7 +270,7 @@ When mmgpy is installed, every PyVista `UnstructuredGrid` and `PolyData` instanc
 
 ### Remeshing variants
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 import pyvista as pv
@@ -298,7 +298,7 @@ carved = mesh.mmg.remesh_levelset(levelset)
 
 Pass a `local_sizing` keyword to any remesh variant. Each constraint is a dict whose `"shape"` selects the geometry:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 constrained = mesh.mmg.remesh(
@@ -317,7 +317,7 @@ constrained = mesh.mmg.remesh(
 
 `.sol`/`.solb` files round-trip through the accessor; sibling `.sol` files are auto-loaded on `pv.read("foo.mesh")`:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 mesh.point_data["metric"] = my_metric
@@ -329,7 +329,7 @@ other.mmg.load_sol("foo.sol")
 
 ### Validation and quality
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 report = mesh.mmg.validate(detailed=True)  # ValidationReport
@@ -343,7 +343,7 @@ qualities = mesh.mmg.element_qualities()
 
 PyVista exposes 0-based VTK adjacency via `dataset.cell_neighbors(idx)` and `dataset.point_neighbors(idx)`. When you specifically need MMG's 1-based adjacency or its volume/area-weighted centroid (distinct from `dataset.center`, which is the unweighted arithmetic mean), use the accessor:
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 mesh.mmg.adjacent_elements(1)   # MMG-adjacent elements of element 1
@@ -353,7 +353,7 @@ mesh.mmg.center_of_mass()       # volume-weighted (3D) or area-weighted (2D)
 
 ### Mesh kind
 
-<!-- pytest-codeblocks:skip -->
+<!-- mmgpy-test:skip -->
 
 ```python
 print(mesh.mmg.kind)  # MeshKind.TETRAHEDRAL / TRIANGULAR_2D / TRIANGULAR_SURFACE

--- a/docs/tutorials/surface-remeshing.md
+++ b/docs/tutorials/surface-remeshing.md
@@ -43,8 +43,6 @@ print(f"Triangles: {mesh.n_cells} -> {remeshed.n_cells}")
 
 The `hausd` parameter is crucial for surface meshes - it controls how closely the remeshed surface approximates the original:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 # Tight approximation (more triangles, better geometry)
 tight = mesh.mmg.remesh(hmax=0.1, hausd=0.0001)
@@ -60,8 +58,6 @@ Setting `hausd` too large can cause loss of geometric features. Start with small
 
 MMG can detect and preserve sharp edges based on the angle between adjacent faces:
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmax=0.1,
@@ -74,8 +70,6 @@ remeshed = mesh.mmg.remesh(
 
 To prevent vertex movement during remeshing (vertices stay in place, but edges may still be swapped or split):
 
-<!-- pytest-codeblocks:cont -->
-
 ```python
 remeshed = mesh.mmg.remesh(
     hmax=0.1,
@@ -86,8 +80,6 @@ remeshed = mesh.mmg.remesh(
 ## Smooth Surface Remeshing
 
 For smooth surfaces without sharp features:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import MmgSOptions
@@ -105,8 +97,6 @@ remeshed = mesh.mmg.remesh(opts)
 ## Mechanical Part Remeshing
 
 For industrial/CAD parts with sharp edges:
-
-<!-- pytest-codeblocks:cont -->
 
 ```python
 from mmgpy import MmgSOptions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ dev = [
     "pytest-benchmark>=5.2.3",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.14",
-    "pytest-codeblocks>=0.17.0",
+    "pytest-examples>=0.0.18",
     "pytest-pyvista>=0.3.3",
     "pyvista>=0.48,<1",
 ]

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -1,0 +1,91 @@
+"""Run every Python code block in ``docs/`` via pytest-examples.
+
+Replacement for the previous ``pytest --codeblocks docs/`` invocation
+(``pytest-codeblocks`` is dormant since Sep 2023).
+
+Semantic mapping:
+
+- pytest-codeblocks ``<!-- pytest-codeblocks:cont -->`` (block depends on
+  state from previous block in same file) is preserved here by running ALL
+  blocks of a single doc file inside ONE test function with a shared
+  ``module_globals`` dict. Reading a doc file top-to-bottom matches the test
+  execution order, which is the natural reading semantics anyway.
+- pytest-codeblocks ``<!-- pytest-codeblocks:skip -->`` (do not execute) is
+  ported to ``<!-- mmgpy-test:skip -->``. The marker is recognised when it
+  appears alone on the line immediately preceding a fenced code block.
+
+The heavy ``docs/conftest.py`` monkeypatching (mmgpy/pv I/O fakes) still
+applies at module load time — same as before.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_examples import EvalExample, find_examples
+
+if TYPE_CHECKING:
+    from pytest_examples import CodeExample
+
+_DOCS = Path(__file__).resolve().parent.parent / "docs"
+_SKIP_MARKER = "<!-- mmgpy-test:skip -->"
+_FENCE_RE = re.compile(r"^\s*```")
+
+
+def _skipped_lines(path: Path) -> set[int]:
+    r"""Return the set of fenced-block start lines that should be skipped.
+
+    A block is skipped when the most recent non-blank line above its opening
+    fence (triple backticks) is the literal ``_SKIP_MARKER`` comment.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    skip_at: set[int] = set()
+    pending_skip = False
+    for idx, raw in enumerate(lines, start=1):
+        stripped = raw.strip()
+        if stripped == _SKIP_MARKER:
+            pending_skip = True
+            continue
+        if not stripped:
+            # blank line — preserve pending_skip
+            continue
+        if _FENCE_RE.match(raw) and pending_skip:
+            # opening fence — pytest-examples reports start_line as the
+            # FIRST line of the code body, i.e. the line after the fence
+            skip_at.add(idx + 1)
+            pending_skip = False
+            continue
+        # any other content line clears the pending skip
+        pending_skip = False
+    return skip_at
+
+
+# Group all examples by file so each test gets a clean namespace
+_EXAMPLES_BY_FILE: dict[Path, list[CodeExample]] = defaultdict(list)
+for _ex in find_examples(str(_DOCS)):
+    _EXAMPLES_BY_FILE[_ex.path].append(_ex)
+for _examples in _EXAMPLES_BY_FILE.values():
+    _examples.sort(key=lambda e: e.start_line)
+
+# Skip caches keyed by file path
+_SKIPS_BY_FILE: dict[Path, set[int]] = {p: _skipped_lines(p) for p in _EXAMPLES_BY_FILE}
+
+# Stable, human-readable IDs (file path relative to docs/)
+_FILE_IDS = [str(p.relative_to(_DOCS)) for p in sorted(_EXAMPLES_BY_FILE)]
+_FILE_PATHS = sorted(_EXAMPLES_BY_FILE)
+
+
+@pytest.mark.parametrize("doc_path", _FILE_PATHS, ids=_FILE_IDS)
+def test_doc_file(doc_path: Path, eval_example: EvalExample) -> None:
+    """Run every non-skipped code block in ``doc_path`` with shared globals."""
+    module_globals: dict[str, object] = {}
+    skip_lines = _SKIPS_BY_FILE[doc_path]
+    for example in _EXAMPLES_BY_FILE[doc_path]:
+        if example.start_line in skip_lines:
+            continue
+        result = eval_example.run(example, module_globals=module_globals)
+        module_globals.update(result)

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -1,21 +1,23 @@
-"""Run every Python code block in ``docs/`` via pytest-examples.
+"""Run every Python code block in ``docs/`` via pytest-examples discovery.
 
 Replacement for the previous ``pytest --codeblocks docs/`` invocation
 (``pytest-codeblocks`` is dormant since Sep 2023).
 
-Semantic mapping:
+Design notes:
 
-- pytest-codeblocks ``<!-- pytest-codeblocks:cont -->`` (block depends on
-  state from previous block in same file) is preserved here by running ALL
-  blocks of a single doc file inside ONE test function with a shared
-  ``module_globals`` dict. Reading a doc file top-to-bottom matches the test
-  execution order, which is the natural reading semantics anyway.
-- pytest-codeblocks ``<!-- pytest-codeblocks:skip -->`` (do not execute) is
-  ported to ``<!-- mmgpy-test:skip -->``. The marker is recognised when it
-  appears alone on the line immediately preceding a fenced code block.
-
-The heavy ``docs/conftest.py`` monkeypatching (mmgpy/pv I/O fakes) still
-applies at module load time — same as before.
+- ``pytest-examples`` is used only for DISCOVERY (``find_examples``). Each
+  block is exec'd directly into a per-file shared ``globals`` dict, which
+  matches pytest-codeblocks semantics: a function defined in block N closes
+  over the same dict that later blocks add names to. pytest-examples'
+  ``EvalExample.run`` builds a fresh module per block, breaking that.
+- ``<!-- mmgpy-test:skip -->`` (replaces ``<!-- pytest-codeblocks:skip -->``)
+  is recognised when it appears alone on a line OUTSIDE any code fence
+  immediately before a Python fence. Marker matching is whitespace-tolerant.
+  Intervening non-Python fences (bash, yaml) do NOT consume the skip — the
+  marker still applies to the next ``python``/``py`` block.
+- ``docs/conftest.py`` monkeypatches mmgpy / pv I/O. Patches are applied and
+  reverted by a session-scoped autouse fixture so they cannot leak into
+  other test files when the full suite runs in one pytest invocation.
 """
 
 from __future__ import annotations
@@ -27,80 +29,118 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from pytest_examples import EvalExample, find_examples
+from pytest_examples import find_examples
 
 if TYPE_CHECKING:
     from pytest_examples import CodeExample
 
 _DOCS = Path(__file__).resolve().parent.parent / "docs"
-_SKIP_MARKER = "<!-- mmgpy-test:skip -->"
-_FENCE_RE = re.compile(r"^\s*```")
-
-# ``docs/conftest.py`` monkeypatches mmgpy/pv I/O so doc snippets that
-# reference fake mesh files (``mmgpy.read("input.mesh")``) work without those
-# files on disk. With pytest-codeblocks, that conftest was auto-loaded because
-# ``--codeblocks docs/`` treated ``docs/`` as a test path. With pytest-examples
-# called from ``tests/``, pytest never scans ``docs/``, so we load the patches
-# explicitly here at module import time — same effect.
 _DOCS_CONFTEST = _DOCS / "conftest.py"
-_spec = importlib.util.spec_from_file_location("_mmgpy_docs_conftest", _DOCS_CONFTEST)
-if _spec is None or _spec.loader is None:  # pragma: no cover
-    msg = f"could not load {_DOCS_CONFTEST}"
-    raise RuntimeError(msg)
-_module = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_module)
+
+if not _DOCS_CONFTEST.exists():
+    pytest.skip(
+        f"docs/conftest.py not found at {_DOCS_CONFTEST}",
+        allow_module_level=True,
+    )
+
+# Marker matching tolerates optional whitespace around the inner directive
+# so contributors who copy-paste `<!--mmgpy-test:skip-->` (no inner spaces)
+# still get the intended skip behaviour.
+_SKIP_RE = re.compile(r"^\s*<!--\s*mmgpy-test:skip\s*-->\s*$")
+# Opening fence for python/py blocks (the only language pytest-examples runs).
+_FENCE_PY_OPEN_RE = re.compile(r"^\s*```\s*(?:py|python)\b")
+# Any fence line — used for tracking in-fence / out-of-fence state.
+_FENCE_ANY_RE = re.compile(r"^\s*```")
 
 
 def _skipped_lines(path: Path) -> set[int]:
-    r"""Return the set of fenced-block start lines that should be skipped.
+    """Return the set of opening-fence line numbers that should be skipped.
 
-    A block is skipped when the most recent non-blank line above its opening
-    fence (triple backticks) is the literal ``_SKIP_MARKER`` comment.
+    A state machine tracks whether we are inside a code fence, so a marker
+    appearing as data inside a code block is ignored. Outside a fence, a
+    marker sets a pending flag that attaches to the next OPENING PYTHON
+    fence — non-Python fences (bash, yaml) are passed through, so a marker
+    placed before docs-only blocks still skips the python block following.
     """
     lines = path.read_text(encoding="utf-8").splitlines()
     skip_at: set[int] = set()
     pending_skip = False
+    in_fence = False
     for idx, raw in enumerate(lines, start=1):
-        stripped = raw.strip()
-        if stripped == _SKIP_MARKER:
+        if in_fence:
+            if _FENCE_ANY_RE.match(raw):
+                in_fence = False
+            continue
+        if _FENCE_ANY_RE.match(raw):
+            in_fence = True
+            if pending_skip and _FENCE_PY_OPEN_RE.match(raw):
+                skip_at.add(idx)
+                pending_skip = False
+            continue
+        if _SKIP_RE.match(raw):
             pending_skip = True
             continue
-        if not stripped:
-            # blank line — preserve pending_skip
-            continue
-        if _FENCE_RE.match(raw) and pending_skip:
-            # pytest-examples' ``CodeExample.start_line`` is the line of the
-            # opening fence itself (1-indexed), not the first code line.
-            skip_at.add(idx)
+        if raw.strip():
+            # any other non-blank content line clears the pending skip
             pending_skip = False
-            continue
-        # any other content line clears the pending skip
-        pending_skip = False
     return skip_at
 
 
-# Group all examples by file so each test gets a clean namespace
+# Load docs/conftest.py to access ``apply_patches`` / ``restore_patches``.
+# This import is now a no-op for side effects — the helpers must be invoked
+# explicitly (see the session-scoped autouse fixture below).
+_spec = importlib.util.spec_from_file_location(
+    "_mmgpy_docs_conftest",
+    _DOCS_CONFTEST,
+)
+assert _spec is not None
+assert _spec.loader is not None
+_docs_conftest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_docs_conftest)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _docs_io_patches():
+    """Apply docs I/O patches for this session, then revert at teardown.
+
+    Without this scoping, monkeypatches installed at import time would leak
+    into every other test in ``tests/`` whenever the full suite runs in a
+    single pytest invocation (``uv run pytest`` without ``--ignore``).
+    """
+    _docs_conftest.apply_patches()
+    try:
+        yield
+    finally:
+        _docs_conftest.restore_patches()
+
+
+# Group examples by file; sort within each file by line number.
 _EXAMPLES_BY_FILE: dict[Path, list[CodeExample]] = defaultdict(list)
 for _ex in find_examples(str(_DOCS)):
     _EXAMPLES_BY_FILE[_ex.path].append(_ex)
 for _examples in _EXAMPLES_BY_FILE.values():
     _examples.sort(key=lambda e: e.start_line)
 
-# Skip caches keyed by file path
 _SKIPS_BY_FILE: dict[Path, set[int]] = {p: _skipped_lines(p) for p in _EXAMPLES_BY_FILE}
 
-# Stable, human-readable IDs (file path relative to docs/)
-_FILE_IDS = [str(p.relative_to(_DOCS)) for p in sorted(_EXAMPLES_BY_FILE)]
+# Single sort: keys and IDs derived from the SAME ordered list, so they can
+# never desync if the dict is mutated between two list comprehensions.
 _FILE_PATHS = sorted(_EXAMPLES_BY_FILE)
+_FILE_IDS = [str(p.relative_to(_DOCS)) for p in _FILE_PATHS]
 
 
 @pytest.mark.parametrize("doc_path", _FILE_PATHS, ids=_FILE_IDS)
-def test_doc_file(doc_path: Path, eval_example: EvalExample) -> None:
-    """Run every non-skipped code block in ``doc_path`` with shared globals."""
-    module_globals: dict[str, object] = {}
+def test_doc_file(doc_path: Path) -> None:
+    """Run every non-skipped Python block in ``doc_path`` with shared globals."""
+    module_globals: dict[str, object] = {"__name__": "__doc_example__"}
     skip_lines = _SKIPS_BY_FILE[doc_path]
     for example in _EXAMPLES_BY_FILE[doc_path]:
         if example.start_line in skip_lines:
             continue
-        result = eval_example.run(example, module_globals=module_globals)
-        module_globals.update(result)
+        # Pad with blank lines so traceback line numbers match the doc file.
+        # ``example.start_line`` is the opening fence; first code line is
+        # ``start_line + 1``, so prepending ``start_line`` newlines aligns
+        # source line 1 with doc-file line ``start_line + 1``.
+        padded = "\n" * example.start_line + example.source
+        code = compile(padded, str(example.path), "exec")
+        exec(code, module_globals)  # noqa: S102

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -20,6 +20,7 @@ applies at module load time — same as before.
 
 from __future__ import annotations
 
+import importlib.util
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -34,6 +35,20 @@ if TYPE_CHECKING:
 _DOCS = Path(__file__).resolve().parent.parent / "docs"
 _SKIP_MARKER = "<!-- mmgpy-test:skip -->"
 _FENCE_RE = re.compile(r"^\s*```")
+
+# ``docs/conftest.py`` monkeypatches mmgpy/pv I/O so doc snippets that
+# reference fake mesh files (``mmgpy.read("input.mesh")``) work without those
+# files on disk. With pytest-codeblocks, that conftest was auto-loaded because
+# ``--codeblocks docs/`` treated ``docs/`` as a test path. With pytest-examples
+# called from ``tests/``, pytest never scans ``docs/``, so we load the patches
+# explicitly here at module import time — same effect.
+_DOCS_CONFTEST = _DOCS / "conftest.py"
+_spec = importlib.util.spec_from_file_location("_mmgpy_docs_conftest", _DOCS_CONFTEST)
+if _spec is None or _spec.loader is None:  # pragma: no cover
+    msg = f"could not load {_DOCS_CONFTEST}"
+    raise RuntimeError(msg)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
 
 
 def _skipped_lines(path: Path) -> set[int]:
@@ -54,9 +69,9 @@ def _skipped_lines(path: Path) -> set[int]:
             # blank line — preserve pending_skip
             continue
         if _FENCE_RE.match(raw) and pending_skip:
-            # opening fence — pytest-examples reports start_line as the
-            # FIRST line of the code body, i.e. the line after the fence
-            skip_at.add(idx + 1)
+            # pytest-examples' ``CodeExample.start_line`` is the line of the
+            # opening fence itself (1-indexed), not the first code line.
+            skip_at.add(idx)
             pending_skip = False
             continue
         # any other content line clears the pending skip

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -13,7 +13,7 @@ Design notes:
 - ``<!-- mmgpy-test:skip -->`` (replaces ``<!-- pytest-codeblocks:skip -->``)
   is recognised when it appears alone on a line OUTSIDE any code fence
   immediately before a Python fence. Marker matching is whitespace-tolerant.
-  Intervening non-Python fences (bash, yaml) do NOT consume the skip — the
+  Intervening non-Python fences (bash, yaml) do NOT consume the skip; the
   marker still applies to the next ``python``/``py`` block.
 - ``docs/conftest.py`` monkeypatches mmgpy / pv I/O. Patches are applied and
   reverted by a session-scoped autouse fixture so they cannot leak into
@@ -49,7 +49,7 @@ if not _DOCS_CONFTEST.exists():
 _SKIP_RE = re.compile(r"^\s*<!--\s*mmgpy-test:skip\s*-->\s*$")
 # Opening fence for python/py blocks (the only language pytest-examples runs).
 _FENCE_PY_OPEN_RE = re.compile(r"^\s*```\s*(?:py|python)\b")
-# Any fence line — used for tracking in-fence / out-of-fence state.
+# Any fence line: used for tracking in-fence / out-of-fence state.
 _FENCE_ANY_RE = re.compile(r"^\s*```")
 
 
@@ -59,7 +59,7 @@ def _skipped_lines(path: Path) -> set[int]:
     A state machine tracks whether we are inside a code fence, so a marker
     appearing as data inside a code block is ignored. Outside a fence, a
     marker sets a pending flag that attaches to the next OPENING PYTHON
-    fence — non-Python fences (bash, yaml) are passed through, so a marker
+    fence; non-Python fences (bash, yaml) are passed through, so a marker
     placed before docs-only blocks still skips the python block following.
     """
     lines = path.read_text(encoding="utf-8").splitlines()
@@ -87,7 +87,7 @@ def _skipped_lines(path: Path) -> set[int]:
 
 
 # Load docs/conftest.py to access ``apply_patches`` / ``restore_patches``.
-# This import is now a no-op for side effects — the helpers must be invoked
+# This import is now a no-op for side effects: the helpers must be invoked
 # explicitly (see the session-scoped autouse fixture below).
 _spec = importlib.util.spec_from_file_location(
     "_mmgpy_docs_conftest",
@@ -127,6 +127,11 @@ _SKIPS_BY_FILE: dict[Path, set[int]] = {p: _skipped_lines(p) for p in _EXAMPLES_
 # never desync if the dict is mutated between two list comprehensions.
 _FILE_PATHS = sorted(_EXAMPLES_BY_FILE)
 _FILE_IDS = [str(p.relative_to(_DOCS)) for p in _FILE_PATHS]
+
+# Fail loudly if discovery returns nothing (e.g., docs restructured, fence
+# syntax changed). Otherwise parametrize generates zero tests and CI silently
+# reports success for the doc-codeblocks step.
+assert _FILE_PATHS, f"pytest-examples discovered no code blocks under {_DOCS}"
 
 
 @pytest.mark.parametrize("doc_path", _FILE_PATHS, ids=_FILE_IDS)

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,50 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/84/b3f55026206a9e8820a91503308075ca48eadc515e436731ca01dbe043b3/black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893", size = 1987719, upload-time = "2026-05-18T17:05:02.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/34/7db312c5e5783d6e76cffd9d5ac8972a32badae4c6e3288dac0eed8d3bed/black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90", size = 1810083, upload-time = "2026-05-18T17:05:04.302Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e2/e0101e73c2c8727634e2efcb35e2b34bd23ad70dfa673789f5773a591b21/black-26.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4", size = 1860633, upload-time = "2026-05-18T17:05:06.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4c/e15c0c5b23cf3651035fe5addcce90e283af3548a3f91bb03d81b83106ab/black-26.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef", size = 1477886, upload-time = "2026-05-18T17:05:07.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3f/59d43ade98d2ce5c8dc34a4e46cbecd177e6d55d7d4092969c6003ccc655/black-26.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22", size = 1277111, upload-time = "2026-05-18T17:05:09.473Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
+]
+
+[[package]]
 name = "bottle"
 version = "0.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1404,8 +1448,8 @@ dev = [
     { name = "pybind11" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
-    { name = "pytest-codeblocks" },
     { name = "pytest-cov" },
+    { name = "pytest-examples" },
     { name = "pytest-pyvista" },
     { name = "pyvista" },
     { name = "ruff" },
@@ -1454,8 +1498,8 @@ dev = [
     { name = "pybind11", specifier = ">=3.0.4" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
-    { name = "pytest-codeblocks", specifier = ">=0.17.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-examples", specifier = ">=0.0.18" },
     { name = "pytest-pyvista", specifier = ">=0.3.3" },
     { name = "pyvista", specifier = ">=0.48,<1" },
     { name = "ruff", specifier = ">=0.15.14" },
@@ -1682,6 +1726,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/8f/0a60e501584145588be1af5cc829265701ba3c35a64aec8e07cbb71d39bb/multidict-6.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:09929cab6fcb68122776d575e03c6cc64ee0b8fca48d17e135474b042ce515cd", size = 53507, upload-time = "2025-10-06T14:51:53.672Z" },
     { url = "https://files.pythonhosted.org/packages/7f/ae/3148b988a9c6239903e786eac19c889fab607c31d6efa7fb2147e5680f23/multidict-6.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:cc41db090ed742f32bd2d2c721861725e6109681eddf835d0a82bd3a5c382827", size = 44804, upload-time = "2025-10-06T14:51:55.415Z" },
     { url = "https://files.pythonhosted.org/packages/b7/da/7d22601b625e241d4f23ef1ebff8acfc60da633c9e7e7922e24d10f592b3/multidict-6.7.0-py3-none-any.whl", hash = "sha256:394fc5c42a333c9ffc3e421a4c85e08580d990e08b99f6bf35b4132114c5dcb3", size = 12317, upload-time = "2025-10-06T14:52:29.272Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -2341,18 +2394,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-codeblocks"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/99/1ee3017a525dcb36566f0523938fbc20fb33ef8bf957205fafe6659f3a60/pytest_codeblocks-0.17.0.tar.gz", hash = "sha256:446e1babd182f54b4f113d567737a22f5405cade144c08a0085b2985247943d5", size = 11176, upload-time = "2023-09-17T19:17:31.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/2c/503f797c7ac1e35d81944f8fbcf3ea7a1965e435676570a833035d8d0937/pytest_codeblocks-0.17.0-py3-none-any.whl", hash = "sha256:b2aed8e66c3ce65435630783b391e7c7ae46f80b8220d3fa1bb7c689b36e78ad", size = 7716, upload-time = "2023-09-17T19:17:29.506Z" },
-]
-
-[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2364,6 +2405,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-examples"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "black" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/71/4ae972fd95f474454aa450108ee1037830e7ba11840363e981b8d48fd16a/pytest_examples-0.0.18.tar.gz", hash = "sha256:9a464f007f805b113677a15e2f8942ebb92d7d3eb5312e9a405d018478ec9801", size = 21237, upload-time = "2025-05-06T07:46:10.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/52/7bbfb6e987d9a8a945f22941a8da63e3529465f1b106ef0e26f5df7c780d/pytest_examples-0.0.18-py3-none-any.whl", hash = "sha256:86c195b98c4e55049a0df3a0a990ca89123b7280473ab57608eecc6c47bcfe9c", size = 18169, upload-time = "2025-05-06T07:46:09.349Z" },
 ]
 
 [[package]]
@@ -2400,6 +2455,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/d6/1afd75edd932306ae9bd2c2d961d603dc2b52fcec51b04afea464f1f6646/pythonnet-3.0.5.tar.gz", hash = "sha256:48e43ca463941b3608b32b4e236db92d8d40db4c58a75ace902985f76dac21cf", size = 239212, upload-time = "2024-12-13T08:30:44.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/f1/bfb6811df4745f92f14c47a29e50e89a36b1533130fcc56452d4660bd2d6/pythonnet-3.0.5-py3-none-any.whl", hash = "sha256:f6702d694d5d5b163c9f3f5cc34e0bed8d6857150237fae411fefb883a656d20", size = 297506, upload-time = "2024-12-13T08:30:40.661Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
From the audit's "Track items" in #310. `pytest-codeblocks` has been dormant since Sep 2023; this swaps it for the actively maintained `pytest-examples` (Pydantic, last release 2026-05-22).

## Summary
- Add `tests/docs_test.py`: pytest-examples runner that discovers all code blocks in `docs/`, groups by file, and runs each file's blocks sequentially in a shared `module_globals` dict, preserving `pytest-codeblocks:cont` semantics (60 markers across 13 files) without requiring any explicit continuation directive.
- Rename marker in 25 doc files:
  - `<!-- pytest-codeblocks:skip -->` to `<!-- mmgpy-test:skip -->` (45 markers).
  - `<!-- pytest-codeblocks:cont -->` removed (66 markers; file-scoped namespace handles continuation implicitly).
- Replace `pytest-codeblocks>=0.17.0` with `pytest-examples>=0.0.18` in `[dependency-groups].dev`.
- Update CI: `pytest --codeblocks docs/` to `pytest tests/docs_test.py` in `build-and-test.yml` and `build-wheels.yml` validate-release. Add `--ignore=tests/docs_test.py` to the coverage run so docs are not tested twice.
- `docs/conftest.py` kept. Its module-level monkeypatches (mmgpy / pv I/O fakes) still apply, loaded explicitly by `tests/docs_test.py` since pytest no longer scans `docs/`.

## Verification
Local discovery confirmed: pytest-examples picks up 21 doc files, executes blocks in order with shared globals, skip-marker parser works. Other failures locally are due to no editable mmgpy install in this venv. CI has a real install.

## Notes
- `pytest-examples` pulls in `black` and `mypy-extensions` as transitive deps for its linting feature, which we do not use.
- `docs_test.py` follows the project's `*_test.py` naming convention.