### PR TITLE
Fix stats chart dates and release docs deployment

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -428,7 +428,13 @@ jobs:
     needs: publish-to-pypi
     runs-on: ubuntu-latest
     name: Deploy versioned docs
-    if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
+    if: >-
+      (github.event_name == 'release' &&
+       github.event.action == 'published' &&
+       !github.event.release.prerelease) ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.publish_to_pypi &&
+       startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: write
     concurrency:

--- a/docs/assets/js/blender-extension-stats.js
+++ b/docs/assets/js/blender-extension-stats.js
@@ -50,6 +50,10 @@
     }).format(new Date(value + "T00:00:00Z"));
   }
 
+  function dateValue(value) {
+    return Date.parse(value + "T00:00:00Z");
+  }
+
   function formatRating(value) {
     if (value === null || value === undefined || value === "") return "n/a";
     return Number(value).toFixed(1) + " / 5";
@@ -97,9 +101,9 @@
     const exactIndex = daily.findIndex((row) => row.date === date);
     if (exactIndex !== -1) return exactIndex;
 
-    const target = Date.parse(date + "T00:00:00Z");
+    const target = dateValue(date);
     const laterIndex = daily.findIndex(
-      (row) => Date.parse(row.date + "T00:00:00Z") >= target,
+      (row) => dateValue(row.date) >= target,
     );
     return laterIndex === -1 ? daily.length - 1 : laterIndex;
   }
@@ -168,7 +172,7 @@
     const reviewMarkers = payload.reviews.map((review) => {
       const index = indexForDate(daily, review.date);
       return {
-        x: index,
+        x: dateValue(review.date),
         y: daily[index].downloads,
         review,
       };
@@ -176,7 +180,7 @@
     const releaseMarkers = releaseEvents.map((event) => {
       const index = indexForDate(daily, event.date);
       return {
-        x: index,
+        x: dateValue(event.date),
         y: daily[index].downloads,
         event,
       };
@@ -188,8 +192,8 @@
         datasets: [
           {
             label: "Downloads",
-            data: daily.map((row, index) => ({
-              x: index,
+            data: daily.map((row) => ({
+              x: dateValue(row.date),
               y: row.downloads,
               row,
             })),
@@ -258,14 +262,14 @@
         scales: {
           x: {
             type: "linear",
-            min: 0,
-            max: daily.length - 1,
+            min: dateValue(first.date),
+            max: dateValue(latest.date),
             ticks: {
               color: colors.muted,
               maxTicksLimit: 7,
               callback: (value) => {
-                const row = daily[Math.round(value)];
-                return row ? formatDate(row.date).replace(", ", " ") : "";
+                const date = new Date(Number(value)).toISOString().slice(0, 10);
+                return formatDate(date).replace(", ", " ");
               },
             },
             grid: { color: colors.grid },

--- a/tests/docs_deployment_test.py
+++ b/tests/docs_deployment_test.py
@@ -1,0 +1,28 @@
+"""Regression checks for documentation charting and release deployment."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_download_chart_uses_elapsed_dates_for_x_coordinates() -> None:
+    """Missing tracker days must occupy their real width on the x-axis."""
+    script = (ROOT / "docs/assets/js/blender-extension-stats.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "x: dateValue(row.date)" in script
+    assert "x: dateValue(review.date)" in script
+    assert "x: dateValue(event.date)" in script
+    assert "min: dateValue(first.date)" in script
+    assert "max: dateValue(latest.date)" in script
+
+
+def test_dispatched_release_build_deploys_versioned_docs() -> None:
+    """The release orchestrator dispatch must update Mike's latest alias."""
+    workflow = (ROOT / ".github/workflows/build-wheels.yml").read_text(encoding="utf-8")
+    deploy_job = workflow.split("  deploy-versioned-docs:", maxsplit=1)[1]
+
+    assert "github.event_name == 'workflow_dispatch'" in deploy_job
+    assert "inputs.publish_to_pypi" in deploy_job
+    assert "startsWith(github.ref, 'refs/tags/v')" in deploy_job


### PR DESCRIPTION
## What changed

- Plot marketplace statistics against real UTC dates instead of tracker sample indices.
- Position review and release markers on the same date-based x-axis.
- Allow tag-based, PyPI-publishing `workflow_dispatch` runs to deploy versioned docs and update Mike's `latest` alias.
- Add focused regression checks for both behaviors.

## Root causes

The chart assigned each observation an evenly spaced integer x-coordinate. When tracking missed July 8–11, the five-day interval from July 7 to July 12 was compressed into one sample interval and the cumulative increase looked like a one-day spike.

The release orchestrator publishes releases by dispatching `build-wheels.yml` on the release tag with `publish_to_pypi=true`. The versioned-docs job only accepted the separate `release: published` event, so the successful v0.16.2 dispatch published packages but skipped the docs deployment. Consequently Mike's deployed metadata still pointed `latest` at 0.13.

## Impact

Missing tracker days now occupy their true width on the chart, so slopes represent elapsed time. Future automated releases will publish their versioned documentation and advance the root site's `latest` alias.

The existing `Redeploy docs` workflow was run separately to backfill the already-released `0.16` slot from `v0.16.2`; the live site now assigns `latest` to `0.16`.

## Validation

- `uv run --no-sync pytest tests/docs_deployment_test.py -q` (2 passed)
- `uv run --no-sync prek run --files .github/workflows/build-wheels.yml docs/assets/js/blender-extension-stats.js tests/docs_deployment_test.py`
- Node syntax check for `blender-extension-stats.js`
- Live verification of `versions.json`, the July 7 → July 12 data gap, and the completed 0.16 backfill