### PR TITLE
Use default Complexipy threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ preview = true
 # Lower this incrementally as the highest-complexity functions are refactored.
 # The UI is currently out of scope.
 paths = ["src/mmgpy"]
-max-complexity-allowed = 18
+max-complexity-allowed = 17
 exclude = ["ui/**"]
 failed = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,10 +155,8 @@ markers = [
 preview = true
 
 [tool.complexipy]
-# Lower this incrementally as the highest-complexity functions are refactored.
 # The UI is currently out of scope.
 paths = ["src/mmgpy"]
-max-complexity-allowed = 17
 exclude = ["ui/**"]
 failed = true
 

--- a/src/mmgpy/_io.py
+++ b/src/mmgpy/_io.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pyvista as pv
@@ -44,6 +44,9 @@ from mmgpy._mesh import (
 from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 from mmgpy._pyvista import from_pyvista
 
+if TYPE_CHECKING:
+    from typing import TextIO
+
 logger = logging.getLogger("mmgpy")
 
 _MEDIT_KEYWORD_ONLY_PATTERN = re.compile(r"^\s*(\w+)\s*$", re.IGNORECASE)
@@ -53,6 +56,36 @@ _MEDIT_DIMENSION_INLINE_PATTERN = re.compile(
 )
 _MEDIT_DIMENSION_VALUE_PATTERN = re.compile(r"^\s*(\d+)\s*$")
 _MMG_FIELDS = frozenset({"metric", "displacement", "levelset", "tensor"})
+
+
+def _parse_medit_header_line(
+    line: str,
+    lines: TextIO,
+) -> tuple[int | None, str | None]:
+    """Parse a dimension or element keyword from a Medit header line.
+
+    Returns
+    -------
+    tuple[int | None, str | None]
+        The parsed dimension and keyword, when present.
+
+    """
+    dimension_match = _MEDIT_DIMENSION_INLINE_PATTERN.match(line)
+    if dimension_match:
+        return int(dimension_match.group(1)), None
+
+    keyword_match = _MEDIT_KEYWORD_ONLY_PATTERN.match(line)
+    if not keyword_match:
+        return None, None
+
+    keyword = keyword_match.group(1).lower()
+    if keyword != "dimension":
+        return None, keyword
+
+    value_match = _MEDIT_DIMENSION_VALUE_PATTERN.match(next(lines, "").strip())
+    if value_match:
+        return int(value_match.group(1)), keyword
+    return None, keyword
 
 
 def _parse_medit_header(path: Path) -> tuple[int | None, bool, bool]:
@@ -76,30 +109,16 @@ def _parse_medit_header(path: Path) -> tuple[int | None, bool, bool]:
             if not stripped or stripped.startswith("#"):
                 continue
 
-            # Check for inline "Dimension N" format first
-            dim_inline = _MEDIT_DIMENSION_INLINE_PATTERN.match(stripped)
-            if dim_inline:
-                dimension = int(dim_inline.group(1))
-                continue
-
-            # Check for keyword-only format
-            keyword_match = _MEDIT_KEYWORD_ONLY_PATTERN.match(stripped)
-            if not keyword_match:
-                continue
-
-            keyword = keyword_match.group(1).lower()
-            if keyword == "dimension":
-                next_line = next(f, "").strip()
-                val_match = _MEDIT_DIMENSION_VALUE_PATTERN.match(next_line)
-                if val_match:
-                    dimension = int(val_match.group(1))
-            elif keyword == "tetrahedra":
+            parsed_dimension, keyword = _parse_medit_header_line(stripped, f)
+            if parsed_dimension is not None:
+                dimension = parsed_dimension
+                if keyword is None:
+                    continue
+            if keyword == "tetrahedra":
                 has_tetrahedra = True
             elif keyword == "triangles":
                 has_triangles = True
 
-            # Stop early only if we found tetrahedra (volumetric mesh)
-            # Continue scanning if only triangles found (might have tetrahedra later)
             if dimension is not None and has_tetrahedra:
                 break
 

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -378,11 +378,50 @@ def _collect_constraints_from_data(
         Mapping from MMG constraint kwarg name to the (zero-indexed)
         per-entity indices marked by the dataset's reserved tag arrays.
 
+    """
+    out = _collect_point_constraints(dataset)
+    out.update(_collect_cell_constraints(dataset))
+    return out
+
+
+def _constraint_mask(
+    data: pv.DataSetAttributes,
+    tag_name: str,
+    expected_count: int,
+    association: str,
+) -> NDArray[np.bool_]:
+    """Return a constraint tag as a validated Boolean mask.
+
+    Returns
+    -------
+    ndarray of bool
+        The normalized constraint mask.
+
     Raises
     ------
     ValueError
-        If any reserved tag array does not match ``dataset.n_points`` or
-        ``dataset.n_cells``.
+        If the tag length does not match the expected entity count.
+
+    """
+    mask = np.asarray(data[tag_name]).astype(bool, copy=False)
+    if mask.shape[0] != expected_count:
+        msg = (
+            f"{association}_data[{tag_name!r}] length {mask.shape[0]} does not "
+            f"match dataset.n_{association}s {expected_count}"
+        )
+        raise ValueError(msg)
+    return mask
+
+
+def _collect_point_constraints(
+    dataset: pv.UnstructuredGrid | pv.PolyData,
+) -> dict[str, NDArray[np.int32]]:
+    """Collect constraint indices from reserved point tags.
+
+    Returns
+    -------
+    dict[str, ndarray of int32]
+        Constraint names mapped to marked point indices.
 
     """
     out: dict[str, NDArray[np.int32]] = {}
@@ -390,15 +429,28 @@ def _collect_constraints_from_data(
     for tag_name, kwarg_name in _POINT_TAG_TO_KWARG.items():
         if tag_name not in dataset.point_data:
             continue
-        mask = np.asarray(dataset.point_data[tag_name]).astype(bool, copy=False)
-        if mask.shape[0] != dataset.n_points:
-            msg = (
-                f"point_data[{tag_name!r}] length {mask.shape[0]} does not "
-                f"match dataset.n_points {dataset.n_points}"
-            )
-            raise ValueError(msg)
+        mask = _constraint_mask(
+            dataset.point_data,
+            tag_name,
+            int(dataset.n_points),
+            "point",
+        )
         out[kwarg_name] = np.where(mask)[0].astype(np.int32, copy=False)
+    return out
 
+
+def _collect_cell_constraints(
+    dataset: pv.UnstructuredGrid | pv.PolyData,
+) -> dict[str, NDArray[np.int32]]:
+    """Collect constraint indices from reserved cell tags.
+
+    Returns
+    -------
+    dict[str, ndarray of int32]
+        Constraint names mapped to marked per-type cell indices.
+
+    """
+    out: dict[str, NDArray[np.int32]] = {}
     cell_tags_present = [
         (tag_name, kwarg_name, cell_type)
         for tag_name, (kwarg_name, cell_type) in _CELL_TAG_TO_KWARG.items()
@@ -406,23 +458,20 @@ def _collect_constraints_from_data(
     ]
     if not cell_tags_present:
         return out
-
-    # For UnstructuredGrid we cache `celltypes` and per-cell-type cumsums
-    # across all cell tags (the loop visits up to 6 tags but at most 3
-    # distinct cell types). PolyData stays on the per-tag fast path in
-    # `_per_type_indices_marked` since its slicing is already O(1) lookups.
-    is_unstructured = isinstance(dataset, pv.UnstructuredGrid)
-    types_arr = np.asarray(dataset.celltypes) if is_unstructured else None
+    types_arr = (
+        np.asarray(dataset.celltypes)
+        if isinstance(dataset, pv.UnstructuredGrid)
+        else None
+    )
     per_type_cache: dict[int, tuple[NDArray[np.bool_], NDArray[np.intp]]] = {}
 
     for tag_name, kwarg_name, cell_type in cell_tags_present:
-        mask = np.asarray(dataset.cell_data[tag_name]).astype(bool, copy=False)
-        if mask.shape[0] != dataset.n_cells:
-            msg = (
-                f"cell_data[{tag_name!r}] length {mask.shape[0]} does not "
-                f"match dataset.n_cells {dataset.n_cells}"
-            )
-            raise ValueError(msg)
+        mask = _constraint_mask(
+            dataset.cell_data,
+            tag_name,
+            int(dataset.n_cells),
+            "cell",
+        )
 
         if types_arr is None:
             out[kwarg_name] = _per_type_indices_marked(dataset, cell_type, mask)
@@ -873,6 +922,16 @@ def _coerce_metric_kwarg(
     return arr
 
 
+def _apply_metric_kwarg(
+    mesh: _Mesh,
+    dataset: pv.UnstructuredGrid | pv.PolyData,
+    metric: NDArray[np.float64] | None,
+) -> None:
+    """Apply an explicit metric to a mesh when one is supplied."""
+    if metric is not None:
+        mesh["metric"] = _coerce_metric_kwarg(metric, int(dataset.n_points))
+
+
 # ---------------------------------------------------------------------------
 # .mmg dataset accessor
 # ---------------------------------------------------------------------------
@@ -999,14 +1058,7 @@ class MmgAccessor:
 
         constraints = _split_constraint_kwargs(options)
         mesh = _build_mesh_with_mmg_fields(self._dataset)
-        if metric is not None:
-            # Smart routing in Mesh.__setitem__ dispatches to the scalar or
-            # tensor channel based on shape; overrides any metric loaded
-            # from point_data above without mutating self._dataset.
-            mesh["metric"] = _coerce_metric_kwarg(
-                metric,
-                int(self._dataset.n_points),
-            )
+        _apply_metric_kwarg(mesh, self._dataset, metric)
         _apply_constraint_markers(mesh, self._dataset, constraints)
         _apply_local_sizing_specs(mesh, local_sizing)
         _apply_pending_mmg_config(mesh, self._dataset)

--- a/src/mmgpy/_sol.py
+++ b/src/mmgpy/_sol.py
@@ -93,27 +93,40 @@ def _fields_from_block(
     fields: dict[str, dict] = {}
     col_idx = 0
     for sol_idx, sol_type in enumerate(sol_types):
+        layout = _sol_field_layout(sol_type, sol_idx, n_solutions, dimension)
+        if layout is None:
+            continue
+        base, width = layout
+        payload = data[:, col_idx : col_idx + width]
         if sol_type == _TYPE_SCALAR:
-            base = f"solution_{sol_idx}" if n_solutions > 1 else "solution"
-            payload = data if data.ndim == 1 else data[:, col_idx]
-            fields[f"{base}@{location}"] = {"data": payload, "location": location}
-            col_idx += 1
-        elif sol_type == _TYPE_VECTOR:
-            base = f"vector_{sol_idx}" if n_solutions > 1 else "vector"
-            fields[f"{base}@{location}"] = {
-                "data": data[:, col_idx : col_idx + dimension],
-                "location": location,
-            }
-            col_idx += dimension
-        elif sol_type == _TYPE_TENSOR:
-            tensor_size = dimension * (dimension + 1) // 2
-            base = f"tensor_{sol_idx}" if n_solutions > 1 else "tensor"
-            fields[f"{base}@{location}"] = {
-                "data": data[:, col_idx : col_idx + tensor_size],
-                "location": location,
-            }
-            col_idx += tensor_size
+            payload = data if data.ndim == 1 else payload[:, 0]
+        fields[f"{base}@{location}"] = {"data": payload, "location": location}
+        col_idx += width
     return fields
+
+
+def _sol_field_layout(
+    sol_type: int,
+    sol_idx: int,
+    n_solutions: int,
+    dimension: int,
+) -> tuple[str, int] | None:
+    """Return the field name and column width for a solution type.
+
+    Returns
+    -------
+    tuple[str, int] or None
+        The field name and width, or ``None`` for an unsupported type.
+
+    """
+    suffix = f"_{sol_idx}" if n_solutions > 1 else ""
+    if sol_type == _TYPE_SCALAR:
+        return f"solution{suffix}", 1
+    if sol_type == _TYPE_VECTOR:
+        return f"vector{suffix}", dimension
+    if sol_type == _TYPE_TENSOR:
+        return f"tensor{suffix}", dimension * (dimension + 1) // 2
+    return None
 
 
 def parse_sol_file(content: str) -> dict[str, dict]:


### PR DESCRIPTION
## Summary

- use Complexipy's default maximum complexity of 15 for the non-UI source tree
- remove the explicit incremental threshold setting
- extract Medit header-line parsing from the file scanner
- separate solution-field layout selection from array slicing
- separate point and cell constraint collection and centralize tag-mask validation
- isolate explicit metric application from the PyVista accessor remesh flow

## Complexity

- `_parse_medit_header`: 18 -> 15
- `_fields_from_block`: 17 -> 8
- `_collect_constraints_from_data`: 16 -> 0; extracted helpers score at most 9
- `MmgAccessor.remesh`: 16 -> 15

## Validation

- Complexipy with its default threshold
- Ruff check and format
- pre-commit builtin checks, pyupgrade, docstring formatting, codespell, and pyproject validation
- direct isolated solution-parser scalar/vector check
- `git diff --check`

The local `ty` hook cannot start because the existing `.venv\Lib` directory is permission-locked. A focused isolated pytest run also could not build the native extension because the configured global uv Python include directory is inaccessible on this Windows machine. CI will run the complete checks in a clean environment.