### PR TITLE
Lower Complexipy threshold to 18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ preview = true
 # Lower this incrementally as the highest-complexity functions are refactored.
 # The UI is currently out of scope.
 paths = ["src/mmgpy"]
-max-complexity-allowed = 19
+max-complexity-allowed = 18
 exclude = ["ui/**"]
 failed = true
 

--- a/src/mmgpy/_options.py
+++ b/src/mmgpy/_options.py
@@ -33,6 +33,80 @@ _MAX_ANGLE_DEGREES = 180
 _MIN_GRADATION = 1.0
 
 
+def _validate_positive_option(name: str, value: float | None) -> None:
+    """Validate an optional positive numeric value.
+
+    Raises
+    ------
+    ValueError
+        If the value is not positive.
+
+    """
+    if value is not None and value <= 0:
+        msg = f"{name} must be positive"
+        raise ValueError(msg)
+
+
+def _validate_size_options(
+    opts: Mmg3DOptions | Mmg2DOptions | MmgSOptions,
+) -> None:
+    """Validate the common mesh size options.
+
+    Raises
+    ------
+    ValueError
+        If a size option is invalid.
+
+    """
+    for name, value in (
+        ("hmin", opts.hmin),
+        ("hmax", opts.hmax),
+        ("hsiz", opts.hsiz),
+        ("hausd", opts.hausd),
+    ):
+        _validate_positive_option(name, value)
+    if opts.hmin is not None and opts.hmax is not None and opts.hmin > opts.hmax:
+        msg = "hmin must be less than or equal to hmax"
+        raise ValueError(msg)
+
+
+def _validate_gradation_options(
+    opts: Mmg3DOptions | Mmg2DOptions | MmgSOptions,
+) -> None:
+    """Validate the common gradation options.
+
+    Raises
+    ------
+    ValueError
+        If a gradation option is invalid.
+
+    """
+    if opts.hgrad is not None and opts.hgrad < _MIN_GRADATION:
+        msg = f"hgrad must be >= {_MIN_GRADATION}"
+        raise ValueError(msg)
+    if (
+        opts.hgradreq is not None
+        and opts.hgradreq != -1
+        and opts.hgradreq < _MIN_GRADATION
+    ):
+        msg = f"hgradreq must be >= {_MIN_GRADATION} or -1 to disable"
+        raise ValueError(msg)
+
+
+def _validate_angle_option(value: float | None) -> None:
+    """Validate the angle detection option.
+
+    Raises
+    ------
+    ValueError
+        If the angle is outside the supported range.
+
+    """
+    if value is not None and (value < 0 or value > _MAX_ANGLE_DEGREES):
+        msg = f"ar (angle detection) must be between 0 and {_MAX_ANGLE_DEGREES} degrees"
+        raise ValueError(msg)
+
+
 def _validate_common_options(opts: Mmg3DOptions | Mmg2DOptions | MmgSOptions) -> None:
     """Validate options common to all mesh types.
 
@@ -41,44 +115,11 @@ def _validate_common_options(opts: Mmg3DOptions | Mmg2DOptions | MmgSOptions) ->
     opts : Mmg3DOptions | Mmg2DOptions | MmgSOptions
         Options object to validate.
 
-    Raises
-    ------
-    ValueError
-        If any option value is invalid.
-
     """
-    if opts.hmin is not None and opts.hmin <= 0:
-        msg = "hmin must be positive"
-        raise ValueError(msg)
-    if opts.hmax is not None and opts.hmax <= 0:
-        msg = "hmax must be positive"
-        raise ValueError(msg)
-    if opts.hsiz is not None and opts.hsiz <= 0:
-        msg = "hsiz must be positive"
-        raise ValueError(msg)
-    if opts.hmin is not None and opts.hmax is not None and opts.hmin > opts.hmax:
-        msg = "hmin must be less than or equal to hmax"
-        raise ValueError(msg)
-    if opts.hausd is not None and opts.hausd <= 0:
-        msg = "hausd must be positive"
-        raise ValueError(msg)
-    if opts.hgrad is not None and opts.hgrad < _MIN_GRADATION:
-        msg = f"hgrad must be >= {_MIN_GRADATION}"
-        raise ValueError(msg)
-    # hgradreq can be -1 to disable, or >= 1.0 for gradation control
-    if (
-        opts.hgradreq is not None
-        and opts.hgradreq != -1
-        and opts.hgradreq < _MIN_GRADATION
-    ):
-        msg = f"hgradreq must be >= {_MIN_GRADATION} or -1 to disable"
-        raise ValueError(msg)
-    if opts.ar is not None and (opts.ar < 0 or opts.ar > _MAX_ANGLE_DEGREES):
-        msg = f"ar (angle detection) must be between 0 and {_MAX_ANGLE_DEGREES} degrees"
-        raise ValueError(msg)
-    if opts.mem is not None and opts.mem <= 0:
-        msg = "mem must be positive"
-        raise ValueError(msg)
+    _validate_size_options(opts)
+    _validate_gradation_options(opts)
+    _validate_angle_option(opts.ar)
+    _validate_positive_option("mem", opts.mem)
 
 
 def _options_to_dict(

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -20,7 +20,7 @@ Example:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, NamedTuple, overload
 
 import numpy as np
 import pyvista as pv
@@ -521,6 +521,88 @@ def _extract_element_refs(
     return None
 
 
+class _Mmg3DCells(NamedTuple):
+    """Connectivity and reference arrays extracted from a 3D grid."""
+
+    elements: NDArray[np.int32]
+    edges: NDArray[np.int32] | None
+    edge_refs: NDArray[np.int64] | None
+    triangles: NDArray[np.int32] | None
+    triangle_refs: NDArray[np.int64] | None
+
+
+def _extract_mmg3d_cells(
+    mesh: pv.UnstructuredGrid,
+    cells_dict: CellsDict | None,
+) -> _Mmg3DCells:
+    """Extract MMG-compatible connectivity from a 3D grid.
+
+    Returns
+    -------
+    _Mmg3DCells
+        The extracted connectivity and reference arrays.
+
+    Raises
+    ------
+    ValueError
+        If the mixed-cell grid does not contain tetrahedra.
+
+    """
+    celltypes = np.asarray(mesh.celltypes)
+    tetra_type = int(pv.CellType.TETRA)
+    if celltypes.size > 0 and bool((celltypes == tetra_type).all()):
+        elements = np.asarray(mesh.cell_connectivity).reshape(-1, 4).astype(np.int32)
+        return _Mmg3DCells(elements, None, None, None, None)
+
+    if cells_dict is None:
+        cells_dict = mesh.cells_dict
+    if pv.CellType.TETRA not in cells_dict:
+        msg = "UnstructuredGrid must contain tetrahedra (CellType.TETRA)"
+        raise ValueError(msg)
+
+    elements = cells_dict[pv.CellType.TETRA].astype(np.int32)
+    edges, edge_refs = _extract_edges(mesh, cells_dict=cells_dict)
+    triangles = _triangle_connectivity_unstructured(mesh, cells_dict=cells_dict)
+    triangle_refs = None
+    if triangles is not None:
+        triangle_refs = _refs_for_unstructured_grid_cells(
+            mesh,
+            pv.CellType.TRIANGLE,
+            len(triangles),
+        )
+    return _Mmg3DCells(elements, edges, edge_refs, triangles, triangle_refs)
+
+
+def _build_mmg3d_mesh(
+    vertices: NDArray[np.float64],
+    cells: _Mmg3DCells,
+) -> MmgMesh3D:
+    """Build a 3D MMG mesh from vertices and connectivity.
+
+    Returns
+    -------
+    MmgMesh3D
+        The populated 3D mesh.
+
+    """
+    if cells.edges is None and cells.triangles is None:
+        return MmgMesh3D(vertices, cells.elements)
+
+    mmg_mesh = MmgMesh3D()
+    size_kwargs: dict[str, int] = {
+        "vertices": len(vertices),
+        "tetrahedra": len(cells.elements),
+    }
+    if cells.edges is not None:
+        size_kwargs["edges"] = len(cells.edges)
+    if cells.triangles is not None:
+        size_kwargs["triangles"] = len(cells.triangles)
+    mmg_mesh.set_mesh_size(**size_kwargs)
+    mmg_mesh.set_vertices(vertices)
+    mmg_mesh.set_tetrahedra(cells.elements)
+    return mmg_mesh
+
+
 def _from_pyvista_to_mmg3d(
     mesh: pv.UnstructuredGrid,
     cells_dict: CellsDict | None = None,
@@ -546,70 +628,24 @@ def _from_pyvista_to_mmg3d(
     MmgMesh3D
         The populated 3D mesh.
 
-    Raises
-    ------
-    ValueError
-        If the mixed-cell path is taken and no TETRA cells are present.
-
     """
-    celltypes = np.asarray(mesh.celltypes)
-    tetra_type = int(pv.CellType.TETRA)
-    is_all_tetra = celltypes.size > 0 and bool((celltypes == tetra_type).all())
-
-    if is_all_tetra:
-        elements = np.asarray(mesh.cell_connectivity).reshape(-1, 4).astype(np.int32)
-        edges, edge_refs = None, None
-        triangles, tri_refs = None, None
-    else:
-        if cells_dict is None:
-            cells_dict = mesh.cells_dict
-        if pv.CellType.TETRA not in cells_dict:
-            msg = "UnstructuredGrid must contain tetrahedra (CellType.TETRA)"
-            raise ValueError(msg)
-        elements = cells_dict[pv.CellType.TETRA].astype(np.int32)
-        edges, edge_refs = _extract_edges(mesh, cells_dict=cells_dict)
-        triangles = _triangle_connectivity_unstructured(mesh, cells_dict=cells_dict)
-        tri_refs = (
-            _refs_for_unstructured_grid_cells(
-                mesh,
-                pv.CellType.TRIANGLE,
-                len(triangles),
-            )
-            if triangles is not None
-            else None
-        )
-
+    cells = _extract_mmg3d_cells(mesh, cells_dict)
     vertices = np.array(mesh.points, dtype=np.float64)
     elem_refs = _extract_element_refs(
         mesh,
-        len(elements),
+        len(cells.elements),
         cell_type=pv.CellType.TETRA,
     )
-
-    if edges is None and triangles is None:
-        mmg_mesh = MmgMesh3D(vertices, elements)
-    else:
-        mmg_mesh = MmgMesh3D()
-        size_kwargs: dict[str, int] = {
-            "vertices": len(vertices),
-            "tetrahedra": len(elements),
-        }
-        if edges is not None:
-            size_kwargs["edges"] = len(edges)
-        if triangles is not None:
-            size_kwargs["triangles"] = len(triangles)
-        mmg_mesh.set_mesh_size(**size_kwargs)
-        mmg_mesh.set_vertices(vertices)
-        mmg_mesh.set_tetrahedra(elements)
+    mmg_mesh = _build_mmg3d_mesh(vertices, cells)
 
     if elem_refs is not None:
-        mmg_mesh.set_tetrahedra(elements, elem_refs)
+        mmg_mesh.set_tetrahedra(cells.elements, elem_refs)
 
-    if edges is not None:
-        mmg_mesh.set_edges(edges, edge_refs)
+    if cells.edges is not None:
+        mmg_mesh.set_edges(cells.edges, cells.edge_refs)
 
-    if triangles is not None:
-        mmg_mesh.set_triangles(triangles, tri_refs)
+    if cells.triangles is not None:
+        mmg_mesh.set_triangles(cells.triangles, cells.triangle_refs)
 
     _apply_solution_aliases(mmg_mesh, mesh.point_data)
 


### PR DESCRIPTION
## Summary

- lower the non-UI Complexipy threshold from 19 to 18
- split common option validation into focused private validators
- split 3D PyVista conversion into private connectivity extraction and mesh construction helpers
- preserve the all-tetrahedra fast path and mixed-cell edge/triangle reference handling

## Complexity

- `_validate_common_options`: 19 -> 0
- `_from_pyvista_to_mmg3d`: 19 -> 3
- new helpers: maximum score 5

## Validation

- Complexipy at threshold 18
- Ruff check and format
- pre-commit builtin checks, pyupgrade, docstring formatting, codespell, and pyproject validation
- `git diff --check`

The local `ty` and focused pytest commands could not start because the existing Windows `.venv\Lib` directory is permission-locked; CI will run them in a clean environment.