### PR TITLE
Lower Complexipy threshold to 19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ preview = true
 # Lower this incrementally as the highest-complexity functions are refactored.
 # The UI is currently out of scope.
 paths = ["src/mmgpy"]
-max-complexity-allowed = 20
+max-complexity-allowed = 19
 exclude = ["ui/**"]
 failed = true
 

--- a/src/mmgpy/_io.py
+++ b/src/mmgpy/_io.py
@@ -28,13 +28,21 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import numpy as np
 import pyvista as pv
 
-from mmgpy._mesh import _DIMS_2D, _DIMS_3D, MeshKind
+from mmgpy._mesh import (
+    _DIMS_2D,
+    _DIMS_3D,
+    Mesh,
+    MeshKind,
+    _LazyFieldSource,
+    _mesh_from_impl,
+)
 from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
+from mmgpy._pyvista import from_pyvista
 
 logger = logging.getLogger("mmgpy")
 
@@ -44,6 +52,7 @@ _MEDIT_DIMENSION_INLINE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _MEDIT_DIMENSION_VALUE_PATTERN = re.compile(r"^\s*(\d+)\s*$")
+_MMG_FIELDS = frozenset({"metric", "displacement", "levelset", "tensor"})
 
 
 def _parse_medit_header(path: Path) -> tuple[int | None, bool, bool]:
@@ -236,8 +245,44 @@ def _load_medit_native(
     raise ValueError(msg)
 
 
-if TYPE_CHECKING:
-    from mmgpy._mesh import Mesh
+def _wrap_impl(
+    impl: MmgMesh3D | MmgMesh2D | MmgMeshS,
+    point_data: pv.DataSetAttributes | None = None,
+) -> Mesh:
+    """Wrap a native mesh and preserve non-MMG point data lazily.
+
+    Returns
+    -------
+    Mesh
+        The internal mesh wrapper.
+
+    """
+    lazy = None
+    if point_data is not None:
+        fields = {
+            key: np.asarray(point_data[key])
+            for key in point_data
+            if key not in _MMG_FIELDS
+        }
+        lazy = _LazyFieldSource(fields) if fields else None
+    return _mesh_from_impl(impl, _impl_to_kind(impl), lazy_source=lazy)
+
+
+def _read_pyvista_mesh(
+    source: pv.UnstructuredGrid | pv.PolyData,
+    mesh_kind: MeshKind | None,
+) -> Mesh:
+    """Convert a PyVista dataset and retain its user-defined point data.
+
+    Returns
+    -------
+    Mesh
+        The converted internal mesh wrapper.
+
+    """
+    mesh_class = _mesh_kind_to_class(mesh_kind) if mesh_kind is not None else None
+    impl = from_pyvista(source, mesh_class)
+    return _wrap_impl(impl, source.point_data)
 
 
 def _read_mesh_internal(
@@ -264,59 +309,23 @@ def _read_mesh_internal(
         If ``source`` is none of the supported input types.
 
     """
-    # Import here to avoid circular imports
-    from mmgpy._mesh import Mesh, _LazyFieldSource  # noqa: PLC0415
-    from mmgpy._pyvista import from_pyvista  # noqa: PLC0415
-
-    # MMG field names are routed to C++ — exclude from lazy source
-    mmg_fields = frozenset({"metric", "displacement", "levelset", "tensor"})
-
-    # Handle PyVista objects
     if isinstance(source, pv.UnstructuredGrid | pv.PolyData):
-        mesh_class = _mesh_kind_to_class(mesh_kind) if mesh_kind else None
-        impl = from_pyvista(source, mesh_class)
-        kind = _impl_to_kind(impl)
-        point_data = {
-            k: np.asarray(source.point_data[k])
-            for k in source.point_data
-            if k not in mmg_fields
-        }
-        lazy = _LazyFieldSource(point_data) if point_data else None
-        return Mesh._from_impl(impl, kind, lazy_source=lazy)  # noqa: SLF001
+        return _read_pyvista_mesh(source, mesh_kind)
 
-    # Handle file paths
-    if isinstance(source, str | Path):
-        path = Path(source)
-        if not path.exists():
-            msg = f"File not found: {path}"
-            raise FileNotFoundError(msg)
+    if not isinstance(source, str | Path):
+        msg = f"Unsupported source type: {type(source)}"
+        raise TypeError(msg)
 
-        # Use native MMG loading for Medit format to preserve MMG-specific
-        # keywords (Ridges, RequiredVertices, Tangents, reference markers)
-        suffix = path.suffix.lower()
-        if suffix in {".mesh", ".meshb"}:
-            impl = _load_medit_native(path, mesh_kind)
-            kind = _impl_to_kind(impl)
-            return Mesh._from_impl(impl, kind)  # noqa: SLF001
+    path = Path(source)
+    if not path.exists():
+        msg = f"File not found: {path}"
+        raise FileNotFoundError(msg)
 
-        # Use PyVista for other formats. ``pv.read`` returns a wider union
-        # (DataSet | MultiBlock | ...) but on the file extensions we support
-        # only the two PyVista mesh classes come back; ``cast`` keeps mypy
-        # and ty happy without a per-tool type-ignore.
-        pv_mesh = cast("pv.UnstructuredGrid | pv.PolyData", pv.read(path))
-        mesh_class = _mesh_kind_to_class(mesh_kind) if mesh_kind else None
-        impl = from_pyvista(pv_mesh, mesh_class)
-        kind = _impl_to_kind(impl)
-        point_data = {
-            k: np.asarray(pv_mesh.point_data[k])
-            for k in pv_mesh.point_data
-            if k not in mmg_fields
-        }
-        lazy = _LazyFieldSource(point_data) if point_data else None
-        return Mesh._from_impl(impl, kind, lazy_source=lazy)  # noqa: SLF001
+    if path.suffix.lower() in {".mesh", ".meshb"}:
+        return _wrap_impl(_load_medit_native(path, mesh_kind))
 
-    msg = f"Unsupported source type: {type(source)}"
-    raise TypeError(msg)
+    pv_mesh = cast("pv.UnstructuredGrid | pv.PolyData", pv.read(path))
+    return _read_pyvista_mesh(pv_mesh, mesh_kind)
 
 
 def read(

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -664,6 +664,30 @@ def _normalize_ls_base_references(references: Sequence[int]) -> list[int]:
     return normalized
 
 
+class _MeshState(NamedTuple):
+    """Internal state used to construct a mesh around an existing implementation."""
+
+    impl: MmgMesh3D | MmgMesh2D | MmgMeshS
+    kind: MeshKind
+    lazy_source: _LazyFieldSource | None
+
+
+def _mesh_from_impl(
+    impl: MmgMesh3D | MmgMesh2D | MmgMeshS,
+    kind: MeshKind,
+    lazy_source: _LazyFieldSource | None = None,
+) -> Mesh:
+    """Create an internal mesh around an existing implementation.
+
+    Returns
+    -------
+    Mesh
+        A mesh containing the supplied implementation and deferred fields.
+
+    """
+    return Mesh(_MeshState(impl, kind, lazy_source))
+
+
 class Mesh:
     """Unified mesh class with auto-detection of mesh type.
 
@@ -724,7 +748,14 @@ class Mesh:
 
     def __init__(
         self,
-        source: NDArray[np.floating] | str | Path | pv.UnstructuredGrid | pv.PolyData,
+        source: (
+            NDArray[np.floating]
+            | str
+            | Path
+            | pv.UnstructuredGrid
+            | pv.PolyData
+            | _MeshState
+        ),
         cells: NDArray[np.integer] | None = None,
         refs: NDArray[np.integer] | None = None,
         edges: NDArray[np.integer] | None = None,
@@ -748,6 +779,12 @@ class Mesh:
         self._user_fields = {}
         self._metric_is_tensor = False
         self._lazy_source = None
+
+        if isinstance(source, _MeshState):
+            self._impl = source.impl
+            self._kind = source.kind
+            self._lazy_source = source.lazy_source
+            return
 
         array_only_kwargs_provided = (
             refs is not None or edges is not None or edge_refs is not None
@@ -808,39 +845,6 @@ class Mesh:
         )
 
     @classmethod
-    def _from_impl(
-        cls,
-        impl: MmgMesh3D | MmgMesh2D | MmgMeshS,
-        kind: MeshKind,
-        lazy_source: _LazyFieldSource | None = None,
-    ) -> Mesh:
-        """Create a Mesh from an existing implementation (internal use).
-
-        Parameters
-        ----------
-        impl : MmgMesh3D | MmgMesh2D | MmgMeshS
-            The underlying mesh implementation.
-        kind : MeshKind
-            The mesh kind.
-        lazy_source : _LazyFieldSource, optional
-            Deferred point data from the original file.
-
-        Returns
-        -------
-        Mesh
-            A new Mesh wrapping the implementation.
-
-        """
-        mesh = object.__new__(cls)
-        mesh._impl = impl  # noqa: SLF001
-        mesh._kind = kind  # noqa: SLF001
-        mesh._lazy_source = lazy_source  # noqa: SLF001
-        mesh._sizing_constraints = []  # noqa: SLF001
-        mesh._user_fields = {}  # noqa: SLF001
-        mesh._metric_is_tensor = False  # noqa: SLF001
-        return mesh
-
-    @classmethod
     def _from_arrays(
         cls,
         vertices: NDArray[np.floating],
@@ -875,7 +879,7 @@ class Mesh:
             refs=cell_refs,
             edges=_build_edge_data(edges_arr, e_refs),
         )
-        return cls._from_impl(impl, kind)
+        return _mesh_from_impl(impl, kind)
 
     @property
     def _impl_unwrap(self) -> MmgMesh3D | MmgMesh2D | MmgMeshS:

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -66,7 +66,7 @@ _SOLUTION_HINTS: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 def _apply_solution_aliases(
     mmg_mesh: MmgMesh3D | MmgMesh2D | MmgMeshS,
-    point_data: Any,  # noqa: ANN401 - pyvista.DataSetAttributes is not a Mapping
+    point_data: pv.DataSetAttributes,
 ) -> None:
     """Auto-populate ``metric`` / ``levelset`` from VTK-style array names.
 
@@ -76,18 +76,8 @@ def _apply_solution_aliases(
     """
     if not point_data:
         return
-    matches: dict[str, tuple[str, NDArray[np.float64]]] = {}
-    for key in point_data:
-        for slot, hints in _SOLUTION_HINTS:
-            if slot in matches:
-                continue
-            if any(hint in key for hint in hints):
-                matches[slot] = (key, np.asarray(point_data[key], dtype=np.float64))
-                break
-        if len(matches) == len(_SOLUTION_HINTS):
-            break
-    for slot, (key, arr) in matches.items():
-        shaped = arr.reshape(-1, 1) if arr.ndim == 1 else arr
+    for slot, (key, values) in _find_solution_aliases(point_data).items():
+        shaped = values.reshape(-1, 1) if values.ndim == 1 else values
         try:
             mmg_mesh[slot] = shaped
         except (RuntimeError, ValueError) as exc:
@@ -97,6 +87,46 @@ def _apply_solution_aliases(
                 slot,
                 exc,
             )
+
+
+def _find_solution_aliases(
+    point_data: pv.DataSetAttributes,
+) -> dict[str, tuple[str, NDArray[np.float64]]]:
+    """Return the first point-data array matching each solution slot.
+
+    Returns
+    -------
+    dict
+        Solution slots mapped to their source key and converted values.
+
+    """
+    matches: dict[str, tuple[str, NDArray[np.float64]]] = {}
+    for key in point_data:
+        slot = _match_solution_slot(key, matches)
+        if slot is None:
+            continue
+        matches[slot] = (key, np.asarray(point_data[key], dtype=np.float64))
+        if len(matches) == len(_SOLUTION_HINTS):
+            break
+    return matches
+
+
+def _match_solution_slot(
+    key: str,
+    matches: dict[str, tuple[str, NDArray[np.float64]]],
+) -> str | None:
+    """Find an unmatched solution slot whose hint occurs in ``key``.
+
+    Returns
+    -------
+    str | None
+        The matching slot, or ``None`` when no unused hint matches.
+
+    """
+    for slot, hints in _SOLUTION_HINTS:
+        if slot not in matches and any(hint in key for hint in hints):
+            return slot
+    return None
 
 
 def _all_faces_are_triangles(mesh: pv.PolyData) -> bool:

--- a/src/mmgpy/interactive/sizing_editor.py
+++ b/src/mmgpy/interactive/sizing_editor.py
@@ -119,15 +119,15 @@ class SizingEditor:
         """
         # Wrap raw MmgMesh* objects in a Mesh wrapper
         from mmgpy import MeshKind
-        from mmgpy._mesh import Mesh as MeshClass
+        from mmgpy._mesh import _mesh_from_impl
         from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 
         if isinstance(mesh, MmgMesh3D):
-            self._mesh: Mesh = MeshClass._from_impl(mesh, MeshKind.TETRAHEDRAL)  # noqa: SLF001
+            self._mesh: Mesh = _mesh_from_impl(mesh, MeshKind.TETRAHEDRAL)
         elif isinstance(mesh, MmgMesh2D):
-            self._mesh = MeshClass._from_impl(mesh, MeshKind.TRIANGULAR_2D)  # noqa: SLF001
+            self._mesh = _mesh_from_impl(mesh, MeshKind.TRIANGULAR_2D)
         elif isinstance(mesh, MmgMeshS):
-            self._mesh = MeshClass._from_impl(mesh, MeshKind.TRIANGULAR_SURFACE)  # noqa: SLF001
+            self._mesh = _mesh_from_impl(mesh, MeshKind.TRIANGULAR_SURFACE)
         else:
             self._mesh = mesh
         self._pv_mesh: pv.PolyData | pv.UnstructuredGrid | None = None

--- a/tests/internal/validation_test.py
+++ b/tests/internal/validation_test.py
@@ -11,7 +11,7 @@ from mmgpy import (
     ValidationIssue,
     ValidationReport,
 )
-from mmgpy._mesh import Mesh
+from mmgpy._mesh import Mesh, _mesh_from_impl
 from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 
 
@@ -173,7 +173,7 @@ class TestMmgMesh3DValidation:
         raw_mesh.set_mesh_size(vertices=len(vertices), tetrahedra=len(tet))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_tetrahedra(tet)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
 
         # Mesh should be valid after MMG's internal reordering
         report = mesh.validate(detailed=True)
@@ -293,7 +293,7 @@ class TestMmgMesh2DValidation:
         raw_mesh.set_mesh_size(vertices=len(vertices), triangles=len(tri))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_triangles(tri)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TRIANGULAR_2D)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TRIANGULAR_2D)
 
         # Mesh should be valid (MMG may fix orientation or store as-is)
         report = mesh.validate(detailed=True)
@@ -528,7 +528,7 @@ class TestValidationEdgeCases:
         raw_mesh.set_mesh_size(vertices=len(vertices), tetrahedra=len(tet))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_tetrahedra(tet)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
 
         report = mesh.validate(detailed=True)
         degenerate_warnings = [
@@ -575,7 +575,7 @@ class TestValidationEdgeCases:
         raw_mesh.set_mesh_size(vertices=len(vertices), tetrahedra=len(tetrahedra))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_tetrahedra(tetrahedra)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
 
         report = mesh.validate(detailed=True)
         orphan_warnings = [w for w in report.warnings if "orphan" in w.check_name]
@@ -612,7 +612,7 @@ class TestValidationEdgeCases:
         raw_mesh.set_mesh_size(vertices=len(vertices), triangles=len(triangles))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_triangles(triangles)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TRIANGULAR_2D)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TRIANGULAR_2D)
 
         # This mesh should validate without non-manifold issues
         # (each edge has max 2 faces)
@@ -766,7 +766,7 @@ class TestDuplicateVertexDetection:
         raw_mesh.set_mesh_size(vertices=len(vertices), tetrahedra=len(tetrahedra))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_tetrahedra(tetrahedra)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
 
         report = mesh.validate(detailed=True)
         duplicate_warnings = [w for w in report.warnings if "duplicate" in w.check_name]
@@ -786,7 +786,7 @@ class TestDuplicateVertexDetection:
         raw_mesh.set_mesh_size(vertices=len(vertices), tetrahedra=len(tetrahedra))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_tetrahedra(tetrahedra)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
 
         report = mesh.validate(detailed=True)
         duplicate_warnings = [w for w in report.warnings if "duplicate" in w.check_name]
@@ -804,7 +804,7 @@ class TestDuplicateVertexDetection:
         raw_mesh.set_mesh_size(vertices=len(vertices), tetrahedra=len(tetrahedra))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_tetrahedra(tetrahedra)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
 
         report = mesh.validate(detailed=True)
         duplicate_warnings = [w for w in report.warnings if "duplicate" in w.check_name]
@@ -861,7 +861,7 @@ class TestDuplicateVertexDetection:
         raw_mesh.set_mesh_size(vertices=len(vertices), tetrahedra=len(tetrahedra))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_tetrahedra(tetrahedra)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TETRAHEDRAL)
 
         report = mesh.validate(detailed=True)
         duplicate_warnings = [w for w in report.warnings if "duplicate" in w.check_name]
@@ -885,7 +885,7 @@ class TestDuplicateVertexDetection:
         raw_mesh.set_mesh_size(vertices=len(vertices), triangles=len(triangles))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_triangles(triangles)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TRIANGULAR_2D)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TRIANGULAR_2D)
 
         report = mesh.validate(detailed=True)
         duplicate_warnings = [w for w in report.warnings if "duplicate" in w.check_name]
@@ -917,7 +917,7 @@ class TestDuplicateVertexDetection:
         raw_mesh.set_mesh_size(vertices=len(vertices), triangles=len(triangles))
         raw_mesh.set_vertices(vertices)
         raw_mesh.set_triangles(triangles)
-        mesh = Mesh._from_impl(raw_mesh, MeshKind.TRIANGULAR_SURFACE)
+        mesh = _mesh_from_impl(raw_mesh, MeshKind.TRIANGULAR_SURFACE)
 
         report = mesh.validate(detailed=True)
         duplicate_warnings = [w for w in report.warnings if "duplicate" in w.check_name]


### PR DESCRIPTION
## Summary

- lower the Complexipy threshold from 20 to 19
- refactor `_read_mesh_internal` from cognitive complexity 20 to 4 by centralizing native-mesh wrapping and PyVista conversion
- refactor `_apply_solution_aliases` from cognitive complexity 20 to 6 by separating alias discovery from assignment
- preserve lazy loading for non-MMG point data and first-match-wins behavior for VTK solution aliases
- replace the private classmethod factory with a private module-level factory and construction state
- remove the `SLF001` suppression from `_io.py`, six suppressions from the old factory, three sizing-editor suppressions, and the broad `ANN401` suppression

## Why

Two functions were tied at complexity 20, so both had to be simplified before the repository-wide non-UI threshold could move to 19. The deeper mesh-construction boundary also avoids reaching into a private class member from other modules without making that factory public.

## Impact

The refactor keeps the existing mesh-loading and VTK alias behavior while making each function responsible for one level of orchestration. Existing internal callers now use the private `_mesh_from_impl` module factory.

## Validation

- `prek run ruff-check --files src/mmgpy/_io.py src/mmgpy/_mesh.py src/mmgpy/_pyvista.py src/mmgpy/interactive/sizing_editor.py tests/internal/validation_test.py`
- `prek run ruff-format --files src/mmgpy/_io.py src/mmgpy/_mesh.py src/mmgpy/_pyvista.py src/mmgpy/interactive/sizing_editor.py tests/internal/validation_test.py`
- `prek run check-toml --files pyproject.toml`
- `prek run codespell --files src/mmgpy/_io.py src/mmgpy/_mesh.py src/mmgpy/_pyvista.py src/mmgpy/interactive/sizing_editor.py tests/internal/validation_test.py pyproject.toml`
- `prek run complexipy --all-files`
- `prek run check-ast --files src/mmgpy/_io.py src/mmgpy/_mesh.py src/mmgpy/_pyvista.py src/mmgpy/interactive/sizing_editor.py tests/internal/validation_test.py`
