### PR TITLE
Add Complexipy cognitive complexity checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,17 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+    rev: "v7.0.1"
+    hooks:
+      - id: complexipy
+        args: [--plain]
+        files: ^src/mmgpy/.*\.py$
+        exclude: ^src/mmgpy/ui/
+        # Analyze the configured package path so the threshold applies to the
+        # complete non-UI source tree, not only the files staged for this commit.
+        pass_filenames: false
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,24 @@ tests/
 
 All rules enabled except INP001. Per-file exceptions exist in pyproject.toml for tests (S101, T201, SLF001) and **init**.py (S603, E402, C901 for subprocess/lazy loading patterns).
 
+## Cognitive Complexity
+
+Complexipy checks non-UI package code; `src/mmgpy/ui/**` is currently excluded. The configured threshold in `pyproject.toml` is temporary and should be lowered incrementally as the highest-scoring functions are refactored. Do not increase the threshold or add inline ignores to make checks pass.
+
+```bash
+prek run complexipy --all-files
+uvx --from complexipy==7.0.1 complexipy src/mmgpy --failed --suggest-refactors
+```
+
+Treat Complexipy suggestions as guidance:
+
+- "Safe to apply" means high confidence, not that review or tests can be skipped.
+- "Needs review" and "Informational" suggestions require human judgment.
+- Prefer behavior-preserving guard clauses and focused helper extraction.
+- Do not optimize solely for the score; preserve API behavior and readability.
+- Remove obsolete Ruff complexity `noqa` suppressions after refactoring.
+- When the highest remaining score decreases, lower `max-complexity-allowed` in the same PR.
+
 ## UI Development
 
 The interface is built with **trame** (PyVista + Vuetify 3). Main file: `src/mmgpy/ui/app.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,14 @@ markers = [
 [tool.ruff]
 preview = true
 
+[tool.complexipy]
+# Lower this incrementally as the highest-complexity functions are refactored.
+# The UI is currently out of scope.
+paths = ["src/mmgpy"]
+max-complexity-allowed = 21
+exclude = ["ui/**"]
+failed = true
+
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -2044,49 +2044,6 @@ class Mesh:
             metric = metric.reshape(-1, 1)
         self["metric"] = metric
 
-    def _apply_remesh_options(
-        self,
-        options: Mmg3DOptions | Mmg2DOptions | MmgSOptions | None,
-        kwargs: dict[str, Any],
-    ) -> None:
-        """Validate an options object and merge it into remeshing arguments.
-
-        Raises
-        ------
-        TypeError
-            If options are combined with keyword arguments or do not match the
-            mesh kind.
-
-        """
-        if options is None:
-            return
-        if kwargs:
-            msg = (
-                "Cannot pass both options object and keyword arguments. "
-                "Use one or the other."
-            )
-            raise TypeError(msg)
-
-        from mmgpy._options import (  # noqa: PLC0415
-            Mmg2DOptions,
-            Mmg3DOptions,
-            MmgSOptions,
-        )
-
-        options_type_map = {
-            MeshKind.TETRAHEDRAL: Mmg3DOptions,
-            MeshKind.TRIANGULAR_2D: Mmg2DOptions,
-            MeshKind.TRIANGULAR_SURFACE: MmgSOptions,
-        }
-        expected_type = options_type_map[self._kind]
-        if not isinstance(options, expected_type):
-            msg = (
-                f"Expected {expected_type.__name__} for {self._kind.value} mesh, "
-                f"got {type(options).__name__}"
-            )
-            raise TypeError(msg)
-        kwargs.update(options.to_dict())
-
     def _update_fields_after_remesh(
         self,
         fields_to_transfer: dict[str, NDArray[np.float64]],
@@ -2191,7 +2148,12 @@ class Mesh:
         ...     return True  # Continue
         >>> mesh.remesh(hmax=0.1, progress=my_callback)
 
-        """  # noqa: DOC502
+        """
+        from mmgpy._options import (  # noqa: PLC0415
+            Mmg2DOptions,
+            Mmg3DOptions,
+            MmgSOptions,
+        )
         from mmgpy._progress import CancellationError, _emit_event  # noqa: PLC0415
 
         self._load_remesh_input_solution(input_sol)
@@ -2205,7 +2167,27 @@ class Mesh:
             )
             raise ValueError(msg)
 
-        self._apply_remesh_options(options, kwargs)
+        if options is not None:
+            if kwargs:
+                msg = (
+                    "Cannot pass both options object and keyword arguments. "
+                    "Use one or the other."
+                )
+                raise TypeError(msg)
+
+            options_type_map = {
+                MeshKind.TETRAHEDRAL: Mmg3DOptions,
+                MeshKind.TRIANGULAR_2D: Mmg2DOptions,
+                MeshKind.TRIANGULAR_SURFACE: MmgSOptions,
+            }
+            expected_type = options_type_map[self._kind]
+            if not isinstance(options, expected_type):
+                msg = (
+                    f"Expected {expected_type.__name__} for {self._kind.value} mesh, "
+                    f"got {type(options).__name__}"
+                )
+                raise TypeError(msg)
+            kwargs.update(options.to_dict())
 
         do_rcm = _pop_renum_redirect(kwargs)
 

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -2028,7 +2028,88 @@ class Mesh:
             method=interpolation,
         )
 
-    def remesh(  # noqa: C901, PLR0912, PLR0915
+    def _load_remesh_input_solution(
+        self,
+        input_sol: str | Path | NDArray[np.float64] | None,
+    ) -> None:
+        """Load file-based or array-based solution data before remeshing."""
+        if input_sol is None:
+            return
+        if isinstance(input_sol, str | Path):
+            self.load_sol(input_sol)
+            return
+
+        metric = np.asarray(input_sol, dtype=np.float64)
+        if metric.ndim == 1:
+            metric = metric.reshape(-1, 1)
+        self["metric"] = metric
+
+    def _apply_remesh_options(
+        self,
+        options: Mmg3DOptions | Mmg2DOptions | MmgSOptions | None,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Validate an options object and merge it into remeshing arguments.
+
+        Raises
+        ------
+        TypeError
+            If options are combined with keyword arguments or do not match the
+            mesh kind.
+
+        """
+        if options is None:
+            return
+        if kwargs:
+            msg = (
+                "Cannot pass both options object and keyword arguments. "
+                "Use one or the other."
+            )
+            raise TypeError(msg)
+
+        from mmgpy._options import (  # noqa: PLC0415
+            Mmg2DOptions,
+            Mmg3DOptions,
+            MmgSOptions,
+        )
+
+        options_type_map = {
+            MeshKind.TETRAHEDRAL: Mmg3DOptions,
+            MeshKind.TRIANGULAR_2D: Mmg2DOptions,
+            MeshKind.TRIANGULAR_SURFACE: MmgSOptions,
+        }
+        expected_type = options_type_map[self._kind]
+        if not isinstance(options, expected_type):
+            msg = (
+                f"Expected {expected_type.__name__} for {self._kind.value} mesh, "
+                f"got {type(options).__name__}"
+            )
+            raise TypeError(msg)
+        kwargs.update(options.to_dict())
+
+    def _update_fields_after_remesh(
+        self,
+        fields_to_transfer: dict[str, NDArray[np.float64]],
+        old_vertices: NDArray[np.float64] | None,
+        old_elements: NDArray[np.int32] | None,
+        interpolation: str,
+    ) -> None:
+        """Transfer captured fields or discard fields invalidated by remeshing."""
+        if fields_to_transfer and old_vertices is not None and old_elements is not None:
+            self._execute_field_transfer(
+                fields_to_transfer,
+                old_vertices,
+                old_elements,
+                interpolation,
+            )
+            return
+
+        self._user_fields.clear()
+        if self._lazy_source is not None:
+            self._lazy_source.invalidate()
+            self._lazy_source = None
+
+    def remesh(
         self,
         options: Mmg3DOptions | Mmg2DOptions | MmgSOptions | None = None,
         *,
@@ -2110,23 +2191,10 @@ class Mesh:
         ...     return True  # Continue
         >>> mesh.remesh(hmax=0.1, progress=my_callback)
 
-        """
-        from mmgpy._options import (  # noqa: PLC0415
-            Mmg2DOptions,
-            Mmg3DOptions,
-            MmgSOptions,
-        )
+        """  # noqa: DOC502
         from mmgpy._progress import CancellationError, _emit_event  # noqa: PLC0415
 
-        # Load solution data if provided
-        if input_sol is not None:
-            if isinstance(input_sol, str | Path):
-                self.load_sol(input_sol)
-            else:
-                arr = np.asarray(input_sol, dtype=np.float64)
-                if arr.ndim == 1:
-                    arr = arr.reshape(-1, 1)
-                self["metric"] = arr
+        self._load_remesh_input_solution(input_sol)
 
         # Validate interpolation method
         valid_methods = ("linear", "nearest")
@@ -2137,29 +2205,7 @@ class Mesh:
             )
             raise ValueError(msg)
 
-        # Validate and convert options object
-        if options is not None:
-            if kwargs:
-                msg = (
-                    "Cannot pass both options object and keyword arguments. "
-                    "Use one or the other."
-                )
-                raise TypeError(msg)
-
-            # Validate options type matches mesh type
-            options_type_map = {
-                MeshKind.TETRAHEDRAL: Mmg3DOptions,
-                MeshKind.TRIANGULAR_2D: Mmg2DOptions,
-                MeshKind.TRIANGULAR_SURFACE: MmgSOptions,
-            }
-            expected_type = options_type_map[self._kind]
-            if not isinstance(options, expected_type):
-                msg = (
-                    f"Expected {expected_type.__name__} for {self._kind.value} mesh, "
-                    f"got {type(options).__name__}"
-                )
-                raise TypeError(msg)
-            kwargs.update(options.to_dict())
+        self._apply_remesh_options(options, kwargs)
 
         do_rcm = _pop_renum_redirect(kwargs)
 
@@ -2194,24 +2240,12 @@ class Mesh:
             stats = self._impl.remesh(**kwargs)
             final_vertices = len(self._impl.get_vertices())
 
-            # Transfer fields to new mesh if captured, otherwise clear stale fields
-            if (
-                fields_to_transfer
-                and old_vertices is not None
-                and old_elements is not None
-            ):
-                self._execute_field_transfer(
-                    fields_to_transfer,
-                    old_vertices,
-                    old_elements,
-                    interpolation,
-                )
-            else:
-                # Clear user fields as they have incorrect vertex count after remeshing
-                self._user_fields.clear()
-                if self._lazy_source is not None:
-                    self._lazy_source.invalidate()
-                    self._lazy_source = None
+            self._update_fields_after_remesh(
+                fields_to_transfer,
+                old_vertices,
+                old_elements,
+                interpolation,
+            )
 
             if do_rcm:
                 from mmgpy._reorder import _apply_rcm_to_mesh  # noqa: PLC0415

--- a/tests/internal/mesh_unified_test.py
+++ b/tests/internal/mesh_unified_test.py
@@ -699,6 +699,32 @@ class TestMeshMethods:
 class TestMeshRemeshing:
     """Tests for Mesh remeshing operations."""
 
+    @pytest.mark.parametrize(
+        "metric",
+        [np.ones(4), np.ones((4, 1))],
+        ids=["one-dimensional", "two-dimensional"],
+    )
+    def test_load_remesh_input_solution_array(
+        self,
+        tetra_vertices: np.ndarray,
+        tetra_cells: np.ndarray,
+        metric: np.ndarray,
+    ) -> None:
+        """Array input solutions are stored as column-shaped metrics."""
+        mesh = Mesh(tetra_vertices, tetra_cells)
+
+        mesh._load_remesh_input_solution(metric)
+
+        np.testing.assert_array_equal(mesh["metric"], np.ones((4, 1)))
+
+    def test_load_remesh_input_solution_path(self) -> None:
+        """Path input solutions are loaded into the mesh metric."""
+        mesh = read(_ASSETS / "hole.mesh")
+
+        mesh._load_remesh_input_solution(_ASSETS / "hole.sol")
+
+        assert len(mesh["metric"]) == len(mesh.get_vertices())
+
     def test_remesh(self) -> None:
         """Test basic remeshing."""
         x = np.linspace(0, 1, 4)


### PR DESCRIPTION
## Summary

- add Complexipy 7.0.1 to the pre-commit checks
- analyze the complete non-UI `src/mmgpy` package with an initial maximum complexity of 21
- refactor `Mesh.remesh` into focused helpers, reducing its cognitive complexity from 24 to 12
- document the threshold-ratcheting and refactoring workflow in `AGENTS.md`
- keep `src/mmgpy/ui` out of scope for the incremental cleanup

## Why

Complexipy complements Ruff's cyclomatic-complexity checks with a cognitive-complexity metric. Starting at the next current maximum lets the check pass immediately while future PRs progressively refactor the remaining outliers and lower the threshold toward the default of 15.

## Validation

Passed:

- Complexipy pre-commit hook
- Ruff check and format
- TOML and YAML validation
- `validate-pyproject`
- `python -m compileall src/mmgpy/_mesh.py`
- AGENTS.md line-ending, docstring, spelling, and Prettier hooks
- `git diff --check`

Not run successfully locally:

- targeted pytest suite
- ty pre-commit hook

Both are blocked during editable installation by the existing Windows/Clang native build error where `MMG{2D,3D,S}_MULTISOL_API` function-pointer tables are rejected as non-constant `constexpr` initializers. The failure occurs in unchanged C++ binding files before Python tests or type checking begin.