### PR TITLE
Lower Complexipy threshold to 20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ preview = true
 # Lower this incrementally as the highest-complexity functions are refactored.
 # The UI is currently out of scope.
 paths = ["src/mmgpy"]
-max-complexity-allowed = 21
+max-complexity-allowed = 20
 exclude = ["ui/**"]
 failed = true
 

--- a/src/mmgpy/_sol.py
+++ b/src/mmgpy/_sol.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
     from numpy.typing import NDArray
 
@@ -239,6 +239,80 @@ def infer_sol_type(array: NDArray[np.float64], dimension: int) -> int:
     raise ValueError(msg)
 
 
+def _group_sol_fields(
+    fields: Sequence[tuple[str, NDArray[np.float64], Location]],
+    dimension: int,
+) -> dict[Location, list[tuple[str, NDArray[np.float64], int]]]:
+    """Normalize solution arrays and group them by mesh entity location.
+
+    Returns
+    -------
+    dict
+        Normalized fields grouped by entity location.
+
+    Raises
+    ------
+    ValueError
+        If a field uses an unsupported entity location.
+
+    """
+    by_location: dict[Location, list[tuple[str, NDArray[np.float64], int]]] = {}
+    for name, raw, location in fields:
+        if location not in _LOCATION_TO_KEYWORD:
+            msg = (
+                f"Unknown location {location!r} for field {name!r}; expected "
+                f"one of {sorted(_LOCATION_TO_KEYWORD)}"
+            )
+            raise ValueError(msg)
+        array = np.ascontiguousarray(raw, dtype=np.float64)
+        sol_type = infer_sol_type(array, dimension)
+        by_location.setdefault(location, []).append((name, array, sol_type))
+    return by_location
+
+
+def _format_sol_group(
+    location: Location,
+    group: list[tuple[str, NDArray[np.float64], int]],
+) -> list[str]:
+    """Format one location group's header and interleaved data rows.
+
+    Returns
+    -------
+    list[str]
+        Header, data rows, and trailing separator for the location group.
+
+    Raises
+    ------
+    ValueError
+        If fields in the location group have inconsistent row counts.
+
+    """
+    n_entities = group[0][1].shape[0]
+    for name, array, _ in group:
+        if array.shape[0] != n_entities:
+            msg = (
+                f"All sol blocks at {location!r} must share length "
+                f"{n_entities}; field {name!r} has length {array.shape[0]}"
+            )
+            raise ValueError(msg)
+
+    type_header = [str(len(group)), *(str(sol_type) for _, _, sol_type in group)]
+    lines = [_LOCATION_TO_KEYWORD[location], str(n_entities), " ".join(type_header)]
+
+    # Concatenate each row across all blocks. This is the per-vertex
+    # "all values" layout Medit expects.
+    per_row_chunks = [
+        array if array.ndim == _TABLE_NDIM else array.reshape(-1, 1)
+        for _, array, _ in group
+    ]
+    joined = np.concatenate(per_row_chunks, axis=1)
+    # %.17g is the shortest round-trip-safe double format and matches
+    # Medit's expectation of plain decimal / scientific notation.
+    lines.extend(" ".join(f"{value:.17g}" for value in row) for row in joined)
+    lines.append("")
+    return lines
+
+
 def write_sol_file(
     path: str | Path,
     fields: Sequence[tuple[str, NDArray[np.float64], Location]],
@@ -277,48 +351,10 @@ def write_sol_file(
         msg = "write_sol_file: no fields to write"
         raise ValueError(msg)
 
-    by_location: dict[Location, list[tuple[str, NDArray[np.float64], int]]] = {}
-    for name, raw, location in fields:
-        if location not in _LOCATION_TO_KEYWORD:
-            msg = (
-                f"Unknown location {location!r} for field {name!r}; expected "
-                f"one of {sorted(_LOCATION_TO_KEYWORD)}"
-            )
-            raise ValueError(msg)
-        arr = np.ascontiguousarray(raw, dtype=np.float64)
-        sol_type = infer_sol_type(arr, dimension)
-        by_location.setdefault(location, []).append((name, arr, sol_type))
-
+    by_location = _group_sol_fields(fields, dimension)
     lines: list[str] = ["MeshVersionFormatted 2", "", f"Dimension {dimension}", ""]
-
     for location, group in by_location.items():
-        keyword = _LOCATION_TO_KEYWORD[location]
-        n_entities = group[0][1].shape[0]
-        for name, arr, _ in group:
-            if arr.shape[0] != n_entities:
-                msg = (
-                    f"All sol blocks at {location!r} must share length "
-                    f"{n_entities}; field {name!r} has length {arr.shape[0]}"
-                )
-                raise ValueError(msg)
-        lines.extend((keyword, str(n_entities)))
-        type_header = [str(len(group))] + [str(t) for _, _, t in group]
-        lines.append(" ".join(type_header))
-
-        # Concatenate each row across all blocks. This is the per-vertex
-        # "all values" layout Medit expects.
-        per_row_chunks = [
-            arr if arr.ndim == _TABLE_NDIM else arr.reshape(-1, 1)
-            for _, arr, _ in group
-        ]
-        joined = np.concatenate(per_row_chunks, axis=1)
-        # %.17g is the shortest round-trip-safe double format and matches
-        # Medit's expectation of plain decimal / scientific notation.
-        lines.extend(" ".join(f"{v:.17g}" for v in row.tolist()) for row in joined)
-        lines.append("")
+        lines.extend(_format_sol_group(location, group))
 
     lines.extend(("End", ""))
-
-    from pathlib import Path as _Path  # noqa: PLC0415
-
-    _Path(path).write_text("\n".join(lines), encoding="utf-8")
+    Path(path).write_text("\n".join(lines), encoding="utf-8")

--- a/tests/sol_writer_test.py
+++ b/tests/sol_writer_test.py
@@ -1,0 +1,73 @@
+"""Focused tests for the pure-Python Medit solution writer."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+def _load_sol_module():
+    """Load ``_sol.py`` without importing the compiled mmgpy extension."""
+    module_path = Path(__file__).parents[1] / "src" / "mmgpy" / "_sol.py"
+    spec = importlib.util.spec_from_file_location("mmgpy_sol_writer_test", module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load {module_path}"
+        raise ImportError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sol = _load_sol_module()
+
+
+def test_write_sol_file_round_trips_multiple_locations(tmp_path: Path) -> None:
+    """Writer preserves grouped scalar, vector, and cell data."""
+    scalar = np.array([1.0, 2.0])
+    vector = np.array([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
+    cell_scalar = np.array([9.0])
+    output = tmp_path / "combined.sol"
+
+    sol.write_sol_file(
+        output,
+        [
+            ("scalar", scalar, "vertices"),
+            ("vector", vector, "vertices"),
+            ("cell", cell_scalar, "tetrahedra"),
+        ],
+        dimension=3,
+    )
+
+    parsed = sol.parse_sol_file(output.read_text(encoding="utf-8"))
+    np.testing.assert_array_equal(parsed["solution_0@vertices"]["data"], scalar)
+    np.testing.assert_array_equal(parsed["vector_1@vertices"]["data"], vector)
+    np.testing.assert_array_equal(
+        parsed["solution@tetrahedra"]["data"],
+        cell_scalar,
+    )
+
+
+def test_write_sol_file_rejects_mismatched_group_lengths(tmp_path: Path) -> None:
+    """Fields at one entity location must have the same row count."""
+    with pytest.raises(ValueError, match="must share length 2"):
+        sol.write_sol_file(
+            tmp_path / "bad.sol",
+            [
+                ("first", np.ones(2), "vertices"),
+                ("second", np.ones(3), "vertices"),
+            ],
+            dimension=3,
+        )
+
+
+def test_write_sol_file_rejects_unknown_location(tmp_path: Path) -> None:
+    """Unsupported entity locations produce a field-specific error."""
+    with pytest.raises(ValueError, match="Unknown location 'edges' for field 'field'"):
+        sol.write_sol_file(
+            tmp_path / "bad.sol",
+            [("field", np.ones(2), "edges")],
+            dimension=3,
+        )


### PR DESCRIPTION
## Summary

- lower the Complexipy threshold from 21 to 20
- refactor `write_sol_file` from cognitive complexity 21 to 3 by separating field grouping and group formatting
- keep validation for supported locations, matching row counts, and scalar/vector field shapes
- add focused solution-writer tests for multi-location output and validation failures

## Validation

- `prek run ruff-check --files src/mmgpy/_sol.py tests/sol_writer_test.py`
- `prek run ruff-format --files src/mmgpy/_sol.py tests/sol_writer_test.py`
- `prek run check-toml --files pyproject.toml`
- `prek run codespell --files src/mmgpy/_sol.py tests/sol_writer_test.py pyproject.toml`
- `prek run complexipy --all-files`
- `uv run --no-project --with pytest --with numpy python -m pytest tests/sol_writer_test.py -q --noconftest` (3 passed)
