### PR TITLE
Fix Blender version history parser

### DIFF
--- a/scripts/track_downloads.py
+++ b/scripts/track_downloads.py
@@ -91,8 +91,14 @@ VERSION_DETAILS_PATTERN = re.compile(
     rb'<details[^>]*id="v\d+"[^>]*>.*?</details>',
     re.DOTALL,
 )
-VERSION_NUMBER_PATTERN = re.compile(rb"<summary>\s*([0-9.]+)")
+VERSION_NUMBER_PATTERN = re.compile(
+    rb"<summary>.*?([0-9]+(?:\.[0-9]+)+)",
+    re.DOTALL,
+)
 VERSION_DATE_PATTERN = re.compile(rb'href="#v\d+"\s+title="([^"]+)"')
+VERSION_DOWNLOADS_PATTERN = re.compile(
+    rb'<i\s+class="i-download"[^>]*></i>\s*([\d,]+)',
+)
 VERSION_STATUS_PATTERN = re.compile(
     rb"<dt>\s*Status\s*</dt>.*?<span[^>]*title=\"([^\"]+)\"",
     re.DOTALL,
@@ -400,7 +406,9 @@ def parse_version_events(body: bytes) -> list[VersionEvent]:
         details = details_match.group(0)
         version_match = VERSION_NUMBER_PATTERN.search(details)
         date_match = VERSION_DATE_PATTERN.search(details)
-        downloads_match = DOWNLOADS_PATTERN.search(details)
+        downloads_match = VERSION_DOWNLOADS_PATTERN.search(details)
+        if downloads_match is None:
+            downloads_match = DOWNLOADS_PATTERN.search(details)
         if version_match is None or date_match is None or downloads_match is None:
             msg = "version card markup did not contain version, date, and downloads"
             raise RuntimeError(msg)

--- a/tests/track_downloads_test.py
+++ b/tests/track_downloads_test.py
@@ -152,7 +152,8 @@ def test_parse_version_events() -> None:
     html = b"""
     <details open id="v0162">
       <summary>
-        0.16.2
+        <span class="version-string">0.16.2</span>
+        <li class="show-on-collapse"><i class="i-download"></i> 1,828</li>
         <a href="#v0162" title="Saturday 23rd, May 2026 - 15:22">
           May 23rd, 2026
         </a>
@@ -166,9 +167,6 @@ def test_parse_version_events() -> None:
       <li><i class="i-macos"></i> macOS <span>Apple Silicon</span></li>
       <li><i class="i-windows"></i> Windows</li>
       <li><i class="i-linux"></i> Linux</li>
-      <div class="dl-row">
-        <div class="dl-col"><dt>Downloads</dt><dd>1,828</dd></div>
-      </div>
       <div class="dl-row">
         <div class="dl-col">
           <dt>Status</dt><dd><span title="Approved"></span></dd>


### PR DESCRIPTION
## What changed

- Parse version numbers from the new `version-string` span in Blender Extensions version cards.
- Parse per-version downloads from the new summary download item while retaining the legacy definition-list fallback.
- Update the regression fixture to match the current live markup.

## Root cause

Blender Extensions changed its version-history HTML. The tracker still expected the version number as direct summary text and downloads in a `<dt>/<dd>` pair, so the scheduled workflow raised `RuntimeError: version card markup did not contain version, date, and downloads`.

## Impact

The scheduled extension-download tracker can read version history again and continue updating its stats gist.

## Validation

- `uv run pytest tests/track_downloads_test.py -q` (17 passed)
- `uv run ruff check scripts/track_downloads.py tests/track_downloads_test.py`
- `uv run ruff format --check scripts/track_downloads.py tests/track_downloads_test.py`
- Live-page parser smoke test against the Blender Extensions version-history page