### PR TITLE
docs: add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released version of mmgpy. Users
+should upgrade to the newest release before reporting an issue that may already
+have been fixed.
+
+| Version        | Supported |
+| -------------- | --------- |
+| Latest release | Yes       |
+| Older releases | No        |
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities through
+[GitHub private vulnerability reporting](https://github.com/kmarchais/mmgpy/security/advisories/new).
+Do not open a public issue or discussion for an undisclosed vulnerability.
+
+Include as much of the following information as possible:
+
+- the affected mmgpy version and operating system;
+- a description of the vulnerability and its potential impact;
+- minimal reproduction steps or a proof of concept;
+- any known mitigations or suggested fixes.
+
+Reports are reviewed privately. We may ask for additional information, prepare
+a fix in a private security fork, and coordinate disclosure with the reporter.
+Please allow time for investigation and remediation before publishing details.
+
+For ordinary bugs that do not have security implications, use the repository's
+[public issue tracker](https://github.com/kmarchais/mmgpy/issues).


### PR DESCRIPTION
## Summary

- document that security fixes target the latest mmgpy release
- direct vulnerability reports to GitHub's private reporting workflow
- describe the information reporters should include
- distinguish security reports from ordinary public bug reports

## Why

Private vulnerability reporting is enabled, but the repository had no published security policy. This policy gives researchers a clear, non-public disclosure path and sets maintainable support expectations without promising a fixed response SLA.

## Validation

- `git diff --check`
- applicable prek hooks: file hygiene, private-key detection, pydocstringformatter, codespell, and prettier
- the unrelated `ty` hook remains blocked locally by the existing Windows/Clang editable-build issue in the multi-solution bindings; this PR changes Markdown only