### PR TITLE
[codex] Use official ty pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,14 @@ repos:
       - id: codespell
         files: ^.*\.(py|rst|md)$
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    # v0.0.48
+    rev: a71646c845a122391e3ce3a43502fcf4003d1efa
     hooks:
       - id: ty
-        name: ty type checker
-        entry: uvx ty check
-        language: system
-        types: [python]
-        pass_filenames: false
 
+  - repo: local
+    hooks:
       - id: sync-versions
         name: sync downstream version files with pyproject.toml
         entry: uv run --no-project python .github/scripts/sync_versions.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,12 +342,14 @@ ignore = [
 ]
 
 [tool.ty.src]
-# Exclude tests, scripts, examples, and certain modules from type checking
+# Keep ty's full-project pre-commit hook focused on the package source,
+# matching `uv run ty check src/mmgpy/`.
+include = ["src/mmgpy"]
+# Exclude modules that rely on runtime integrations or incomplete third-party stubs.
 # Progress module uses union types that cause complex type inference issues
 # Interactive module uses PyVista types that have incomplete stubs
 # UI module uses trame which has no type stubs
-# Blender extension uses bpy property decorators that ty doesn't understand
-exclude = ["tests/**", "scripts/**", "examples/**", "docs/**", "src/mmgpy/_progress.py", "src/mmgpy/interactive/**", "src/mmgpy/ui/**", "blender_mmgpy/**"]
+exclude = ["src/mmgpy/_progress.py", "src/mmgpy/interactive/**", "src/mmgpy/ui/**"]
 
 [tool.ty.rules]
 # Ignore unresolved imports for C++ extension module that isn't available at type-check time

--- a/src/mmgpy/metrics.py
+++ b/src/mmgpy/metrics.py
@@ -734,7 +734,7 @@ def _solve_hessian_2d(
     x, y = coords_n[:, 0], coords_n[:, 1]
     basis = np.column_stack([x, y, 0.5 * x * x, x * y, 0.5 * y * y])
     coeffs, _, _, _ = np.linalg.lstsq(basis, vals, rcond=None)
-    return coeffs[2:5]
+    return np.asarray(coeffs[2:5], dtype=np.float64)
 
 
 def _solve_hessian_3d(
@@ -756,4 +756,4 @@ def _solve_hessian_3d(
         [x, y, z, 0.5 * x * x, x * y, x * z, 0.5 * y * y, y * z, 0.5 * z * z],
     )
     coeffs, _, _, _ = np.linalg.lstsq(basis, vals, rcond=None)
-    return coeffs[3:9]
+    return np.asarray(coeffs[3:9], dtype=np.float64)


### PR DESCRIPTION
## Summary
- Replace the local `uvx ty check` pre-commit hook with Astral’s official `ty-pre-commit` hook.
- Pin the hook by full commit SHA, with a comment documenting the corresponding `v0.0.48` release.
- Scope `ty` to `src/mmgpy` so the full-project hook matches the documented developer command and ignores local scratch files.
- Add explicit float64 casts for Hessian coefficient slices so `ty` accepts the tracked source tree.

## Validation
- `uv run prek run ty --all-files`
- `uv run ty check`
- `uv run prek run validate-pyproject --files pyproject.toml`
- `uv run ruff check src/mmgpy/metrics.py`
- `uv run pytest tests/headless_subset_test.py -q`
- Commit-time pre-commit suite passed.
