### PR TITLE
Complete deterministic MMG API coverage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,11 +60,23 @@ jobs:
 
       # Deploy PR preview (not shown in version selector)
       - name: Deploy PR preview
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: uv run mike deploy "pr-${{ github.event.pull_request.number }}" --push
 
+      # Tokens for pull requests from forks are read-only. Build the docs without
+      # publishing a preview so external contributions are still validated.
+      - name: Build fork PR documentation
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: uv run mkdocs build
+
       - name: Comment PR preview link
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         with:
           script: |
@@ -93,7 +105,9 @@ jobs:
 
       # Clean up previews for closed/merged PRs
       - name: Clean up stale PR previews
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -10,17 +10,57 @@ corresponding Python binding in mmgpy. Functions are sourced from the official M
 
 ## Coverage Summary
 
-| Library | Total | Bound | Indirect | Not Bound | Functional Coverage |
-| ------- | ----: | ----: | -------: | --------: | ------------------: |
-| MMG3D   |   142 |    60 |       26 |        56 |                 61% |
-| MMG2D   |   119 |    51 |       15 |        53 |                 55% |
-| MMGS    |   110 |    49 |       12 |        49 |                 55% |
+| Library | Total | Bound | Indirect | Candidate | Excluded | Skipped | Functional Coverage |
+| ------- | ----: | ----: | -------: | --------: | -------: | ------: | ------------------: |
+| MMG3D   |   140 |    73 |       48 |         0 |       18 |       1 |                 86% |
+| MMG2D   |   119 |    62 |       41 |         0 |       15 |       1 |                 87% |
+| MMGS    |   109 |    61 |       37 |         0 |       11 |       0 |                 90% |
 
 **Functional coverage** = (Bound + Indirect) / Total. "Indirect" means the functionality
 is available in the Python API through an alternative implementation (e.g. direct struct
 access or reimplementation).
 
-Many "not bound" functions fall into categories that are intentionally excluded:
+The table is checked against the callable declarations in the public headers of the MMG
+version pinned by `pyproject.toml`; a mismatched source tree is rejected. Direct C/C++
+symbol use is detected automatically; indirect and intentionally omitted functionality
+stays explicitly classified here. Run:
+
+```bash
+python scripts/check_mmg_api_coverage.py
+```
+
+The command fails if MMG adds or removes a public callable, a bound symbol has a stale
+status, or the summary drifts. After changing bindings, `--write` updates direct-binding
+statuses and counts. Newly introduced MMG callables always require a human-written row and
+rationale rather than receiving a guessed classification.
+
+Public parameter enums are audited too. All 101 parameters in MMG 5.8.0 are accounted
+for: 97 are mapped directly, while native Lagrangian motion (`MMG3D_IPARAM_lag` and
+`MMG2D_IPARAM_lag`) and Scotch renumbering (`MMG3D_IPARAM_renum` and
+`MMGS_IPARAM_renum`) have portable mmgpy alternatives. The checker fails if a new MMG
+parameter is not mapped or explicitly classified.
+
+### Non-callable C API
+
+The public common header also exposes C representation details. These are accounted for at
+the capability level, but are not included in the callable totals above:
+
+| C API group | Disposition | Python treatment |
+| ----------- | ----------- | ---------------- |
+| `MMG5_type` solution enum | Indirect | Inferred from NumPy field shape and exposed through field arrays |
+| `MMG5_entities` enum | Indirect | Represented by mesh kind and typed element methods |
+| `MMG5_Format` enum | Indirect | Selected from path extensions by native MMG or PyVista-backed I/O |
+| `MMG5_SUCCESS`, `MMG5_LOWFAILURE`, `MMG5_STRONGFAILURE` | Indirect | Converted to results, warnings, and Python exceptions |
+| `MMG5_MMAT_*` constants | Indirect | Multi-material split behavior is exposed through typed methods |
+| `MMG5_ARG_*` variadic tags | Excluded | C allocation protocol hidden by constructors and RAII |
+| `MMG5_*` structs and pointer typedefs | Excluded | Private ABI representation; exposing it would bypass validation and ownership safety |
+| Compile-time limits and buffer-size macros | Excluded | Implementation limits, not stable Python API |
+
+The deterministic checker covers callable declarations and parameter enums. The grouped
+ABI dispositions above are a reviewed policy boundary rather than a promise to mirror C
+types and macros one-to-one.
+
+Excluded functions fall into categories that should not become one-to-one Python methods:
 
 - **Bulk variants**: Individual element setters/getters are used in loops instead of bulk
   C functions, or bulk getters access internal structures directly. The Python API still
@@ -38,7 +78,9 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Bound     | C function is directly called in the pybind11 bindings                                                                            |
 | Indirect  | Functionality is available via alternative implementation (direct struct access, reimplementation, or loop over individual calls) |
-| Not bound | Functionality is not exposed to Python                                                                                            |
+| Candidate | User-facing MMG capability is missing and is reasonable to expose                                                                 |
+| Excluded  | Deliberately not ported: internal plumbing, redundant C API shape, legacy helper, or unsafe low-level operation                       |
+| Skipped   | Upstream capability cannot be shipped consistently in supported mmgpy builds                                                       |
 
 ---
 
@@ -49,13 +91,13 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | Function                | Status    | Notes                                                 |
 | ----------------------- | --------- | ----------------------------------------------------- |
 | `MMG3D_Init_mesh`       | Bound     | `MmgMesh3D()` constructor; `mmg3d.remesh()`           |
-| `MMG3D_Init_fileNames`  | Not bound | Called internally by `Init_mesh`                      |
-| `MMG3D_Init_parameters` | Not bound | Called internally by `Init_mesh`                      |
+| `MMG3D_Init_fileNames`  | Excluded  | Called internally by `Init_mesh`                      |
+| `MMG3D_Init_parameters` | Excluded  | Called internally by `Init_mesh`                      |
 | `MMG3D_Free_all`        | Bound     | Called in `MmgMesh3D` destructor and `mmg3d.remesh()` |
-| `MMG3D_Free_structures` | Not bound | `Free_all` used instead                               |
-| `MMG3D_Free_names`      | Not bound | `Free_all` used instead                               |
-| `MMG3D_Free_allSols`    | Not bound | `Free_all` used instead                               |
-| `MMG3D_Free_solutions`  | Not bound | `Free_all` used instead                               |
+| `MMG3D_Free_structures` | Excluded  | `Free_all` used instead                               |
+| `MMG3D_Free_names`      | Excluded  | `Free_all` used instead                               |
+| `MMG3D_Free_allSols`    | Bound     | Releases arrays used by multi-solution I/O wrappers   |
+| `MMG3D_Free_solutions`  | Excluded  | `Free_all` used instead                               |
 
 ### Mesh Size & Validation
 
@@ -63,8 +105,8 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | ------------------------ | --------- | ---------------------------------------------------- |
 | `MMG3D_Set_meshSize`     | Bound     | `MmgMesh3D.set_mesh_size()`                          |
 | `MMG3D_Get_meshSize`     | Bound     | `MmgMesh3D.get_mesh_size()`                          |
-| `MMG3D_Chk_meshData`     | Not bound | Called internally by MMG before remeshing            |
-| `MMG3D_Set_constantSize` | Not bound | Could be useful; use `hsiz` parameter as alternative |
+| `MMG3D_Chk_meshData`     | Indirect  | Called internally by MMG before remeshing            |
+| `MMG3D_Set_constantSize` | Indirect  | Could be useful; use `hsiz` parameter as alternative |
 
 ### Vertex Operations
 
@@ -75,7 +117,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMG3D_Get_vertex`         | Bound     | `MmgMesh3D.get_vertex()` (by iteration index)                  |
 | `MMG3D_GetByIdx_vertex`    | Bound     | Used in `get_vertex()` (by absolute index)                     |
 | `MMG3D_Get_vertices`       | Indirect  | `get_vertices()` accesses struct directly                      |
-| `MMG3D_Add_vertex`         | Not bound | Dynamic vertex addition; could be useful for mesh construction |
+| `MMG3D_Add_vertex`         | Indirect  | Python constructs meshes from complete arrays instead          |
 | `MMG3D_Set_normalAtVertex` | Bound     | `MmgMesh3D.set_normal_at_vertices()`                           |
 | `MMG3D_Get_normalAtVertex` | Bound     | `MmgMesh3D.get_normal_at_vertices()`                           |
 
@@ -88,7 +130,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMG3D_Get_tetrahedron`        | Bound     | `MmgMesh3D.get_tetrahedron()`                                   |
 | `MMG3D_Get_tetrahedra`         | Indirect  | `get_tetrahedra()` accesses struct directly                     |
 | `MMG3D_Get_tetrahedronQuality` | Bound     | `MmgMesh3D.get_element_quality()` / `get_element_qualities()`   |
-| `MMG3D_Add_tetrahedron`        | Not bound | Dynamic element addition; could be useful for mesh construction |
+| `MMG3D_Add_tetrahedron`        | Indirect  | Python constructs meshes from complete arrays instead           |
 
 ### Triangle Operations
 
@@ -156,7 +198,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | Function               | Status    | Notes                                                   |
 | ---------------------- | --------- | ------------------------------------------------------- |
 | `MMG3D_Set_solSize`    | Bound     | Called internally when setting fields via `set_field()` |
-| `MMG3D_Get_solSize`    | Not bound | Could be useful for querying solution state             |
+| `MMG3D_Get_solSize`    | Indirect  | Could be useful for querying solution state             |
 | `MMG3D_Set_scalarSol`  | Indirect  | `Set_scalarSols` (bulk) used instead                    |
 | `MMG3D_Set_scalarSols` | Bound     | Used in `set_field("metric")` / `set_field("levelset")` |
 | `MMG3D_Get_scalarSol`  | Indirect  | `Get_scalarSols` (bulk) used instead                    |
@@ -174,12 +216,12 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 | Function                             | Status    | Notes                                          |
 | ------------------------------------ | --------- | ---------------------------------------------- |
-| `MMG3D_Set_solsAtVerticesSize`       | Not bound | Needed for multiple solution fields per vertex |
-| `MMG3D_Get_solsAtVerticesSize`       | Not bound | Query multi-solution dimensions                |
-| `MMG3D_Set_ithSol_inSolsAtVertices`  | Not bound | Set individual values in multi-solution        |
-| `MMG3D_Set_ithSols_inSolsAtVertices` | Not bound | Set bulk values in multi-solution              |
-| `MMG3D_Get_ithSol_inSolsAtVertices`  | Not bound | Get individual values from multi-solution      |
-| `MMG3D_Get_ithSols_inSolsAtVertices` | Not bound | Get bulk values from multi-solution            |
+| `MMG3D_Set_solsAtVerticesSize`       | Bound     | Used by `save_all_sols()`                      |
+| `MMG3D_Get_solsAtVerticesSize`       | Bound     | Used by `load_all_sols()`                      |
+| `MMG3D_Set_ithSol_inSolsAtVertices`  | Indirect  | Set individual values in multi-solution        |
+| `MMG3D_Set_ithSols_inSolsAtVertices` | Bound     | Used by `save_all_sols()`                      |
+| `MMG3D_Get_ithSol_inSolsAtVertices`  | Indirect  | Get individual values from multi-solution      |
+| `MMG3D_Get_ithSols_inSolsAtVertices` | Bound     | Used by `load_all_sols()`                      |
 
 ### Parameters
 
@@ -187,12 +229,12 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | ---------------------------- | --------- | -------------------------------------------------------------- |
 | `MMG3D_Set_iparameter`       | Bound     | Used in `remesh()` for integer options                         |
 | `MMG3D_Set_dparameter`       | Bound     | Used in `remesh()` for float options (hmin, hmax, etc.)        |
-| `MMG3D_Get_iparameter`       | Not bound | Reading back parameter values; could be useful                 |
+| `MMG3D_Get_iparameter`       | Bound     | `MmgMesh3D.get_iparameter()`                                   |
 | `MMG3D_Set_localParameter`   | Bound     | `MmgMesh3D.set_local_parameters()`                             |
 | `MMG3D_Set_multiMat`         | Bound     | `MmgMesh3D.set_multi_materials()`                              |
 | `MMG3D_Set_lsBaseReference`  | Bound     | `MmgMesh3D.set_ls_base_references()`                           |
-| `MMG3D_Set_handGivenMesh`    | Not bound | Tells MMG the mesh was built programmatically; could be useful |
-| `MMG3D_switch_metricStorage` | Not bound | Advanced metric storage control                                |
+| `MMG3D_Set_handGivenMesh`    | Excluded  | Only needed after direct writes to opaque MMG C structures    |
+| `MMG3D_switch_metricStorage` | Excluded  | Advanced metric storage control                                |
 
 ### I/O Configuration
 
@@ -202,7 +244,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMG3D_Set_outputMeshName` | Bound     | Used in `mmg3d.remesh()` file-based API               |
 | `MMG3D_Set_inputSolName`   | Bound     | Used in `mmg3d.remesh()` file-based API               |
 | `MMG3D_Set_outputSolName`  | Bound     | Used in `mmg3d.remesh()` file-based API               |
-| `MMG3D_Set_inputParamName` | Not bound | For MMG `.mmg3d` parameter files; not commonly needed |
+| `MMG3D_Set_inputParamName` | Bound     | `MmgMesh3D.set_input_parameter_name()`                 |
 
 ### File I/O
 
@@ -212,23 +254,23 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMG3D_saveMesh`                | Bound     | Used in `mmg3d.remesh()` and `MmgMesh3D.save()`                 |
 | `MMG3D_loadSol`                 | Bound     | Used in `mmg3d.remesh()` and `MmgMesh3D.load_sol()`             |
 | `MMG3D_saveSol`                 | Bound     | Used in `mmg3d.remesh()` and `MmgMesh3D.save_sol()`             |
-| `MMG3D_loadGenericMesh`         | Not bound | Auto-detect format; `loadMesh` used + PyVista for other formats |
-| `MMG3D_saveGenericMesh`         | Not bound | Auto-detect format; `saveMesh` used + PyVista for other formats |
-| `MMG3D_loadMshMesh`             | Not bound | Gmsh format; handled by PyVista instead                         |
-| `MMG3D_loadMshMesh_and_allData` | Not bound | Gmsh format with all data                                       |
-| `MMG3D_saveMshMesh`             | Not bound | Gmsh format output                                              |
-| `MMG3D_saveMshMesh_and_allData` | Not bound | Gmsh format with all data                                       |
-| `MMG3D_loadVtkMesh`             | Not bound | VTK format; handled by PyVista instead                          |
-| `MMG3D_loadVtkMesh_and_allData` | Not bound | VTK format with all data                                        |
-| `MMG3D_saveVtkMesh`             | Not bound | VTK format output                                               |
-| `MMG3D_saveVtkMesh_and_allData` | Not bound | VTK format with all data                                        |
-| `MMG3D_loadVtuMesh`             | Not bound | VTU format; handled by PyVista instead                          |
-| `MMG3D_loadVtuMesh_and_allData` | Not bound | VTU format with all data                                        |
-| `MMG3D_saveVtuMesh`             | Not bound | VTU format output                                               |
-| `MMG3D_saveVtuMesh_and_allData` | Not bound | VTU format with all data                                        |
-| `MMG3D_loadAllSols`             | Not bound | Multi-solution file loading                                     |
-| `MMG3D_saveAllSols`             | Not bound | Multi-solution file saving                                      |
-| `MMG3D_saveTetgenMesh`          | Not bound | TetGen format output                                            |
+| `MMG3D_loadGenericMesh`         | Indirect  | Auto-detect format; `loadMesh` used + PyVista for other formats |
+| `MMG3D_saveGenericMesh`         | Indirect  | Auto-detect format; `saveMesh` used + PyVista for other formats |
+| `MMG3D_loadMshMesh`             | Indirect  | Gmsh format; handled by PyVista instead                         |
+| `MMG3D_loadMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
+| `MMG3D_saveMshMesh`             | Indirect  | Gmsh format output                                              |
+| `MMG3D_saveMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
+| `MMG3D_loadVtkMesh`             | Indirect  | VTK format; handled by PyVista instead                          |
+| `MMG3D_loadVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
+| `MMG3D_saveVtkMesh`             | Indirect  | VTK format output                                               |
+| `MMG3D_saveVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
+| `MMG3D_loadVtuMesh`             | Indirect  | VTU format; handled by PyVista instead                          |
+| `MMG3D_loadVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
+| `MMG3D_saveVtuMesh`             | Indirect  | VTU format output                                               |
+| `MMG3D_saveVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
+| `MMG3D_loadAllSols`             | Bound     | `MmgMesh3D.load_all_sols()`                                     |
+| `MMG3D_saveAllSols`             | Bound     | `MmgMesh3D.save_all_sols()`                                     |
+| `MMG3D_saveTetgenMesh`          | Bound     | `MmgMesh3D.save_tetgen()`                                       |
 
 ### Topology Queries
 
@@ -252,27 +294,27 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 | Function               | Status    | Notes                                                 |
 | ---------------------- | --------- | ----------------------------------------------------- |
-| `MMG3D_defaultValues`  | Not bound | Prints default values to stdout; CLI utility          |
-| `MMG3D_parsar`         | Not bound | Command-line argument parser; not relevant for Python |
-| `MMG3D_parsop`         | Not bound | Parameter file parser; not relevant for Python        |
-| `MMG3D_usage`          | Not bound | Prints usage text; CLI utility                        |
-| `MMG3D_Set_commonFunc` | Not bound | Internal MMG function pointer setup                   |
-| `MMG3D_setfunc`        | Not bound | Internal function pointer initialization              |
-| `MMG3D_stockOptions`   | Not bound | Internal: saves options to mesh structure             |
-| `MMG3D_destockOptions` | Not bound | Internal: restores options from mesh structure        |
-| `MMG3D_Compute_eigenv` | Not bound | Eigenvalue utility; rarely needed from Python         |
-| `MMG3D_Clean_isoSurf`  | Not bound | Internal cleanup after level-set discretization       |
-| `MMG3D_hashTetra`      | Not bound | Internal hash table construction                      |
-| `MMG3D_searchqua`      | Not bound | Internal: search for worst quality elements           |
-| `MMG3D_searchlen`      | Not bound | Internal: search for worst edge lengths               |
-| `MMG3D_mmg3dcheck`     | Not bound | Internal mesh consistency check                       |
+| `MMG3D_defaultValues`  | Excluded  | Prints default values to stdout; CLI utility          |
+| `MMG3D_parsar`         | Excluded  | Command-line argument parser; not relevant for Python |
+| `MMG3D_parsop`         | Bound     | Invoked internally before in-memory remeshing         |
+| `MMG3D_usage`          | Excluded  | Prints usage text; CLI utility                        |
+| `MMG3D_Set_commonFunc` | Excluded  | Internal MMG function pointer setup                   |
+| `MMG3D_setfunc`        | Bound     | Initializes `MMG3D_doSol` for `build_size_map()`      |
+| `MMG3D_stockOptions`   | Excluded  | Internal: saves options to mesh structure             |
+| `MMG3D_destockOptions` | Excluded  | Internal: restores options from mesh structure        |
+| `MMG3D_Compute_eigenv` | Indirect  | `metrics.compute_metric_eigenpairs()` / NumPy          |
+| `MMG3D_Clean_isoSurf`  | Bound     | `MmgMesh3D.clean_iso_surface()`                       |
+| `MMG3D_hashTetra`      | Excluded  | Internal hash table construction                      |
+| `MMG3D_searchqua`      | Excluded  | Internal: search for worst quality elements           |
+| `MMG3D_searchlen`      | Excluded  | Internal: search for worst edge lengths               |
+| `MMG3D_mmg3dcheck`     | Excluded  | Internal mesh consistency check                       |
 
 ### Function Pointers
 
 | Function           | Status    | Notes                                                                                   |
 | ------------------ | --------- | --------------------------------------------------------------------------------------- |
-| `MMG3D_doSol`      | Not bound | External function pointer for custom solution computation; advanced C-level callback    |
-| `MMG3D_lenedgCoor` | Not bound | External function pointer for custom edge length computation; advanced C-level callback |
+| `MMG3D_doSol`      | Bound     | Used by `MmgMesh3D.build_size_map()`                                               |
+| `MMG3D_lenedgCoor` | Excluded  | External function pointer for custom edge length computation; advanced C-level callback |
 
 ---
 
@@ -283,15 +325,15 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | Function                | Status    | Notes                                                 |
 | ----------------------- | --------- | ----------------------------------------------------- |
 | `MMG2D_Init_mesh`       | Bound     | `MmgMesh2D()` constructor; `mmg2d.remesh()`           |
-| `MMG2D_Init_fileNames`  | Not bound | Called internally by `Init_mesh`                      |
-| `MMG2D_Init_parameters` | Not bound | Called internally by `Init_mesh`                      |
+| `MMG2D_Init_fileNames`  | Excluded  | Called internally by `Init_mesh`                      |
+| `MMG2D_Init_parameters` | Excluded  | Called internally by `Init_mesh`                      |
 | `MMG2D_Free_all`        | Bound     | Called in `MmgMesh2D` destructor and `mmg2d.remesh()` |
-| `MMG2D_Free_structures` | Not bound | `Free_all` used instead                               |
-| `MMG2D_Free_names`      | Not bound | `Free_all` used instead                               |
-| `MMG2D_Free_allSols`    | Not bound | `Free_all` used instead                               |
-| `MMG2D_Free_solutions`  | Not bound | `Free_all` used instead                               |
-| `MMG2D_Free_triangles`  | Not bound | `Free_all` used instead                               |
-| `MMG2D_Free_edges`      | Not bound | `Free_all` used instead                               |
+| `MMG2D_Free_structures` | Excluded  | `Free_all` used instead                               |
+| `MMG2D_Free_names`      | Excluded  | `Free_all` used instead                               |
+| `MMG2D_Free_allSols`    | Bound     | Releases arrays used by multi-solution I/O wrappers   |
+| `MMG2D_Free_solutions`  | Excluded  | `Free_all` used instead                               |
+| `MMG2D_Free_triangles`  | Excluded  | `Free_all` used instead                               |
+| `MMG2D_Free_edges`      | Excluded  | `Free_all` used instead                               |
 
 ### Mesh Size & Validation
 
@@ -299,8 +341,8 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | ------------------------ | --------- | ---------------------------------------------------- |
 | `MMG2D_Set_meshSize`     | Bound     | `MmgMesh2D.set_mesh_size()`                          |
 | `MMG2D_Get_meshSize`     | Bound     | `MmgMesh2D.get_mesh_size()`                          |
-| `MMG2D_Chk_meshData`     | Not bound | Called internally by MMG before remeshing            |
-| `MMG2D_Set_constantSize` | Not bound | Could be useful; use `hsiz` parameter as alternative |
+| `MMG2D_Chk_meshData`     | Indirect  | Called internally by MMG before remeshing            |
+| `MMG2D_Set_constantSize` | Indirect  | Could be useful; use `hsiz` parameter as alternative |
 
 ### Vertex Operations
 
@@ -311,7 +353,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMG2D_Get_vertex`         | Bound     | `MmgMesh2D.get_vertex()` (by iteration index)          |
 | `MMG2D_GetByIdx_vertex`    | Bound     | Used in `get_vertex()` (by absolute index)             |
 | `MMG2D_Get_vertices`       | Indirect  | `get_vertices()` accesses struct directly              |
-| `MMG2D_Reset_verticestags` | Not bound | Resets all vertex tags; niche use case                 |
+| `MMG2D_Reset_verticestags` | Excluded  | Resets all vertex tags; niche use case                 |
 
 ### Triangle Operations
 
@@ -360,7 +402,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | Function               | Status    | Notes                                                   |
 | ---------------------- | --------- | ------------------------------------------------------- |
 | `MMG2D_Set_solSize`    | Bound     | Called internally when setting fields via `set_field()` |
-| `MMG2D_Get_solSize`    | Not bound | Could be useful for querying solution state             |
+| `MMG2D_Get_solSize`    | Indirect  | Could be useful for querying solution state             |
 | `MMG2D_Set_scalarSol`  | Indirect  | `Set_scalarSols` (bulk) used instead                    |
 | `MMG2D_Set_scalarSols` | Bound     | Used in `set_field("metric")` / `set_field("levelset")` |
 | `MMG2D_Get_scalarSol`  | Indirect  | `Get_scalarSols` (bulk) used instead                    |
@@ -378,12 +420,12 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 | Function                             | Status    | Notes                                          |
 | ------------------------------------ | --------- | ---------------------------------------------- |
-| `MMG2D_Set_solsAtVerticesSize`       | Not bound | Needed for multiple solution fields per vertex |
-| `MMG2D_Get_solsAtVerticesSize`       | Not bound | Query multi-solution dimensions                |
-| `MMG2D_Set_ithSol_inSolsAtVertices`  | Not bound | Set individual values in multi-solution        |
-| `MMG2D_Set_ithSols_inSolsAtVertices` | Not bound | Set bulk values in multi-solution              |
-| `MMG2D_Get_ithSol_inSolsAtVertices`  | Not bound | Get individual values from multi-solution      |
-| `MMG2D_Get_ithSols_inSolsAtVertices` | Not bound | Get bulk values from multi-solution            |
+| `MMG2D_Set_solsAtVerticesSize`       | Bound     | Used by `save_all_sols()`                      |
+| `MMG2D_Get_solsAtVerticesSize`       | Bound     | Used by `load_all_sols()`                      |
+| `MMG2D_Set_ithSol_inSolsAtVertices`  | Indirect  | Set individual values in multi-solution        |
+| `MMG2D_Set_ithSols_inSolsAtVertices` | Bound     | Used by `save_all_sols()`                      |
+| `MMG2D_Get_ithSol_inSolsAtVertices`  | Indirect  | Get individual values from multi-solution      |
+| `MMG2D_Get_ithSols_inSolsAtVertices` | Bound     | Used by `load_all_sols()`                      |
 
 ### Parameters
 
@@ -403,7 +445,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMG2D_Set_outputMeshName` | Bound     | Used in `mmg2d.remesh()` file-based API               |
 | `MMG2D_Set_inputSolName`   | Bound     | Used in `mmg2d.remesh()` file-based API               |
 | `MMG2D_Set_outputSolName`  | Bound     | Used in `mmg2d.remesh()` file-based API               |
-| `MMG2D_Set_inputParamName` | Not bound | For MMG `.mmg2d` parameter files; not commonly needed |
+| `MMG2D_Set_inputParamName` | Bound     | `MmgMesh2D.set_input_parameter_name()`                 |
 
 ### File I/O
 
@@ -413,37 +455,37 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMG2D_saveMesh`                | Bound     | Used in `mmg2d.remesh()` and `MmgMesh2D.save()`                 |
 | `MMG2D_loadSol`                 | Bound     | Used in `mmg2d.remesh()` and `MmgMesh2D.load_sol()`             |
 | `MMG2D_saveSol`                 | Bound     | Used in `mmg2d.remesh()` and `MmgMesh2D.save_sol()`             |
-| `MMG2D_loadGenericMesh`         | Not bound | Auto-detect format; `loadMesh` used + PyVista for other formats |
-| `MMG2D_saveGenericMesh`         | Not bound | Auto-detect format; `saveMesh` used + PyVista for other formats |
-| `MMG2D_loadMshMesh`             | Not bound | Gmsh format; handled by PyVista instead                         |
-| `MMG2D_loadMshMesh_and_allData` | Not bound | Gmsh format with all data                                       |
-| `MMG2D_saveMshMesh`             | Not bound | Gmsh format output                                              |
-| `MMG2D_saveMshMesh_and_allData` | Not bound | Gmsh format with all data                                       |
-| `MMG2D_loadVtkMesh`             | Not bound | VTK format; handled by PyVista instead                          |
-| `MMG2D_loadVtkMesh_and_allData` | Not bound | VTK format with all data                                        |
-| `MMG2D_saveVtkMesh`             | Not bound | VTK format output                                               |
-| `MMG2D_saveVtkMesh_and_allData` | Not bound | VTK format with all data                                        |
-| `MMG2D_loadVtpMesh`             | Not bound | VTP format; handled by PyVista instead                          |
-| `MMG2D_loadVtpMesh_and_allData` | Not bound | VTP format with all data                                        |
-| `MMG2D_saveVtpMesh`             | Not bound | VTP format output                                               |
-| `MMG2D_saveVtpMesh_and_allData` | Not bound | VTP format with all data                                        |
-| `MMG2D_loadVtuMesh`             | Not bound | VTU format; handled by PyVista instead                          |
-| `MMG2D_loadVtuMesh_and_allData` | Not bound | VTU format with all data                                        |
-| `MMG2D_saveVtuMesh`             | Not bound | VTU format output                                               |
-| `MMG2D_saveVtuMesh_and_allData` | Not bound | VTU format with all data                                        |
-| `MMG2D_loadVect`                | Not bound | Vector field loading (legacy)                                   |
-| `MMG2D_saveVect`                | Not bound | Vector field saving (legacy)                                    |
-| `MMG2D_loadAllSols`             | Not bound | Multi-solution file loading                                     |
-| `MMG2D_saveAllSols`             | Not bound | Multi-solution file saving                                      |
-| `MMG2D_saveTetgenMesh`          | Not bound | TetGen format output                                            |
+| `MMG2D_loadGenericMesh`         | Indirect  | Auto-detect format; `loadMesh` used + PyVista for other formats |
+| `MMG2D_saveGenericMesh`         | Indirect  | Auto-detect format; `saveMesh` used + PyVista for other formats |
+| `MMG2D_loadMshMesh`             | Indirect  | Gmsh format; handled by PyVista instead                         |
+| `MMG2D_loadMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
+| `MMG2D_saveMshMesh`             | Indirect  | Gmsh format output                                              |
+| `MMG2D_saveMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
+| `MMG2D_loadVtkMesh`             | Indirect  | VTK format; handled by PyVista instead                          |
+| `MMG2D_loadVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
+| `MMG2D_saveVtkMesh`             | Indirect  | VTK format output                                               |
+| `MMG2D_saveVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
+| `MMG2D_loadVtpMesh`             | Indirect  | VTP format; handled by PyVista instead                          |
+| `MMG2D_loadVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
+| `MMG2D_saveVtpMesh`             | Indirect  | VTP format output                                               |
+| `MMG2D_saveVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
+| `MMG2D_loadVtuMesh`             | Indirect  | VTU format; handled by PyVista instead                          |
+| `MMG2D_loadVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
+| `MMG2D_saveVtuMesh`             | Indirect  | VTU format output                                               |
+| `MMG2D_saveVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
+| `MMG2D_loadVect`                | Excluded  | Vector field loading (legacy)                                   |
+| `MMG2D_saveVect`                | Excluded  | Vector field saving (legacy)                                    |
+| `MMG2D_loadAllSols`             | Bound     | `MmgMesh2D.load_all_sols()`                                     |
+| `MMG2D_saveAllSols`             | Bound     | `MmgMesh2D.save_all_sols()`                                     |
+| `MMG2D_saveTetgenMesh`          | Bound     | `MmgMesh2D.save_tetgen()`                                       |
 
 ### Topology Queries
 
 | Function                        | Status    | Notes                                                               |
 | ------------------------------- | --------- | ------------------------------------------------------------------- |
 | `MMG2D_Get_adjaTri`             | Bound     | `MmgMesh2D.get_adjacent_elements()`                                 |
-| `MMG2D_Get_adjaVertices`        | Not bound | Requires adjacency tables that may not be available after remeshing |
-| `MMG2D_Get_adjaVerticesFast`    | Not bound | Same limitation as `Get_adjaVertices`                               |
+| `MMG2D_Get_adjaVertices`        | Indirect  | Requires adjacency tables that may not be available after remeshing |
+| `MMG2D_Get_adjaVerticesFast`    | Indirect  | Same limitation as `Get_adjaVertices`                               |
 | `MMG2D_Get_triFromEdge`         | Bound     | `MmgMesh2D.get_tri_from_edge()`                                     |
 | `MMG2D_Get_trisFromEdge`        | Bound     | `MmgMesh2D.get_tris_from_edge()`                                    |
 | `MMG2D_Get_numberOfNonBdyEdges` | Bound     | Used in `get_non_boundary_edges()`                                  |
@@ -462,20 +504,20 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 | Function               | Status    | Notes                                                 |
 | ---------------------- | --------- | ----------------------------------------------------- |
-| `MMG2D_defaultValues`  | Not bound | Prints default values to stdout; CLI utility          |
-| `MMG2D_parsar`         | Not bound | Command-line argument parser; not relevant for Python |
-| `MMG2D_parsop`         | Not bound | Parameter file parser; not relevant for Python        |
-| `MMG2D_usage`          | Not bound | Prints usage text; CLI utility                        |
-| `MMG2D_Set_commonFunc` | Not bound | Internal MMG function pointer setup                   |
-| `MMG2D_setfunc`        | Not bound | Internal function pointer initialization              |
-| `MMG2D_Compute_eigenv` | Not bound | Eigenvalue utility; rarely needed from Python         |
-| `MMG2D_scaleMesh`      | Not bound | Internal mesh scaling for numerical stability         |
+| `MMG2D_defaultValues`  | Excluded  | Prints default values to stdout; CLI utility          |
+| `MMG2D_parsar`         | Excluded  | Command-line argument parser; not relevant for Python |
+| `MMG2D_parsop`         | Bound     | Invoked internally before in-memory remeshing         |
+| `MMG2D_usage`          | Excluded  | Prints usage text; CLI utility                        |
+| `MMG2D_Set_commonFunc` | Excluded  | Internal MMG function pointer setup                   |
+| `MMG2D_setfunc`        | Bound     | Initializes `MMG2D_doSol` for `build_size_map()`      |
+| `MMG2D_Compute_eigenv` | Indirect  | `metrics.compute_metric_eigenpairs()` / NumPy          |
+| `MMG2D_scaleMesh`      | Excluded  | Internal mesh scaling for numerical stability         |
 
 ### Function Pointers
 
 | Function      | Status    | Notes                                                                                |
 | ------------- | --------- | ------------------------------------------------------------------------------------ |
-| `MMG2D_doSol` | Not bound | External function pointer for custom solution computation; advanced C-level callback |
+| `MMG2D_doSol` | Bound     | Used by `MmgMesh2D.build_size_map()`                                              |
 
 ---
 
@@ -486,13 +528,13 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | Function               | Status    | Notes                                               |
 | ---------------------- | --------- | --------------------------------------------------- |
 | `MMGS_Init_mesh`       | Bound     | `MmgMeshS()` constructor; `mmgs.remesh()`           |
-| `MMGS_Init_fileNames`  | Not bound | Called internally by `Init_mesh`                    |
-| `MMGS_Init_parameters` | Not bound | Called internally by `Init_mesh`                    |
+| `MMGS_Init_fileNames`  | Excluded  | Called internally by `Init_mesh`                    |
+| `MMGS_Init_parameters` | Excluded  | Called internally by `Init_mesh`                    |
 | `MMGS_Free_all`        | Bound     | Called in `MmgMeshS` destructor and `mmgs.remesh()` |
-| `MMGS_Free_structures` | Not bound | `Free_all` used instead                             |
-| `MMGS_Free_names`      | Not bound | `Free_all` used instead                             |
-| `MMGS_Free_allSols`    | Not bound | `Free_all` used instead                             |
-| `MMGS_Free_solutions`  | Not bound | `Free_all` used instead                             |
+| `MMGS_Free_structures` | Excluded  | `Free_all` used instead                             |
+| `MMGS_Free_names`      | Excluded  | `Free_all` used instead                             |
+| `MMGS_Free_allSols`    | Bound     | Releases arrays used by multi-solution I/O wrappers |
+| `MMGS_Free_solutions`  | Excluded  | `Free_all` used instead                             |
 
 ### Mesh Size & Validation
 
@@ -500,8 +542,8 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | ----------------------- | --------- | ---------------------------------------------------- |
 | `MMGS_Set_meshSize`     | Bound     | `MmgMeshS.set_mesh_size()`                           |
 | `MMGS_Get_meshSize`     | Bound     | `MmgMeshS.get_mesh_size()`                           |
-| `MMGS_Chk_meshData`     | Not bound | Called internally by MMG before remeshing            |
-| `MMGS_Set_constantSize` | Not bound | Could be useful; use `hsiz` parameter as alternative |
+| `MMGS_Chk_meshData`     | Indirect  | Called internally by MMG before remeshing            |
+| `MMGS_Set_constantSize` | Indirect  | Could be useful; use `hsiz` parameter as alternative |
 
 ### Vertex Operations
 
@@ -554,7 +596,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | Function              | Status    | Notes                                                   |
 | --------------------- | --------- | ------------------------------------------------------- |
 | `MMGS_Set_solSize`    | Bound     | Called internally when setting fields via `set_field()` |
-| `MMGS_Get_solSize`    | Not bound | Could be useful for querying solution state             |
+| `MMGS_Get_solSize`    | Indirect  | Could be useful for querying solution state             |
 | `MMGS_Set_scalarSol`  | Indirect  | `Set_scalarSols` (bulk) used instead                    |
 | `MMGS_Set_scalarSols` | Bound     | Used in `set_field("metric")` / `set_field("levelset")` |
 | `MMGS_Get_scalarSol`  | Indirect  | `Get_scalarSols` (bulk) used instead                    |
@@ -572,12 +614,12 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 | Function                            | Status    | Notes                                          |
 | ----------------------------------- | --------- | ---------------------------------------------- |
-| `MMGS_Set_solsAtVerticesSize`       | Not bound | Needed for multiple solution fields per vertex |
-| `MMGS_Get_solsAtVerticesSize`       | Not bound | Query multi-solution dimensions                |
-| `MMGS_Set_ithSol_inSolsAtVertices`  | Not bound | Set individual values in multi-solution        |
-| `MMGS_Set_ithSols_inSolsAtVertices` | Not bound | Set bulk values in multi-solution              |
-| `MMGS_Get_ithSol_inSolsAtVertices`  | Not bound | Get individual values from multi-solution      |
-| `MMGS_Get_ithSols_inSolsAtVertices` | Not bound | Get bulk values from multi-solution            |
+| `MMGS_Set_solsAtVerticesSize`       | Bound     | Used by `save_all_sols()`                      |
+| `MMGS_Get_solsAtVerticesSize`       | Bound     | Used by `load_all_sols()`                      |
+| `MMGS_Set_ithSol_inSolsAtVertices`  | Indirect  | Set individual values in multi-solution        |
+| `MMGS_Set_ithSols_inSolsAtVertices` | Bound     | Used by `save_all_sols()`                      |
+| `MMGS_Get_ithSol_inSolsAtVertices`  | Indirect  | Get individual values from multi-solution      |
+| `MMGS_Get_ithSols_inSolsAtVertices` | Bound     | Used by `load_all_sols()`                      |
 
 ### Parameters
 
@@ -585,7 +627,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | -------------------------- | --------- | ------------------------------------------------------- |
 | `MMGS_Set_iparameter`      | Bound     | Used in `remesh()` for integer options                  |
 | `MMGS_Set_dparameter`      | Bound     | Used in `remesh()` for float options (hmin, hmax, etc.) |
-| `MMGS_Get_iparameter`      | Not bound | Reading back parameter values; could be useful          |
+| `MMGS_Get_iparameter`      | Bound     | `MmgMeshS.get_iparameter()`                            |
 | `MMGS_Set_localParameter`  | Bound     | `MmgMeshS.set_local_parameters()`                       |
 | `MMGS_Set_multiMat`        | Bound     | `MmgMeshS.set_multi_materials()`                        |
 | `MMGS_Set_lsBaseReference` | Bound     | `MmgMeshS.set_ls_base_references()`                     |
@@ -598,7 +640,7 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMGS_Set_outputMeshName` | Bound     | Used in `mmgs.remesh()` file-based API               |
 | `MMGS_Set_inputSolName`   | Bound     | Used in `mmgs.remesh()` file-based API               |
 | `MMGS_Set_outputSolName`  | Bound     | Used in `mmgs.remesh()` file-based API               |
-| `MMGS_Set_inputParamName` | Not bound | For MMG `.mmgs` parameter files; not commonly needed |
+| `MMGS_Set_inputParamName` | Bound     | `MmgMeshS.set_input_parameter_name()`                |
 
 ### File I/O
 
@@ -608,33 +650,33 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 | `MMGS_saveMesh`                | Bound     | Used in `mmgs.remesh()` and `MmgMeshS.save()`                   |
 | `MMGS_loadSol`                 | Bound     | Used in `mmgs.remesh()` and `MmgMeshS.load_sol()`               |
 | `MMGS_saveSol`                 | Bound     | Used in `mmgs.remesh()` and `MmgMeshS.save_sol()`               |
-| `MMGS_loadGenericMesh`         | Not bound | Auto-detect format; `loadMesh` used + PyVista for other formats |
-| `MMGS_saveGenericMesh`         | Not bound | Auto-detect format; `saveMesh` used + PyVista for other formats |
-| `MMGS_loadMshMesh`             | Not bound | Gmsh format; handled by PyVista instead                         |
-| `MMGS_loadMshMesh_and_allData` | Not bound | Gmsh format with all data                                       |
-| `MMGS_saveMshMesh`             | Not bound | Gmsh format output                                              |
-| `MMGS_saveMshMesh_and_allData` | Not bound | Gmsh format with all data                                       |
-| `MMGS_loadVtkMesh`             | Not bound | VTK format; handled by PyVista instead                          |
-| `MMGS_loadVtkMesh_and_allData` | Not bound | VTK format with all data                                        |
-| `MMGS_saveVtkMesh`             | Not bound | VTK format output                                               |
-| `MMGS_saveVtkMesh_and_allData` | Not bound | VTK format with all data                                        |
-| `MMGS_loadVtpMesh`             | Not bound | VTP format; handled by PyVista instead                          |
-| `MMGS_loadVtpMesh_and_allData` | Not bound | VTP format with all data                                        |
-| `MMGS_saveVtpMesh`             | Not bound | VTP format output                                               |
-| `MMGS_saveVtpMesh_and_allData` | Not bound | VTP format with all data                                        |
-| `MMGS_loadVtuMesh`             | Not bound | VTU format; handled by PyVista instead                          |
-| `MMGS_loadVtuMesh_and_allData` | Not bound | VTU format with all data                                        |
-| `MMGS_saveVtuMesh`             | Not bound | VTU format output                                               |
-| `MMGS_saveVtuMesh_and_allData` | Not bound | VTU format with all data                                        |
-| `MMGS_loadAllSols`             | Not bound | Multi-solution file loading                                     |
-| `MMGS_saveAllSols`             | Not bound | Multi-solution file saving                                      |
+| `MMGS_loadGenericMesh`         | Indirect  | Auto-detect format; `loadMesh` used + PyVista for other formats |
+| `MMGS_saveGenericMesh`         | Indirect  | Auto-detect format; `saveMesh` used + PyVista for other formats |
+| `MMGS_loadMshMesh`             | Indirect  | Gmsh format; handled by PyVista instead                         |
+| `MMGS_loadMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
+| `MMGS_saveMshMesh`             | Indirect  | Gmsh format output                                              |
+| `MMGS_saveMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
+| `MMGS_loadVtkMesh`             | Indirect  | VTK format; handled by PyVista instead                          |
+| `MMGS_loadVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
+| `MMGS_saveVtkMesh`             | Indirect  | VTK format output                                               |
+| `MMGS_saveVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
+| `MMGS_loadVtpMesh`             | Indirect  | VTP format; handled by PyVista instead                          |
+| `MMGS_loadVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
+| `MMGS_saveVtpMesh`             | Indirect  | VTP format output                                               |
+| `MMGS_saveVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
+| `MMGS_loadVtuMesh`             | Indirect  | VTU format; handled by PyVista instead                          |
+| `MMGS_loadVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
+| `MMGS_saveVtuMesh`             | Indirect  | VTU format output                                               |
+| `MMGS_saveVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
+| `MMGS_loadAllSols`             | Bound     | `MmgMeshS.load_all_sols()`                                      |
+| `MMGS_saveAllSols`             | Bound     | `MmgMeshS.save_all_sols()`                                      |
 
 ### Topology Queries
 
 | Function                       | Status    | Notes                                                               |
 | ------------------------------ | --------- | ------------------------------------------------------------------- |
 | `MMGS_Get_adjaTri`             | Bound     | `MmgMeshS.get_adjacent_elements()`                                  |
-| `MMGS_Get_adjaVerticesFast`    | Not bound | Requires adjacency tables that may not be available after remeshing |
+| `MMGS_Get_adjaVerticesFast`    | Indirect  | Requires adjacency tables that may not be available after remeshing |
 | `MMGS_Get_numberOfNonBdyEdges` | Bound     | Used in `get_non_boundary_edges()`                                  |
 | `MMGS_Get_nonBdyEdge`          | Bound     | Used in `get_non_boundary_edges()`                                  |
 
@@ -649,37 +691,45 @@ Many "not bound" functions fall into categories that are intentionally excluded:
 
 | Function              | Status    | Notes                                                 |
 | --------------------- | --------- | ----------------------------------------------------- |
-| `MMGS_defaultValues`  | Not bound | Prints default values to stdout; CLI utility          |
-| `MMGS_parsar`         | Not bound | Command-line argument parser; not relevant for Python |
-| `MMGS_usage`          | Not bound | Prints usage text; CLI utility                        |
-| `MMGS_Set_commonFunc` | Not bound | Internal MMG function pointer setup                   |
-| `MMGS_setfunc`        | Not bound | Internal function pointer initialization              |
-| `MMGS_stockOptions`   | Not bound | Internal: saves options to mesh structure             |
-| `MMGS_destockOptions` | Not bound | Internal: restores options from mesh structure        |
-| `MMGS_Compute_eigenv` | Not bound | Eigenvalue utility; rarely needed from Python         |
-| `MMGS_Clean_isoSurf`  | Not bound | Internal cleanup after level-set discretization       |
+| `MMGS_defaultValues`  | Excluded  | Prints default values to stdout; CLI utility          |
+| `MMGS_parsar`         | Excluded  | Command-line argument parser; not relevant for Python |
+| `MMGS_usage`          | Excluded  | Prints usage text; CLI utility                        |
+| `MMGS_Set_commonFunc` | Excluded  | Internal MMG function pointer setup                   |
+| `MMGS_setfunc`        | Bound     | Initializes `MMGS_doSol` for `build_size_map()`       |
+| `MMGS_stockOptions`   | Excluded  | Internal: saves options to mesh structure             |
+| `MMGS_destockOptions` | Excluded  | Internal: restores options from mesh structure        |
+| `MMGS_Compute_eigenv` | Indirect  | `metrics.compute_metric_eigenpairs()` / NumPy          |
+| `MMGS_Clean_isoSurf`  | Bound     | `MmgMeshS.clean_iso_surface()`                        |
 
 ### Function Pointers
 
 | Function     | Status    | Notes                                                                                |
 | ------------ | --------- | ------------------------------------------------------------------------------------ |
-| `MMGS_doSol` | Not bound | External function pointer for custom solution computation; advanced C-level callback |
+| `MMGS_doSol` | Bound     | Used by `MmgMeshS.build_size_map()`                                               |
 
 ---
 
-## Potential Future Additions
+## Direct API Candidates
 
-Functions that could provide value if bound:
+There are no remaining direct-binding candidates. Everything marked **Excluded** in the
+detailed tables has been reviewed and should not be ported one-to-one.
 
-| Function Pattern                             | Libraries   | Rationale                                                                   |
-| -------------------------------------------- | ----------- | --------------------------------------------------------------------------- |
-| `*_Get_iparameter`                           | MMG3D, MMGS | Read back integer parameter values for debugging/introspection              |
-| `*_Get_solSize`                              | All         | Query solution field dimensions                                             |
-| `*_Set_solsAtVerticesSize` / `*_*ithSol*`    | All         | Multi-solution support for advanced workflows (e.g. multiple metric fields) |
-| `*_loadAllSols` / `*_saveAllSols`            | All         | File I/O for multi-solution data                                            |
-| `*_Set_constantSize`                         | All         | Shortcut for uniform mesh sizing                                            |
-| `*_Get_adjaVertices*`                        | MMG2D, MMGS | Vertex adjacency queries (requires adjacency table availability)            |
-| `MMG3D_Add_vertex` / `MMG3D_Add_tetrahedron` | MMG3D       | Dynamic mesh construction without pre-allocating size                       |
-| `MMG3D_Set_handGivenMesh`                    | MMG3D       | Optimization hint for programmatically built meshes                         |
+## Capability-Level Differences
 
-| `*_loadGenericMesh` / `*_saveGenericMesh` | All | Auto-detect format (currently handled by PyVista) |
+Some differences do not correspond to a missing C callable:
+
+- MMGS publicly exposes `MMGS_Set_inputParamName` but keeps its parameter-file parser
+  private, unlike MMG3D and MMG2D. The filename setter is bound, but in-memory MMGS parsing
+  needs an upstream API change ([#373](https://github.com/kmarchais/mmgpy/issues/373)).
+
+- Boundary-only level-set splitting is already reachable through the mapped `isosurf`
+  parameter, but lacks a first-class convenience API
+  ([#372](https://github.com/kmarchais/mmgpy/issues/372)).
+- Mixed tetrahedron/prism meshes are supported by the low-level MMG3D bindings, but the
+  PyVista conversion path does not currently round-trip VTK wedge cells.
+- Native `MMG3D_mmg3dmov` and `MMG2D_mmg2dmov` are skipped because ELAS is not available
+  consistently across supported platforms; mmgpy supplies a portable, non-identical mesh
+  motion workflow ([#374](https://github.com/kmarchais/mmgpy/issues/374)).
+- Text multi-solution I/O is bound. Binary `.solb` multi-solution I/O remains disabled
+  pending a reliable upstream MMG round-trip
+  ([#375](https://github.com/kmarchais/mmgpy/issues/375)).

--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -30,9 +30,12 @@ python scripts/check_mmg_api_coverage.py
 ```
 
 The command fails if MMG adds or removes a public callable, a bound symbol has a stale
-status, or the summary drifts. After changing bindings, `--write` updates direct-binding
-statuses and counts. Newly introduced MMG callables always require a human-written row and
-rationale rather than receiving a guessed classification.
+status, or the summary drifts. Here, **Bound** means that the binding implementation calls
+the C symbol; it does not promise a one-to-one public Python method. Memory-management
+symbols such as `Free_allSols` remain internal implementation details. After changing
+bindings, `--write` updates direct-binding statuses and counts. Newly introduced MMG
+callables always require a human-written row and rationale rather than receiving a guessed
+classification.
 
 Public parameter enums are audited too. All 101 parameters in MMG 5.8.0 are accounted
 for: 97 are mapped directly, while native Lagrangian motion (`MMG3D_IPARAM_lag` and
@@ -45,16 +48,16 @@ parameter is not mapped or explicitly classified.
 The public common header also exposes C representation details. These are accounted for at
 the capability level, but are not included in the callable totals above:
 
-| C API group | Disposition | Python treatment |
-| ----------- | ----------- | ---------------- |
-| `MMG5_type` solution enum | Indirect | Inferred from NumPy field shape and exposed through field arrays |
-| `MMG5_entities` enum | Indirect | Represented by mesh kind and typed element methods |
-| `MMG5_Format` enum | Indirect | Selected from path extensions by native MMG or PyVista-backed I/O |
-| `MMG5_SUCCESS`, `MMG5_LOWFAILURE`, `MMG5_STRONGFAILURE` | Indirect | Converted to results, warnings, and Python exceptions |
-| `MMG5_MMAT_*` constants | Indirect | Multi-material split behavior is exposed through typed methods |
-| `MMG5_ARG_*` variadic tags | Excluded | C allocation protocol hidden by constructors and RAII |
-| `MMG5_*` structs and pointer typedefs | Excluded | Private ABI representation; exposing it would bypass validation and ownership safety |
-| Compile-time limits and buffer-size macros | Excluded | Implementation limits, not stable Python API |
+| C API group                                             | Disposition | Python treatment                                                                     |
+| ------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------ |
+| `MMG5_type` solution enum                               | Indirect    | Inferred from NumPy field shape and exposed through field arrays                     |
+| `MMG5_entities` enum                                    | Indirect    | Represented by mesh kind and typed element methods                                   |
+| `MMG5_Format` enum                                      | Indirect    | Selected from path extensions by native MMG or PyVista-backed I/O                    |
+| `MMG5_SUCCESS`, `MMG5_LOWFAILURE`, `MMG5_STRONGFAILURE` | Indirect    | Converted to results, warnings, and Python exceptions                                |
+| `MMG5_MMAT_*` constants                                 | Indirect    | Multi-material split behavior is exposed through typed methods                       |
+| `MMG5_ARG_*` variadic tags                              | Excluded    | C allocation protocol hidden by constructors and RAII                                |
+| `MMG5_*` structs and pointer typedefs                   | Excluded    | Private ABI representation; exposing it would bypass validation and ownership safety |
+| Compile-time limits and buffer-size macros              | Excluded    | Implementation limits, not stable Python API                                         |
 
 The deterministic checker covers callable declarations and parameter enums. The grouped
 ABI dispositions above are a reviewed policy boundary rather than a promise to mirror C
@@ -79,8 +82,8 @@ Excluded functions fall into categories that should not become one-to-one Python
 | Bound     | C function is directly called in the pybind11 bindings                                                                            |
 | Indirect  | Functionality is available via alternative implementation (direct struct access, reimplementation, or loop over individual calls) |
 | Candidate | User-facing MMG capability is missing and is reasonable to expose                                                                 |
-| Excluded  | Deliberately not ported: internal plumbing, redundant C API shape, legacy helper, or unsafe low-level operation                       |
-| Skipped   | Upstream capability cannot be shipped consistently in supported mmgpy builds                                                       |
+| Excluded  | Deliberately not ported: internal plumbing, redundant C API shape, legacy helper, or unsafe low-level operation                   |
+| Skipped   | Upstream capability cannot be shipped consistently in supported mmgpy builds                                                      |
 
 ---
 
@@ -88,49 +91,49 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### Initialization & Memory Management
 
-| Function                | Status    | Notes                                                 |
-| ----------------------- | --------- | ----------------------------------------------------- |
-| `MMG3D_Init_mesh`       | Bound     | `MmgMesh3D()` constructor; `mmg3d.remesh()`           |
-| `MMG3D_Init_fileNames`  | Excluded  | Called internally by `Init_mesh`                      |
-| `MMG3D_Init_parameters` | Excluded  | Called internally by `Init_mesh`                      |
-| `MMG3D_Free_all`        | Bound     | Called in `MmgMesh3D` destructor and `mmg3d.remesh()` |
-| `MMG3D_Free_structures` | Excluded  | `Free_all` used instead                               |
-| `MMG3D_Free_names`      | Excluded  | `Free_all` used instead                               |
-| `MMG3D_Free_allSols`    | Bound     | Releases arrays used by multi-solution I/O wrappers   |
-| `MMG3D_Free_solutions`  | Excluded  | `Free_all` used instead                               |
+| Function                | Status   | Notes                                                     |
+| ----------------------- | -------- | --------------------------------------------------------- |
+| `MMG3D_Init_mesh`       | Bound    | `MmgMesh3D()` constructor; `mmg3d.remesh()`               |
+| `MMG3D_Init_fileNames`  | Excluded | Called internally by `Init_mesh`                          |
+| `MMG3D_Init_parameters` | Excluded | Called internally by `Init_mesh`                          |
+| `MMG3D_Free_all`        | Bound    | Called in `MmgMesh3D` destructor and `mmg3d.remesh()`     |
+| `MMG3D_Free_structures` | Excluded | `Free_all` used instead                                   |
+| `MMG3D_Free_names`      | Excluded | `Free_all` used instead                                   |
+| `MMG3D_Free_allSols`    | Bound    | Internal cleanup for multi-solution I/O; no Python method |
+| `MMG3D_Free_solutions`  | Excluded | `Free_all` used instead                                   |
 
 ### Mesh Size & Validation
 
-| Function                 | Status    | Notes                                                |
-| ------------------------ | --------- | ---------------------------------------------------- |
-| `MMG3D_Set_meshSize`     | Bound     | `MmgMesh3D.set_mesh_size()`                          |
-| `MMG3D_Get_meshSize`     | Bound     | `MmgMesh3D.get_mesh_size()`                          |
-| `MMG3D_Chk_meshData`     | Indirect  | Called internally by MMG before remeshing            |
-| `MMG3D_Set_constantSize` | Indirect  | Could be useful; use `hsiz` parameter as alternative |
+| Function                 | Status   | Notes                                                |
+| ------------------------ | -------- | ---------------------------------------------------- |
+| `MMG3D_Set_meshSize`     | Bound    | `MmgMesh3D.set_mesh_size()`                          |
+| `MMG3D_Get_meshSize`     | Bound    | `MmgMesh3D.get_mesh_size()`                          |
+| `MMG3D_Chk_meshData`     | Indirect | Called internally by MMG before remeshing            |
+| `MMG3D_Set_constantSize` | Indirect | Could be useful; use `hsiz` parameter as alternative |
 
 ### Vertex Operations
 
-| Function                   | Status    | Notes                                                          |
-| -------------------------- | --------- | -------------------------------------------------------------- |
-| `MMG3D_Set_vertex`         | Bound     | `MmgMesh3D.set_vertex()` and loops in `set_vertices()`         |
-| `MMG3D_Set_vertices`       | Indirect  | `set_vertices()` loops over `Set_vertex` instead               |
-| `MMG3D_Get_vertex`         | Bound     | `MmgMesh3D.get_vertex()` (by iteration index)                  |
-| `MMG3D_GetByIdx_vertex`    | Bound     | Used in `get_vertex()` (by absolute index)                     |
-| `MMG3D_Get_vertices`       | Indirect  | `get_vertices()` accesses struct directly                      |
-| `MMG3D_Add_vertex`         | Indirect  | Python constructs meshes from complete arrays instead          |
-| `MMG3D_Set_normalAtVertex` | Bound     | `MmgMesh3D.set_normal_at_vertices()`                           |
-| `MMG3D_Get_normalAtVertex` | Bound     | `MmgMesh3D.get_normal_at_vertices()`                           |
+| Function                   | Status   | Notes                                                  |
+| -------------------------- | -------- | ------------------------------------------------------ |
+| `MMG3D_Set_vertex`         | Bound    | `MmgMesh3D.set_vertex()` and loops in `set_vertices()` |
+| `MMG3D_Set_vertices`       | Indirect | `set_vertices()` loops over `Set_vertex` instead       |
+| `MMG3D_Get_vertex`         | Bound    | `MmgMesh3D.get_vertex()` (by iteration index)          |
+| `MMG3D_GetByIdx_vertex`    | Bound    | Used in `get_vertex()` (by absolute index)             |
+| `MMG3D_Get_vertices`       | Indirect | `get_vertices()` accesses struct directly              |
+| `MMG3D_Add_vertex`         | Indirect | Python constructs meshes from complete arrays instead  |
+| `MMG3D_Set_normalAtVertex` | Bound    | `MmgMesh3D.set_normal_at_vertices()`                   |
+| `MMG3D_Get_normalAtVertex` | Bound    | `MmgMesh3D.get_normal_at_vertices()`                   |
 
 ### Tetrahedron Operations
 
-| Function                       | Status    | Notes                                                           |
-| ------------------------------ | --------- | --------------------------------------------------------------- |
-| `MMG3D_Set_tetrahedron`        | Bound     | `MmgMesh3D.set_tetrahedron()` and loops in `set_tetrahedra()`   |
-| `MMG3D_Set_tetrahedra`         | Indirect  | `set_tetrahedra()` loops over `Set_tetrahedron` instead         |
-| `MMG3D_Get_tetrahedron`        | Bound     | `MmgMesh3D.get_tetrahedron()`                                   |
-| `MMG3D_Get_tetrahedra`         | Indirect  | `get_tetrahedra()` accesses struct directly                     |
-| `MMG3D_Get_tetrahedronQuality` | Bound     | `MmgMesh3D.get_element_quality()` / `get_element_qualities()`   |
-| `MMG3D_Add_tetrahedron`        | Indirect  | Python constructs meshes from complete arrays instead           |
+| Function                       | Status   | Notes                                                         |
+| ------------------------------ | -------- | ------------------------------------------------------------- |
+| `MMG3D_Set_tetrahedron`        | Bound    | `MmgMesh3D.set_tetrahedron()` and loops in `set_tetrahedra()` |
+| `MMG3D_Set_tetrahedra`         | Indirect | `set_tetrahedra()` loops over `Set_tetrahedron` instead       |
+| `MMG3D_Get_tetrahedron`        | Bound    | `MmgMesh3D.get_tetrahedron()`                                 |
+| `MMG3D_Get_tetrahedra`         | Indirect | `get_tetrahedra()` accesses struct directly                   |
+| `MMG3D_Get_tetrahedronQuality` | Bound    | `MmgMesh3D.get_element_quality()` / `get_element_qualities()` |
+| `MMG3D_Add_tetrahedron`        | Indirect | Python constructs meshes from complete arrays instead         |
 
 ### Triangle Operations
 
@@ -195,82 +198,82 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### Solution / Metric Fields
 
-| Function               | Status    | Notes                                                   |
-| ---------------------- | --------- | ------------------------------------------------------- |
-| `MMG3D_Set_solSize`    | Bound     | Called internally when setting fields via `set_field()` |
-| `MMG3D_Get_solSize`    | Indirect  | Could be useful for querying solution state             |
-| `MMG3D_Set_scalarSol`  | Indirect  | `Set_scalarSols` (bulk) used instead                    |
-| `MMG3D_Set_scalarSols` | Bound     | Used in `set_field("metric")` / `set_field("levelset")` |
-| `MMG3D_Get_scalarSol`  | Indirect  | `Get_scalarSols` (bulk) used instead                    |
-| `MMG3D_Get_scalarSols` | Bound     | Used in `get_field("metric")` / `get_field("levelset")` |
-| `MMG3D_Set_vectorSol`  | Indirect  | `Set_vectorSols` (bulk) used instead                    |
-| `MMG3D_Set_vectorSols` | Bound     | Used in `set_field("displacement")`                     |
-| `MMG3D_Get_vectorSol`  | Indirect  | `Get_vectorSols` (bulk) used instead                    |
-| `MMG3D_Get_vectorSols` | Bound     | Used in `get_field("displacement")`                     |
-| `MMG3D_Set_tensorSol`  | Indirect  | `Set_tensorSols` (bulk) used instead                    |
-| `MMG3D_Set_tensorSols` | Bound     | Used in `set_field("tensor")`                           |
-| `MMG3D_Get_tensorSol`  | Indirect  | `Get_tensorSols` (bulk) used instead                    |
-| `MMG3D_Get_tensorSols` | Bound     | Used in `get_field("tensor")`                           |
+| Function               | Status   | Notes                                                   |
+| ---------------------- | -------- | ------------------------------------------------------- |
+| `MMG3D_Set_solSize`    | Bound    | Called internally when setting fields via `set_field()` |
+| `MMG3D_Get_solSize`    | Indirect | Could be useful for querying solution state             |
+| `MMG3D_Set_scalarSol`  | Indirect | `Set_scalarSols` (bulk) used instead                    |
+| `MMG3D_Set_scalarSols` | Bound    | Used in `set_field("metric")` / `set_field("levelset")` |
+| `MMG3D_Get_scalarSol`  | Indirect | `Get_scalarSols` (bulk) used instead                    |
+| `MMG3D_Get_scalarSols` | Bound    | Used in `get_field("metric")` / `get_field("levelset")` |
+| `MMG3D_Set_vectorSol`  | Indirect | `Set_vectorSols` (bulk) used instead                    |
+| `MMG3D_Set_vectorSols` | Bound    | Used in `set_field("displacement")`                     |
+| `MMG3D_Get_vectorSol`  | Indirect | `Get_vectorSols` (bulk) used instead                    |
+| `MMG3D_Get_vectorSols` | Bound    | Used in `get_field("displacement")`                     |
+| `MMG3D_Set_tensorSol`  | Indirect | `Set_tensorSols` (bulk) used instead                    |
+| `MMG3D_Set_tensorSols` | Bound    | Used in `set_field("tensor")`                           |
+| `MMG3D_Get_tensorSol`  | Indirect | `Get_tensorSols` (bulk) used instead                    |
+| `MMG3D_Get_tensorSols` | Bound    | Used in `get_field("tensor")`                           |
 
 ### Multi-Solution Support
 
-| Function                             | Status    | Notes                                          |
-| ------------------------------------ | --------- | ---------------------------------------------- |
-| `MMG3D_Set_solsAtVerticesSize`       | Bound     | Used by `save_all_sols()`                      |
-| `MMG3D_Get_solsAtVerticesSize`       | Bound     | Used by `load_all_sols()`                      |
-| `MMG3D_Set_ithSol_inSolsAtVertices`  | Indirect  | Set individual values in multi-solution        |
-| `MMG3D_Set_ithSols_inSolsAtVertices` | Bound     | Used by `save_all_sols()`                      |
-| `MMG3D_Get_ithSol_inSolsAtVertices`  | Indirect  | Get individual values from multi-solution      |
-| `MMG3D_Get_ithSols_inSolsAtVertices` | Bound     | Used by `load_all_sols()`                      |
+| Function                             | Status   | Notes                                     |
+| ------------------------------------ | -------- | ----------------------------------------- |
+| `MMG3D_Set_solsAtVerticesSize`       | Bound    | Used by `save_all_sols()`                 |
+| `MMG3D_Get_solsAtVerticesSize`       | Bound    | Used by `load_all_sols()`                 |
+| `MMG3D_Set_ithSol_inSolsAtVertices`  | Indirect | Set individual values in multi-solution   |
+| `MMG3D_Set_ithSols_inSolsAtVertices` | Bound    | Used by `save_all_sols()`                 |
+| `MMG3D_Get_ithSol_inSolsAtVertices`  | Indirect | Get individual values from multi-solution |
+| `MMG3D_Get_ithSols_inSolsAtVertices` | Bound    | Used by `load_all_sols()`                 |
 
 ### Parameters
 
-| Function                     | Status    | Notes                                                          |
-| ---------------------------- | --------- | -------------------------------------------------------------- |
-| `MMG3D_Set_iparameter`       | Bound     | Used in `remesh()` for integer options                         |
-| `MMG3D_Set_dparameter`       | Bound     | Used in `remesh()` for float options (hmin, hmax, etc.)        |
-| `MMG3D_Get_iparameter`       | Bound     | `MmgMesh3D.get_iparameter()`                                   |
-| `MMG3D_Set_localParameter`   | Bound     | `MmgMesh3D.set_local_parameters()`                             |
-| `MMG3D_Set_multiMat`         | Bound     | `MmgMesh3D.set_multi_materials()`                              |
-| `MMG3D_Set_lsBaseReference`  | Bound     | `MmgMesh3D.set_ls_base_references()`                           |
-| `MMG3D_Set_handGivenMesh`    | Excluded  | Only needed after direct writes to opaque MMG C structures    |
-| `MMG3D_switch_metricStorage` | Excluded  | Advanced metric storage control                                |
+| Function                     | Status   | Notes                                                      |
+| ---------------------------- | -------- | ---------------------------------------------------------- |
+| `MMG3D_Set_iparameter`       | Bound    | Used in `remesh()` for integer options                     |
+| `MMG3D_Set_dparameter`       | Bound    | Used in `remesh()` for float options (hmin, hmax, etc.)    |
+| `MMG3D_Get_iparameter`       | Bound    | `MmgMesh3D.get_iparameter()`                               |
+| `MMG3D_Set_localParameter`   | Bound    | `MmgMesh3D.set_local_parameters()`                         |
+| `MMG3D_Set_multiMat`         | Bound    | `MmgMesh3D.set_multi_materials()`                          |
+| `MMG3D_Set_lsBaseReference`  | Bound    | `MmgMesh3D.set_ls_base_references()`                       |
+| `MMG3D_Set_handGivenMesh`    | Excluded | Only needed after direct writes to opaque MMG C structures |
+| `MMG3D_switch_metricStorage` | Excluded | Advanced metric storage control                            |
 
 ### I/O Configuration
 
-| Function                   | Status    | Notes                                                 |
-| -------------------------- | --------- | ----------------------------------------------------- |
-| `MMG3D_Set_inputMeshName`  | Bound     | Used in `mmg3d.remesh()` file-based API               |
-| `MMG3D_Set_outputMeshName` | Bound     | Used in `mmg3d.remesh()` file-based API               |
-| `MMG3D_Set_inputSolName`   | Bound     | Used in `mmg3d.remesh()` file-based API               |
-| `MMG3D_Set_outputSolName`  | Bound     | Used in `mmg3d.remesh()` file-based API               |
-| `MMG3D_Set_inputParamName` | Bound     | `MmgMesh3D.set_input_parameter_name()`                 |
+| Function                   | Status | Notes                                   |
+| -------------------------- | ------ | --------------------------------------- |
+| `MMG3D_Set_inputMeshName`  | Bound  | Used in `mmg3d.remesh()` file-based API |
+| `MMG3D_Set_outputMeshName` | Bound  | Used in `mmg3d.remesh()` file-based API |
+| `MMG3D_Set_inputSolName`   | Bound  | Used in `mmg3d.remesh()` file-based API |
+| `MMG3D_Set_outputSolName`  | Bound  | Used in `mmg3d.remesh()` file-based API |
+| `MMG3D_Set_inputParamName` | Bound  | `MmgMesh3D.set_input_parameter_name()`  |
 
 ### File I/O
 
-| Function                        | Status    | Notes                                                           |
-| ------------------------------- | --------- | --------------------------------------------------------------- |
-| `MMG3D_loadMesh`                | Bound     | Used in `mmg3d.remesh()` and `MmgMesh3D(filename)`              |
-| `MMG3D_saveMesh`                | Bound     | Used in `mmg3d.remesh()` and `MmgMesh3D.save()`                 |
-| `MMG3D_loadSol`                 | Bound     | Used in `mmg3d.remesh()` and `MmgMesh3D.load_sol()`             |
-| `MMG3D_saveSol`                 | Bound     | Used in `mmg3d.remesh()` and `MmgMesh3D.save_sol()`             |
-| `MMG3D_loadGenericMesh`         | Indirect  | Auto-detect format; `loadMesh` used + PyVista for other formats |
-| `MMG3D_saveGenericMesh`         | Indirect  | Auto-detect format; `saveMesh` used + PyVista for other formats |
-| `MMG3D_loadMshMesh`             | Indirect  | Gmsh format; handled by PyVista instead                         |
-| `MMG3D_loadMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
-| `MMG3D_saveMshMesh`             | Indirect  | Gmsh format output                                              |
-| `MMG3D_saveMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
-| `MMG3D_loadVtkMesh`             | Indirect  | VTK format; handled by PyVista instead                          |
-| `MMG3D_loadVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
-| `MMG3D_saveVtkMesh`             | Indirect  | VTK format output                                               |
-| `MMG3D_saveVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
-| `MMG3D_loadVtuMesh`             | Indirect  | VTU format; handled by PyVista instead                          |
-| `MMG3D_loadVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
-| `MMG3D_saveVtuMesh`             | Indirect  | VTU format output                                               |
-| `MMG3D_saveVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
-| `MMG3D_loadAllSols`             | Bound     | `MmgMesh3D.load_all_sols()`                                     |
-| `MMG3D_saveAllSols`             | Bound     | `MmgMesh3D.save_all_sols()`                                     |
-| `MMG3D_saveTetgenMesh`          | Bound     | `MmgMesh3D.save_tetgen()`                                       |
+| Function                        | Status   | Notes                                                           |
+| ------------------------------- | -------- | --------------------------------------------------------------- |
+| `MMG3D_loadMesh`                | Bound    | Used in `mmg3d.remesh()` and `MmgMesh3D(filename)`              |
+| `MMG3D_saveMesh`                | Bound    | Used in `mmg3d.remesh()` and `MmgMesh3D.save()`                 |
+| `MMG3D_loadSol`                 | Bound    | Used in `mmg3d.remesh()` and `MmgMesh3D.load_sol()`             |
+| `MMG3D_saveSol`                 | Bound    | Used in `mmg3d.remesh()` and `MmgMesh3D.save_sol()`             |
+| `MMG3D_loadGenericMesh`         | Indirect | Auto-detect format; `loadMesh` used + PyVista for other formats |
+| `MMG3D_saveGenericMesh`         | Indirect | Auto-detect format; `saveMesh` used + PyVista for other formats |
+| `MMG3D_loadMshMesh`             | Indirect | Gmsh format; handled by PyVista instead                         |
+| `MMG3D_loadMshMesh_and_allData` | Indirect | Gmsh format with all data                                       |
+| `MMG3D_saveMshMesh`             | Indirect | Gmsh format output                                              |
+| `MMG3D_saveMshMesh_and_allData` | Indirect | Gmsh format with all data                                       |
+| `MMG3D_loadVtkMesh`             | Indirect | VTK format; handled by PyVista instead                          |
+| `MMG3D_loadVtkMesh_and_allData` | Indirect | VTK format with all data                                        |
+| `MMG3D_saveVtkMesh`             | Indirect | VTK format output                                               |
+| `MMG3D_saveVtkMesh_and_allData` | Indirect | VTK format with all data                                        |
+| `MMG3D_loadVtuMesh`             | Indirect | VTU format; handled by PyVista instead                          |
+| `MMG3D_loadVtuMesh_and_allData` | Indirect | VTU format with all data                                        |
+| `MMG3D_saveVtuMesh`             | Indirect | VTU format output                                               |
+| `MMG3D_saveVtuMesh_and_allData` | Indirect | VTU format with all data                                        |
+| `MMG3D_loadAllSols`             | Bound    | `MmgMesh3D.load_all_sols()`                                     |
+| `MMG3D_saveAllSols`             | Bound    | `MmgMesh3D.save_all_sols()`                                     |
+| `MMG3D_saveTetgenMesh`          | Bound    | `MmgMesh3D.save_tetgen()`                                       |
 
 ### Topology Queries
 
@@ -292,29 +295,29 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### CLI & Internal Utilities
 
-| Function               | Status    | Notes                                                 |
-| ---------------------- | --------- | ----------------------------------------------------- |
-| `MMG3D_defaultValues`  | Excluded  | Prints default values to stdout; CLI utility          |
-| `MMG3D_parsar`         | Excluded  | Command-line argument parser; not relevant for Python |
-| `MMG3D_parsop`         | Bound     | Invoked internally before in-memory remeshing         |
-| `MMG3D_usage`          | Excluded  | Prints usage text; CLI utility                        |
-| `MMG3D_Set_commonFunc` | Excluded  | Internal MMG function pointer setup                   |
-| `MMG3D_setfunc`        | Bound     | Initializes `MMG3D_doSol` for `build_size_map()`      |
-| `MMG3D_stockOptions`   | Excluded  | Internal: saves options to mesh structure             |
-| `MMG3D_destockOptions` | Excluded  | Internal: restores options from mesh structure        |
-| `MMG3D_Compute_eigenv` | Indirect  | `metrics.compute_metric_eigenpairs()` / NumPy          |
-| `MMG3D_Clean_isoSurf`  | Bound     | `MmgMesh3D.clean_iso_surface()`                       |
-| `MMG3D_hashTetra`      | Excluded  | Internal hash table construction                      |
-| `MMG3D_searchqua`      | Excluded  | Internal: search for worst quality elements           |
-| `MMG3D_searchlen`      | Excluded  | Internal: search for worst edge lengths               |
-| `MMG3D_mmg3dcheck`     | Excluded  | Internal mesh consistency check                       |
+| Function               | Status   | Notes                                                 |
+| ---------------------- | -------- | ----------------------------------------------------- |
+| `MMG3D_defaultValues`  | Excluded | Prints default values to stdout; CLI utility          |
+| `MMG3D_parsar`         | Excluded | Command-line argument parser; not relevant for Python |
+| `MMG3D_parsop`         | Bound    | Invoked internally before in-memory remeshing         |
+| `MMG3D_usage`          | Excluded | Prints usage text; CLI utility                        |
+| `MMG3D_Set_commonFunc` | Excluded | Internal MMG function pointer setup                   |
+| `MMG3D_setfunc`        | Bound    | Initializes `MMG3D_doSol` for `build_size_map()`      |
+| `MMG3D_stockOptions`   | Excluded | Internal: saves options to mesh structure             |
+| `MMG3D_destockOptions` | Excluded | Internal: restores options from mesh structure        |
+| `MMG3D_Compute_eigenv` | Indirect | `metrics.compute_metric_eigenpairs()` / NumPy         |
+| `MMG3D_Clean_isoSurf`  | Bound    | `MmgMesh3D.clean_iso_surface()`                       |
+| `MMG3D_hashTetra`      | Excluded | Internal hash table construction                      |
+| `MMG3D_searchqua`      | Excluded | Internal: search for worst quality elements           |
+| `MMG3D_searchlen`      | Excluded | Internal: search for worst edge lengths               |
+| `MMG3D_mmg3dcheck`     | Excluded | Internal mesh consistency check                       |
 
 ### Function Pointers
 
-| Function           | Status    | Notes                                                                                   |
-| ------------------ | --------- | --------------------------------------------------------------------------------------- |
-| `MMG3D_doSol`      | Bound     | Used by `MmgMesh3D.build_size_map()`                                               |
-| `MMG3D_lenedgCoor` | Excluded  | External function pointer for custom edge length computation; advanced C-level callback |
+| Function           | Status   | Notes                                                                                   |
+| ------------------ | -------- | --------------------------------------------------------------------------------------- |
+| `MMG3D_doSol`      | Bound    | Used by `MmgMesh3D.build_size_map()`                                                    |
+| `MMG3D_lenedgCoor` | Excluded | External function pointer for custom edge length computation; advanced C-level callback |
 
 ---
 
@@ -322,38 +325,38 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### Initialization & Memory Management
 
-| Function                | Status    | Notes                                                 |
-| ----------------------- | --------- | ----------------------------------------------------- |
-| `MMG2D_Init_mesh`       | Bound     | `MmgMesh2D()` constructor; `mmg2d.remesh()`           |
-| `MMG2D_Init_fileNames`  | Excluded  | Called internally by `Init_mesh`                      |
-| `MMG2D_Init_parameters` | Excluded  | Called internally by `Init_mesh`                      |
-| `MMG2D_Free_all`        | Bound     | Called in `MmgMesh2D` destructor and `mmg2d.remesh()` |
-| `MMG2D_Free_structures` | Excluded  | `Free_all` used instead                               |
-| `MMG2D_Free_names`      | Excluded  | `Free_all` used instead                               |
-| `MMG2D_Free_allSols`    | Bound     | Releases arrays used by multi-solution I/O wrappers   |
-| `MMG2D_Free_solutions`  | Excluded  | `Free_all` used instead                               |
-| `MMG2D_Free_triangles`  | Excluded  | `Free_all` used instead                               |
-| `MMG2D_Free_edges`      | Excluded  | `Free_all` used instead                               |
+| Function                | Status   | Notes                                                     |
+| ----------------------- | -------- | --------------------------------------------------------- |
+| `MMG2D_Init_mesh`       | Bound    | `MmgMesh2D()` constructor; `mmg2d.remesh()`               |
+| `MMG2D_Init_fileNames`  | Excluded | Called internally by `Init_mesh`                          |
+| `MMG2D_Init_parameters` | Excluded | Called internally by `Init_mesh`                          |
+| `MMG2D_Free_all`        | Bound    | Called in `MmgMesh2D` destructor and `mmg2d.remesh()`     |
+| `MMG2D_Free_structures` | Excluded | `Free_all` used instead                                   |
+| `MMG2D_Free_names`      | Excluded | `Free_all` used instead                                   |
+| `MMG2D_Free_allSols`    | Bound    | Internal cleanup for multi-solution I/O; no Python method |
+| `MMG2D_Free_solutions`  | Excluded | `Free_all` used instead                                   |
+| `MMG2D_Free_triangles`  | Excluded | `Free_all` used instead                                   |
+| `MMG2D_Free_edges`      | Excluded | `Free_all` used instead                                   |
 
 ### Mesh Size & Validation
 
-| Function                 | Status    | Notes                                                |
-| ------------------------ | --------- | ---------------------------------------------------- |
-| `MMG2D_Set_meshSize`     | Bound     | `MmgMesh2D.set_mesh_size()`                          |
-| `MMG2D_Get_meshSize`     | Bound     | `MmgMesh2D.get_mesh_size()`                          |
-| `MMG2D_Chk_meshData`     | Indirect  | Called internally by MMG before remeshing            |
-| `MMG2D_Set_constantSize` | Indirect  | Could be useful; use `hsiz` parameter as alternative |
+| Function                 | Status   | Notes                                                |
+| ------------------------ | -------- | ---------------------------------------------------- |
+| `MMG2D_Set_meshSize`     | Bound    | `MmgMesh2D.set_mesh_size()`                          |
+| `MMG2D_Get_meshSize`     | Bound    | `MmgMesh2D.get_mesh_size()`                          |
+| `MMG2D_Chk_meshData`     | Indirect | Called internally by MMG before remeshing            |
+| `MMG2D_Set_constantSize` | Indirect | Could be useful; use `hsiz` parameter as alternative |
 
 ### Vertex Operations
 
-| Function                   | Status    | Notes                                                  |
-| -------------------------- | --------- | ------------------------------------------------------ |
-| `MMG2D_Set_vertex`         | Bound     | `MmgMesh2D.set_vertex()` and loops in `set_vertices()` |
-| `MMG2D_Set_vertices`       | Indirect  | `set_vertices()` loops over `Set_vertex` instead       |
-| `MMG2D_Get_vertex`         | Bound     | `MmgMesh2D.get_vertex()` (by iteration index)          |
-| `MMG2D_GetByIdx_vertex`    | Bound     | Used in `get_vertex()` (by absolute index)             |
-| `MMG2D_Get_vertices`       | Indirect  | `get_vertices()` accesses struct directly              |
-| `MMG2D_Reset_verticestags` | Excluded  | Resets all vertex tags; niche use case                 |
+| Function                   | Status   | Notes                                                  |
+| -------------------------- | -------- | ------------------------------------------------------ |
+| `MMG2D_Set_vertex`         | Bound    | `MmgMesh2D.set_vertex()` and loops in `set_vertices()` |
+| `MMG2D_Set_vertices`       | Indirect | `set_vertices()` loops over `Set_vertex` instead       |
+| `MMG2D_Get_vertex`         | Bound    | `MmgMesh2D.get_vertex()` (by iteration index)          |
+| `MMG2D_GetByIdx_vertex`    | Bound    | Used in `get_vertex()` (by absolute index)             |
+| `MMG2D_Get_vertices`       | Indirect | `get_vertices()` accesses struct directly              |
+| `MMG2D_Reset_verticestags` | Excluded | Resets all vertex tags; niche use case                 |
 
 ### Triangle Operations
 
@@ -399,33 +402,33 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### Solution / Metric Fields
 
-| Function               | Status    | Notes                                                   |
-| ---------------------- | --------- | ------------------------------------------------------- |
-| `MMG2D_Set_solSize`    | Bound     | Called internally when setting fields via `set_field()` |
-| `MMG2D_Get_solSize`    | Indirect  | Could be useful for querying solution state             |
-| `MMG2D_Set_scalarSol`  | Indirect  | `Set_scalarSols` (bulk) used instead                    |
-| `MMG2D_Set_scalarSols` | Bound     | Used in `set_field("metric")` / `set_field("levelset")` |
-| `MMG2D_Get_scalarSol`  | Indirect  | `Get_scalarSols` (bulk) used instead                    |
-| `MMG2D_Get_scalarSols` | Bound     | Used in `get_field("metric")` / `get_field("levelset")` |
-| `MMG2D_Set_vectorSol`  | Indirect  | `Set_vectorSols` (bulk) used instead                    |
-| `MMG2D_Set_vectorSols` | Bound     | Used in `set_field("displacement")`                     |
-| `MMG2D_Get_vectorSol`  | Indirect  | `Get_vectorSols` (bulk) used instead                    |
-| `MMG2D_Get_vectorSols` | Bound     | Used in `get_field("displacement")`                     |
-| `MMG2D_Set_tensorSol`  | Indirect  | `Set_tensorSols` (bulk) used instead                    |
-| `MMG2D_Set_tensorSols` | Bound     | Used in `set_field("tensor")`                           |
-| `MMG2D_Get_tensorSol`  | Indirect  | `Get_tensorSols` (bulk) used instead                    |
-| `MMG2D_Get_tensorSols` | Bound     | Used in `get_field("tensor")`                           |
+| Function               | Status   | Notes                                                   |
+| ---------------------- | -------- | ------------------------------------------------------- |
+| `MMG2D_Set_solSize`    | Bound    | Called internally when setting fields via `set_field()` |
+| `MMG2D_Get_solSize`    | Indirect | Could be useful for querying solution state             |
+| `MMG2D_Set_scalarSol`  | Indirect | `Set_scalarSols` (bulk) used instead                    |
+| `MMG2D_Set_scalarSols` | Bound    | Used in `set_field("metric")` / `set_field("levelset")` |
+| `MMG2D_Get_scalarSol`  | Indirect | `Get_scalarSols` (bulk) used instead                    |
+| `MMG2D_Get_scalarSols` | Bound    | Used in `get_field("metric")` / `get_field("levelset")` |
+| `MMG2D_Set_vectorSol`  | Indirect | `Set_vectorSols` (bulk) used instead                    |
+| `MMG2D_Set_vectorSols` | Bound    | Used in `set_field("displacement")`                     |
+| `MMG2D_Get_vectorSol`  | Indirect | `Get_vectorSols` (bulk) used instead                    |
+| `MMG2D_Get_vectorSols` | Bound    | Used in `get_field("displacement")`                     |
+| `MMG2D_Set_tensorSol`  | Indirect | `Set_tensorSols` (bulk) used instead                    |
+| `MMG2D_Set_tensorSols` | Bound    | Used in `set_field("tensor")`                           |
+| `MMG2D_Get_tensorSol`  | Indirect | `Get_tensorSols` (bulk) used instead                    |
+| `MMG2D_Get_tensorSols` | Bound    | Used in `get_field("tensor")`                           |
 
 ### Multi-Solution Support
 
-| Function                             | Status    | Notes                                          |
-| ------------------------------------ | --------- | ---------------------------------------------- |
-| `MMG2D_Set_solsAtVerticesSize`       | Bound     | Used by `save_all_sols()`                      |
-| `MMG2D_Get_solsAtVerticesSize`       | Bound     | Used by `load_all_sols()`                      |
-| `MMG2D_Set_ithSol_inSolsAtVertices`  | Indirect  | Set individual values in multi-solution        |
-| `MMG2D_Set_ithSols_inSolsAtVertices` | Bound     | Used by `save_all_sols()`                      |
-| `MMG2D_Get_ithSol_inSolsAtVertices`  | Indirect  | Get individual values from multi-solution      |
-| `MMG2D_Get_ithSols_inSolsAtVertices` | Bound     | Used by `load_all_sols()`                      |
+| Function                             | Status   | Notes                                     |
+| ------------------------------------ | -------- | ----------------------------------------- |
+| `MMG2D_Set_solsAtVerticesSize`       | Bound    | Used by `save_all_sols()`                 |
+| `MMG2D_Get_solsAtVerticesSize`       | Bound    | Used by `load_all_sols()`                 |
+| `MMG2D_Set_ithSol_inSolsAtVertices`  | Indirect | Set individual values in multi-solution   |
+| `MMG2D_Set_ithSols_inSolsAtVertices` | Bound    | Used by `save_all_sols()`                 |
+| `MMG2D_Get_ithSol_inSolsAtVertices`  | Indirect | Get individual values from multi-solution |
+| `MMG2D_Get_ithSols_inSolsAtVertices` | Bound    | Used by `load_all_sols()`                 |
 
 ### Parameters
 
@@ -439,57 +442,57 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### I/O Configuration
 
-| Function                   | Status    | Notes                                                 |
-| -------------------------- | --------- | ----------------------------------------------------- |
-| `MMG2D_Set_inputMeshName`  | Bound     | Used in `mmg2d.remesh()` file-based API               |
-| `MMG2D_Set_outputMeshName` | Bound     | Used in `mmg2d.remesh()` file-based API               |
-| `MMG2D_Set_inputSolName`   | Bound     | Used in `mmg2d.remesh()` file-based API               |
-| `MMG2D_Set_outputSolName`  | Bound     | Used in `mmg2d.remesh()` file-based API               |
-| `MMG2D_Set_inputParamName` | Bound     | `MmgMesh2D.set_input_parameter_name()`                 |
+| Function                   | Status | Notes                                   |
+| -------------------------- | ------ | --------------------------------------- |
+| `MMG2D_Set_inputMeshName`  | Bound  | Used in `mmg2d.remesh()` file-based API |
+| `MMG2D_Set_outputMeshName` | Bound  | Used in `mmg2d.remesh()` file-based API |
+| `MMG2D_Set_inputSolName`   | Bound  | Used in `mmg2d.remesh()` file-based API |
+| `MMG2D_Set_outputSolName`  | Bound  | Used in `mmg2d.remesh()` file-based API |
+| `MMG2D_Set_inputParamName` | Bound  | `MmgMesh2D.set_input_parameter_name()`  |
 
 ### File I/O
 
-| Function                        | Status    | Notes                                                           |
-| ------------------------------- | --------- | --------------------------------------------------------------- |
-| `MMG2D_loadMesh`                | Bound     | Used in `mmg2d.remesh()` and `MmgMesh2D(filename)`              |
-| `MMG2D_saveMesh`                | Bound     | Used in `mmg2d.remesh()` and `MmgMesh2D.save()`                 |
-| `MMG2D_loadSol`                 | Bound     | Used in `mmg2d.remesh()` and `MmgMesh2D.load_sol()`             |
-| `MMG2D_saveSol`                 | Bound     | Used in `mmg2d.remesh()` and `MmgMesh2D.save_sol()`             |
-| `MMG2D_loadGenericMesh`         | Indirect  | Auto-detect format; `loadMesh` used + PyVista for other formats |
-| `MMG2D_saveGenericMesh`         | Indirect  | Auto-detect format; `saveMesh` used + PyVista for other formats |
-| `MMG2D_loadMshMesh`             | Indirect  | Gmsh format; handled by PyVista instead                         |
-| `MMG2D_loadMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
-| `MMG2D_saveMshMesh`             | Indirect  | Gmsh format output                                              |
-| `MMG2D_saveMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
-| `MMG2D_loadVtkMesh`             | Indirect  | VTK format; handled by PyVista instead                          |
-| `MMG2D_loadVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
-| `MMG2D_saveVtkMesh`             | Indirect  | VTK format output                                               |
-| `MMG2D_saveVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
-| `MMG2D_loadVtpMesh`             | Indirect  | VTP format; handled by PyVista instead                          |
-| `MMG2D_loadVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
-| `MMG2D_saveVtpMesh`             | Indirect  | VTP format output                                               |
-| `MMG2D_saveVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
-| `MMG2D_loadVtuMesh`             | Indirect  | VTU format; handled by PyVista instead                          |
-| `MMG2D_loadVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
-| `MMG2D_saveVtuMesh`             | Indirect  | VTU format output                                               |
-| `MMG2D_saveVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
-| `MMG2D_loadVect`                | Excluded  | Vector field loading (legacy)                                   |
-| `MMG2D_saveVect`                | Excluded  | Vector field saving (legacy)                                    |
-| `MMG2D_loadAllSols`             | Bound     | `MmgMesh2D.load_all_sols()`                                     |
-| `MMG2D_saveAllSols`             | Bound     | `MmgMesh2D.save_all_sols()`                                     |
-| `MMG2D_saveTetgenMesh`          | Bound     | `MmgMesh2D.save_tetgen()`                                       |
+| Function                        | Status   | Notes                                                           |
+| ------------------------------- | -------- | --------------------------------------------------------------- |
+| `MMG2D_loadMesh`                | Bound    | Used in `mmg2d.remesh()` and `MmgMesh2D(filename)`              |
+| `MMG2D_saveMesh`                | Bound    | Used in `mmg2d.remesh()` and `MmgMesh2D.save()`                 |
+| `MMG2D_loadSol`                 | Bound    | Used in `mmg2d.remesh()` and `MmgMesh2D.load_sol()`             |
+| `MMG2D_saveSol`                 | Bound    | Used in `mmg2d.remesh()` and `MmgMesh2D.save_sol()`             |
+| `MMG2D_loadGenericMesh`         | Indirect | Auto-detect format; `loadMesh` used + PyVista for other formats |
+| `MMG2D_saveGenericMesh`         | Indirect | Auto-detect format; `saveMesh` used + PyVista for other formats |
+| `MMG2D_loadMshMesh`             | Indirect | Gmsh format; handled by PyVista instead                         |
+| `MMG2D_loadMshMesh_and_allData` | Indirect | Gmsh format with all data                                       |
+| `MMG2D_saveMshMesh`             | Indirect | Gmsh format output                                              |
+| `MMG2D_saveMshMesh_and_allData` | Indirect | Gmsh format with all data                                       |
+| `MMG2D_loadVtkMesh`             | Indirect | VTK format; handled by PyVista instead                          |
+| `MMG2D_loadVtkMesh_and_allData` | Indirect | VTK format with all data                                        |
+| `MMG2D_saveVtkMesh`             | Indirect | VTK format output                                               |
+| `MMG2D_saveVtkMesh_and_allData` | Indirect | VTK format with all data                                        |
+| `MMG2D_loadVtpMesh`             | Indirect | VTP format; handled by PyVista instead                          |
+| `MMG2D_loadVtpMesh_and_allData` | Indirect | VTP format with all data                                        |
+| `MMG2D_saveVtpMesh`             | Indirect | VTP format output                                               |
+| `MMG2D_saveVtpMesh_and_allData` | Indirect | VTP format with all data                                        |
+| `MMG2D_loadVtuMesh`             | Indirect | VTU format; handled by PyVista instead                          |
+| `MMG2D_loadVtuMesh_and_allData` | Indirect | VTU format with all data                                        |
+| `MMG2D_saveVtuMesh`             | Indirect | VTU format output                                               |
+| `MMG2D_saveVtuMesh_and_allData` | Indirect | VTU format with all data                                        |
+| `MMG2D_loadVect`                | Excluded | Vector field loading (legacy)                                   |
+| `MMG2D_saveVect`                | Excluded | Vector field saving (legacy)                                    |
+| `MMG2D_loadAllSols`             | Bound    | `MmgMesh2D.load_all_sols()`                                     |
+| `MMG2D_saveAllSols`             | Bound    | `MmgMesh2D.save_all_sols()`                                     |
+| `MMG2D_saveTetgenMesh`          | Bound    | `MmgMesh2D.save_tetgen()`                                       |
 
 ### Topology Queries
 
-| Function                        | Status    | Notes                                                               |
-| ------------------------------- | --------- | ------------------------------------------------------------------- |
-| `MMG2D_Get_adjaTri`             | Bound     | `MmgMesh2D.get_adjacent_elements()`                                 |
-| `MMG2D_Get_adjaVertices`        | Indirect  | Requires adjacency tables that may not be available after remeshing |
-| `MMG2D_Get_adjaVerticesFast`    | Indirect  | Same limitation as `Get_adjaVertices`                               |
-| `MMG2D_Get_triFromEdge`         | Bound     | `MmgMesh2D.get_tri_from_edge()`                                     |
-| `MMG2D_Get_trisFromEdge`        | Bound     | `MmgMesh2D.get_tris_from_edge()`                                    |
-| `MMG2D_Get_numberOfNonBdyEdges` | Bound     | Used in `get_non_boundary_edges()`                                  |
-| `MMG2D_Get_nonBdyEdge`          | Bound     | Used in `get_non_boundary_edges()`                                  |
+| Function                        | Status   | Notes                                                               |
+| ------------------------------- | -------- | ------------------------------------------------------------------- |
+| `MMG2D_Get_adjaTri`             | Bound    | `MmgMesh2D.get_adjacent_elements()`                                 |
+| `MMG2D_Get_adjaVertices`        | Indirect | Requires adjacency tables that may not be available after remeshing |
+| `MMG2D_Get_adjaVerticesFast`    | Indirect | Same limitation as `Get_adjaVertices`                               |
+| `MMG2D_Get_triFromEdge`         | Bound    | `MmgMesh2D.get_tri_from_edge()`                                     |
+| `MMG2D_Get_trisFromEdge`        | Bound    | `MmgMesh2D.get_tris_from_edge()`                                    |
+| `MMG2D_Get_numberOfNonBdyEdges` | Bound    | Used in `get_non_boundary_edges()`                                  |
+| `MMG2D_Get_nonBdyEdge`          | Bound    | Used in `get_non_boundary_edges()`                                  |
 
 ### Remeshing Functions
 
@@ -502,22 +505,22 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### CLI & Internal Utilities
 
-| Function               | Status    | Notes                                                 |
-| ---------------------- | --------- | ----------------------------------------------------- |
-| `MMG2D_defaultValues`  | Excluded  | Prints default values to stdout; CLI utility          |
-| `MMG2D_parsar`         | Excluded  | Command-line argument parser; not relevant for Python |
-| `MMG2D_parsop`         | Bound     | Invoked internally before in-memory remeshing         |
-| `MMG2D_usage`          | Excluded  | Prints usage text; CLI utility                        |
-| `MMG2D_Set_commonFunc` | Excluded  | Internal MMG function pointer setup                   |
-| `MMG2D_setfunc`        | Bound     | Initializes `MMG2D_doSol` for `build_size_map()`      |
-| `MMG2D_Compute_eigenv` | Indirect  | `metrics.compute_metric_eigenpairs()` / NumPy          |
-| `MMG2D_scaleMesh`      | Excluded  | Internal mesh scaling for numerical stability         |
+| Function               | Status   | Notes                                                 |
+| ---------------------- | -------- | ----------------------------------------------------- |
+| `MMG2D_defaultValues`  | Excluded | Prints default values to stdout; CLI utility          |
+| `MMG2D_parsar`         | Excluded | Command-line argument parser; not relevant for Python |
+| `MMG2D_parsop`         | Bound    | Invoked internally before in-memory remeshing         |
+| `MMG2D_usage`          | Excluded | Prints usage text; CLI utility                        |
+| `MMG2D_Set_commonFunc` | Excluded | Internal MMG function pointer setup                   |
+| `MMG2D_setfunc`        | Bound    | Initializes `MMG2D_doSol` for `build_size_map()`      |
+| `MMG2D_Compute_eigenv` | Indirect | `metrics.compute_metric_eigenpairs()` / NumPy         |
+| `MMG2D_scaleMesh`      | Excluded | Internal mesh scaling for numerical stability         |
 
 ### Function Pointers
 
-| Function      | Status    | Notes                                                                                |
-| ------------- | --------- | ------------------------------------------------------------------------------------ |
-| `MMG2D_doSol` | Bound     | Used by `MmgMesh2D.build_size_map()`                                              |
+| Function      | Status | Notes                                |
+| ------------- | ------ | ------------------------------------ |
+| `MMG2D_doSol` | Bound  | Used by `MmgMesh2D.build_size_map()` |
 
 ---
 
@@ -525,25 +528,25 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### Initialization & Memory Management
 
-| Function               | Status    | Notes                                               |
-| ---------------------- | --------- | --------------------------------------------------- |
-| `MMGS_Init_mesh`       | Bound     | `MmgMeshS()` constructor; `mmgs.remesh()`           |
-| `MMGS_Init_fileNames`  | Excluded  | Called internally by `Init_mesh`                    |
-| `MMGS_Init_parameters` | Excluded  | Called internally by `Init_mesh`                    |
-| `MMGS_Free_all`        | Bound     | Called in `MmgMeshS` destructor and `mmgs.remesh()` |
-| `MMGS_Free_structures` | Excluded  | `Free_all` used instead                             |
-| `MMGS_Free_names`      | Excluded  | `Free_all` used instead                             |
-| `MMGS_Free_allSols`    | Bound     | Releases arrays used by multi-solution I/O wrappers |
-| `MMGS_Free_solutions`  | Excluded  | `Free_all` used instead                             |
+| Function               | Status   | Notes                                                     |
+| ---------------------- | -------- | --------------------------------------------------------- |
+| `MMGS_Init_mesh`       | Bound    | `MmgMeshS()` constructor; `mmgs.remesh()`                 |
+| `MMGS_Init_fileNames`  | Excluded | Called internally by `Init_mesh`                          |
+| `MMGS_Init_parameters` | Excluded | Called internally by `Init_mesh`                          |
+| `MMGS_Free_all`        | Bound    | Called in `MmgMeshS` destructor and `mmgs.remesh()`       |
+| `MMGS_Free_structures` | Excluded | `Free_all` used instead                                   |
+| `MMGS_Free_names`      | Excluded | `Free_all` used instead                                   |
+| `MMGS_Free_allSols`    | Bound    | Internal cleanup for multi-solution I/O; no Python method |
+| `MMGS_Free_solutions`  | Excluded | `Free_all` used instead                                   |
 
 ### Mesh Size & Validation
 
-| Function                | Status    | Notes                                                |
-| ----------------------- | --------- | ---------------------------------------------------- |
-| `MMGS_Set_meshSize`     | Bound     | `MmgMeshS.set_mesh_size()`                           |
-| `MMGS_Get_meshSize`     | Bound     | `MmgMeshS.get_mesh_size()`                           |
-| `MMGS_Chk_meshData`     | Indirect  | Called internally by MMG before remeshing            |
-| `MMGS_Set_constantSize` | Indirect  | Could be useful; use `hsiz` parameter as alternative |
+| Function                | Status   | Notes                                                |
+| ----------------------- | -------- | ---------------------------------------------------- |
+| `MMGS_Set_meshSize`     | Bound    | `MmgMeshS.set_mesh_size()`                           |
+| `MMGS_Get_meshSize`     | Bound    | `MmgMeshS.get_mesh_size()`                           |
+| `MMGS_Chk_meshData`     | Indirect | Called internally by MMG before remeshing            |
+| `MMGS_Set_constantSize` | Indirect | Could be useful; use `hsiz` parameter as alternative |
 
 ### Vertex Operations
 
@@ -593,92 +596,92 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### Solution / Metric Fields
 
-| Function              | Status    | Notes                                                   |
-| --------------------- | --------- | ------------------------------------------------------- |
-| `MMGS_Set_solSize`    | Bound     | Called internally when setting fields via `set_field()` |
-| `MMGS_Get_solSize`    | Indirect  | Could be useful for querying solution state             |
-| `MMGS_Set_scalarSol`  | Indirect  | `Set_scalarSols` (bulk) used instead                    |
-| `MMGS_Set_scalarSols` | Bound     | Used in `set_field("metric")` / `set_field("levelset")` |
-| `MMGS_Get_scalarSol`  | Indirect  | `Get_scalarSols` (bulk) used instead                    |
-| `MMGS_Get_scalarSols` | Bound     | Used in `get_field("metric")` / `get_field("levelset")` |
-| `MMGS_Set_vectorSol`  | Indirect  | `Set_vectorSols` (bulk) used instead                    |
-| `MMGS_Set_vectorSols` | Bound     | Used in `set_field("displacement")`                     |
-| `MMGS_Get_vectorSol`  | Indirect  | `Get_vectorSols` (bulk) used instead                    |
-| `MMGS_Get_vectorSols` | Bound     | Used in `get_field("displacement")`                     |
-| `MMGS_Set_tensorSol`  | Indirect  | `Set_tensorSols` (bulk) used instead                    |
-| `MMGS_Set_tensorSols` | Bound     | Used in `set_field("tensor")`                           |
-| `MMGS_Get_tensorSol`  | Indirect  | `Get_tensorSols` (bulk) used instead                    |
-| `MMGS_Get_tensorSols` | Bound     | Used in `get_field("tensor")`                           |
+| Function              | Status   | Notes                                                   |
+| --------------------- | -------- | ------------------------------------------------------- |
+| `MMGS_Set_solSize`    | Bound    | Called internally when setting fields via `set_field()` |
+| `MMGS_Get_solSize`    | Indirect | Could be useful for querying solution state             |
+| `MMGS_Set_scalarSol`  | Indirect | `Set_scalarSols` (bulk) used instead                    |
+| `MMGS_Set_scalarSols` | Bound    | Used in `set_field("metric")` / `set_field("levelset")` |
+| `MMGS_Get_scalarSol`  | Indirect | `Get_scalarSols` (bulk) used instead                    |
+| `MMGS_Get_scalarSols` | Bound    | Used in `get_field("metric")` / `get_field("levelset")` |
+| `MMGS_Set_vectorSol`  | Indirect | `Set_vectorSols` (bulk) used instead                    |
+| `MMGS_Set_vectorSols` | Bound    | Used in `set_field("displacement")`                     |
+| `MMGS_Get_vectorSol`  | Indirect | `Get_vectorSols` (bulk) used instead                    |
+| `MMGS_Get_vectorSols` | Bound    | Used in `get_field("displacement")`                     |
+| `MMGS_Set_tensorSol`  | Indirect | `Set_tensorSols` (bulk) used instead                    |
+| `MMGS_Set_tensorSols` | Bound    | Used in `set_field("tensor")`                           |
+| `MMGS_Get_tensorSol`  | Indirect | `Get_tensorSols` (bulk) used instead                    |
+| `MMGS_Get_tensorSols` | Bound    | Used in `get_field("tensor")`                           |
 
 ### Multi-Solution Support
 
-| Function                            | Status    | Notes                                          |
-| ----------------------------------- | --------- | ---------------------------------------------- |
-| `MMGS_Set_solsAtVerticesSize`       | Bound     | Used by `save_all_sols()`                      |
-| `MMGS_Get_solsAtVerticesSize`       | Bound     | Used by `load_all_sols()`                      |
-| `MMGS_Set_ithSol_inSolsAtVertices`  | Indirect  | Set individual values in multi-solution        |
-| `MMGS_Set_ithSols_inSolsAtVertices` | Bound     | Used by `save_all_sols()`                      |
-| `MMGS_Get_ithSol_inSolsAtVertices`  | Indirect  | Get individual values from multi-solution      |
-| `MMGS_Get_ithSols_inSolsAtVertices` | Bound     | Used by `load_all_sols()`                      |
+| Function                            | Status   | Notes                                     |
+| ----------------------------------- | -------- | ----------------------------------------- |
+| `MMGS_Set_solsAtVerticesSize`       | Bound    | Used by `save_all_sols()`                 |
+| `MMGS_Get_solsAtVerticesSize`       | Bound    | Used by `load_all_sols()`                 |
+| `MMGS_Set_ithSol_inSolsAtVertices`  | Indirect | Set individual values in multi-solution   |
+| `MMGS_Set_ithSols_inSolsAtVertices` | Bound    | Used by `save_all_sols()`                 |
+| `MMGS_Get_ithSol_inSolsAtVertices`  | Indirect | Get individual values from multi-solution |
+| `MMGS_Get_ithSols_inSolsAtVertices` | Bound    | Used by `load_all_sols()`                 |
 
 ### Parameters
 
-| Function                   | Status    | Notes                                                   |
-| -------------------------- | --------- | ------------------------------------------------------- |
-| `MMGS_Set_iparameter`      | Bound     | Used in `remesh()` for integer options                  |
-| `MMGS_Set_dparameter`      | Bound     | Used in `remesh()` for float options (hmin, hmax, etc.) |
-| `MMGS_Get_iparameter`      | Bound     | `MmgMeshS.get_iparameter()`                            |
-| `MMGS_Set_localParameter`  | Bound     | `MmgMeshS.set_local_parameters()`                       |
-| `MMGS_Set_multiMat`        | Bound     | `MmgMeshS.set_multi_materials()`                        |
-| `MMGS_Set_lsBaseReference` | Bound     | `MmgMeshS.set_ls_base_references()`                     |
+| Function                   | Status | Notes                                                   |
+| -------------------------- | ------ | ------------------------------------------------------- |
+| `MMGS_Set_iparameter`      | Bound  | Used in `remesh()` for integer options                  |
+| `MMGS_Set_dparameter`      | Bound  | Used in `remesh()` for float options (hmin, hmax, etc.) |
+| `MMGS_Get_iparameter`      | Bound  | `MmgMeshS.get_iparameter()`                             |
+| `MMGS_Set_localParameter`  | Bound  | `MmgMeshS.set_local_parameters()`                       |
+| `MMGS_Set_multiMat`        | Bound  | `MmgMeshS.set_multi_materials()`                        |
+| `MMGS_Set_lsBaseReference` | Bound  | `MmgMeshS.set_ls_base_references()`                     |
 
 ### I/O Configuration
 
-| Function                  | Status    | Notes                                                |
-| ------------------------- | --------- | ---------------------------------------------------- |
-| `MMGS_Set_inputMeshName`  | Bound     | Used in `mmgs.remesh()` file-based API               |
-| `MMGS_Set_outputMeshName` | Bound     | Used in `mmgs.remesh()` file-based API               |
-| `MMGS_Set_inputSolName`   | Bound     | Used in `mmgs.remesh()` file-based API               |
-| `MMGS_Set_outputSolName`  | Bound     | Used in `mmgs.remesh()` file-based API               |
-| `MMGS_Set_inputParamName` | Bound     | `MmgMeshS.set_input_parameter_name()`                |
+| Function                  | Status | Notes                                  |
+| ------------------------- | ------ | -------------------------------------- |
+| `MMGS_Set_inputMeshName`  | Bound  | Used in `mmgs.remesh()` file-based API |
+| `MMGS_Set_outputMeshName` | Bound  | Used in `mmgs.remesh()` file-based API |
+| `MMGS_Set_inputSolName`   | Bound  | Used in `mmgs.remesh()` file-based API |
+| `MMGS_Set_outputSolName`  | Bound  | Used in `mmgs.remesh()` file-based API |
+| `MMGS_Set_inputParamName` | Bound  | `MmgMeshS.set_input_parameter_name()`  |
 
 ### File I/O
 
-| Function                       | Status    | Notes                                                           |
-| ------------------------------ | --------- | --------------------------------------------------------------- |
-| `MMGS_loadMesh`                | Bound     | Used in `mmgs.remesh()` and `MmgMeshS(filename)`                |
-| `MMGS_saveMesh`                | Bound     | Used in `mmgs.remesh()` and `MmgMeshS.save()`                   |
-| `MMGS_loadSol`                 | Bound     | Used in `mmgs.remesh()` and `MmgMeshS.load_sol()`               |
-| `MMGS_saveSol`                 | Bound     | Used in `mmgs.remesh()` and `MmgMeshS.save_sol()`               |
-| `MMGS_loadGenericMesh`         | Indirect  | Auto-detect format; `loadMesh` used + PyVista for other formats |
-| `MMGS_saveGenericMesh`         | Indirect  | Auto-detect format; `saveMesh` used + PyVista for other formats |
-| `MMGS_loadMshMesh`             | Indirect  | Gmsh format; handled by PyVista instead                         |
-| `MMGS_loadMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
-| `MMGS_saveMshMesh`             | Indirect  | Gmsh format output                                              |
-| `MMGS_saveMshMesh_and_allData` | Indirect  | Gmsh format with all data                                       |
-| `MMGS_loadVtkMesh`             | Indirect  | VTK format; handled by PyVista instead                          |
-| `MMGS_loadVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
-| `MMGS_saveVtkMesh`             | Indirect  | VTK format output                                               |
-| `MMGS_saveVtkMesh_and_allData` | Indirect  | VTK format with all data                                        |
-| `MMGS_loadVtpMesh`             | Indirect  | VTP format; handled by PyVista instead                          |
-| `MMGS_loadVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
-| `MMGS_saveVtpMesh`             | Indirect  | VTP format output                                               |
-| `MMGS_saveVtpMesh_and_allData` | Indirect  | VTP format with all data                                        |
-| `MMGS_loadVtuMesh`             | Indirect  | VTU format; handled by PyVista instead                          |
-| `MMGS_loadVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
-| `MMGS_saveVtuMesh`             | Indirect  | VTU format output                                               |
-| `MMGS_saveVtuMesh_and_allData` | Indirect  | VTU format with all data                                        |
-| `MMGS_loadAllSols`             | Bound     | `MmgMeshS.load_all_sols()`                                      |
-| `MMGS_saveAllSols`             | Bound     | `MmgMeshS.save_all_sols()`                                      |
+| Function                       | Status   | Notes                                                           |
+| ------------------------------ | -------- | --------------------------------------------------------------- |
+| `MMGS_loadMesh`                | Bound    | Used in `mmgs.remesh()` and `MmgMeshS(filename)`                |
+| `MMGS_saveMesh`                | Bound    | Used in `mmgs.remesh()` and `MmgMeshS.save()`                   |
+| `MMGS_loadSol`                 | Bound    | Used in `mmgs.remesh()` and `MmgMeshS.load_sol()`               |
+| `MMGS_saveSol`                 | Bound    | Used in `mmgs.remesh()` and `MmgMeshS.save_sol()`               |
+| `MMGS_loadGenericMesh`         | Indirect | Auto-detect format; `loadMesh` used + PyVista for other formats |
+| `MMGS_saveGenericMesh`         | Indirect | Auto-detect format; `saveMesh` used + PyVista for other formats |
+| `MMGS_loadMshMesh`             | Indirect | Gmsh format; handled by PyVista instead                         |
+| `MMGS_loadMshMesh_and_allData` | Indirect | Gmsh format with all data                                       |
+| `MMGS_saveMshMesh`             | Indirect | Gmsh format output                                              |
+| `MMGS_saveMshMesh_and_allData` | Indirect | Gmsh format with all data                                       |
+| `MMGS_loadVtkMesh`             | Indirect | VTK format; handled by PyVista instead                          |
+| `MMGS_loadVtkMesh_and_allData` | Indirect | VTK format with all data                                        |
+| `MMGS_saveVtkMesh`             | Indirect | VTK format output                                               |
+| `MMGS_saveVtkMesh_and_allData` | Indirect | VTK format with all data                                        |
+| `MMGS_loadVtpMesh`             | Indirect | VTP format; handled by PyVista instead                          |
+| `MMGS_loadVtpMesh_and_allData` | Indirect | VTP format with all data                                        |
+| `MMGS_saveVtpMesh`             | Indirect | VTP format output                                               |
+| `MMGS_saveVtpMesh_and_allData` | Indirect | VTP format with all data                                        |
+| `MMGS_loadVtuMesh`             | Indirect | VTU format; handled by PyVista instead                          |
+| `MMGS_loadVtuMesh_and_allData` | Indirect | VTU format with all data                                        |
+| `MMGS_saveVtuMesh`             | Indirect | VTU format output                                               |
+| `MMGS_saveVtuMesh_and_allData` | Indirect | VTU format with all data                                        |
+| `MMGS_loadAllSols`             | Bound    | `MmgMeshS.load_all_sols()`                                      |
+| `MMGS_saveAllSols`             | Bound    | `MmgMeshS.save_all_sols()`                                      |
 
 ### Topology Queries
 
-| Function                       | Status    | Notes                                                               |
-| ------------------------------ | --------- | ------------------------------------------------------------------- |
-| `MMGS_Get_adjaTri`             | Bound     | `MmgMeshS.get_adjacent_elements()`                                  |
-| `MMGS_Get_adjaVerticesFast`    | Indirect  | Requires adjacency tables that may not be available after remeshing |
-| `MMGS_Get_numberOfNonBdyEdges` | Bound     | Used in `get_non_boundary_edges()`                                  |
-| `MMGS_Get_nonBdyEdge`          | Bound     | Used in `get_non_boundary_edges()`                                  |
+| Function                       | Status   | Notes                                                               |
+| ------------------------------ | -------- | ------------------------------------------------------------------- |
+| `MMGS_Get_adjaTri`             | Bound    | `MmgMeshS.get_adjacent_elements()`                                  |
+| `MMGS_Get_adjaVerticesFast`    | Indirect | Requires adjacency tables that may not be available after remeshing |
+| `MMGS_Get_numberOfNonBdyEdges` | Bound    | Used in `get_non_boundary_edges()`                                  |
+| `MMGS_Get_nonBdyEdge`          | Bound    | Used in `get_non_boundary_edges()`                                  |
 
 ### Remeshing Functions
 
@@ -689,23 +692,23 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### CLI & Internal Utilities
 
-| Function              | Status    | Notes                                                 |
-| --------------------- | --------- | ----------------------------------------------------- |
-| `MMGS_defaultValues`  | Excluded  | Prints default values to stdout; CLI utility          |
-| `MMGS_parsar`         | Excluded  | Command-line argument parser; not relevant for Python |
-| `MMGS_usage`          | Excluded  | Prints usage text; CLI utility                        |
-| `MMGS_Set_commonFunc` | Excluded  | Internal MMG function pointer setup                   |
-| `MMGS_setfunc`        | Bound     | Initializes `MMGS_doSol` for `build_size_map()`       |
-| `MMGS_stockOptions`   | Excluded  | Internal: saves options to mesh structure             |
-| `MMGS_destockOptions` | Excluded  | Internal: restores options from mesh structure        |
-| `MMGS_Compute_eigenv` | Indirect  | `metrics.compute_metric_eigenpairs()` / NumPy          |
-| `MMGS_Clean_isoSurf`  | Bound     | `MmgMeshS.clean_iso_surface()`                        |
+| Function              | Status   | Notes                                                 |
+| --------------------- | -------- | ----------------------------------------------------- |
+| `MMGS_defaultValues`  | Excluded | Prints default values to stdout; CLI utility          |
+| `MMGS_parsar`         | Excluded | Command-line argument parser; not relevant for Python |
+| `MMGS_usage`          | Excluded | Prints usage text; CLI utility                        |
+| `MMGS_Set_commonFunc` | Excluded | Internal MMG function pointer setup                   |
+| `MMGS_setfunc`        | Bound    | Initializes `MMGS_doSol` for `build_size_map()`       |
+| `MMGS_stockOptions`   | Excluded | Internal: saves options to mesh structure             |
+| `MMGS_destockOptions` | Excluded | Internal: restores options from mesh structure        |
+| `MMGS_Compute_eigenv` | Indirect | `metrics.compute_metric_eigenpairs()` / NumPy         |
+| `MMGS_Clean_isoSurf`  | Bound    | `MmgMeshS.clean_iso_surface()`                        |
 
 ### Function Pointers
 
-| Function     | Status    | Notes                                                                                |
-| ------------ | --------- | ------------------------------------------------------------------------------------ |
-| `MMGS_doSol` | Bound     | Used by `MmgMeshS.build_size_map()`                                               |
+| Function     | Status | Notes                               |
+| ------------ | ------ | ----------------------------------- |
+| `MMGS_doSol` | Bound  | Used by `MmgMeshS.build_size_map()` |
 
 ---
 

--- a/scripts/check_mmg_api_coverage.py
+++ b/scripts/check_mmg_api_coverage.py
@@ -23,7 +23,10 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
 
 _LIBRARIES = ("MMG3D", "MMG2D", "MMGS")
 _HEADER_PATHS = {

--- a/scripts/check_mmg_api_coverage.py
+++ b/scripts/check_mmg_api_coverage.py
@@ -1,0 +1,429 @@
+"""Validate the documented MMG C API coverage against the pinned headers.
+
+The audit has two deterministic inputs:
+
+* callable declarations in MMG's public ``libmmg*.h`` headers;
+* direct symbol references in ``src/bindings`` after comments and literals are
+  removed.
+
+The coverage document remains the source of truth for semantic classifications
+such as ``Indirect``, ``Candidate``, ``Excluded``, and ``Skipped``. Those
+decisions cannot be inferred safely from spelling alone. The checker fails when
+MMG adds or removes an API, when a directly referenced function is not labelled
+``Bound``, or when the summary counts drift. ``--write`` repairs direct-binding
+statuses and the summary table; new functions still require a human
+classification and note.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import tomllib
+
+_LIBRARIES = ("MMG3D", "MMG2D", "MMGS")
+_HEADER_PATHS = {
+    "MMG3D": Path("src/mmg3d/libmmg3d.h"),
+    "MMG2D": Path("src/mmg2d/libmmg2d.h"),
+    "MMGS": Path("src/mmgs/libmmgs.h"),
+}
+_STATUSES = ("Bound", "Indirect", "Candidate", "Excluded", "Skipped")
+_INTENTIONALLY_INDIRECT_PARAMS = frozenset({
+    "MMG3D_IPARAM_lag",
+    "MMG3D_IPARAM_renum",
+    "MMG2D_IPARAM_lag",
+    "MMGS_IPARAM_renum",
+})
+_ROW_RE = re.compile(
+    r"^(?P<lead>\|\s*`(?P<symbol>MMG(?:3D|2D|S)_[A-Za-z0-9_]+)`\s*\|\s*)"
+    r"(?P<status>Bound|Indirect|Candidate|Excluded|Skipped)"
+    r"(?P<trail>\s*\|.*)$",
+    re.MULTILINE,
+)
+_ROW_LINE_RE = re.compile(
+    r"^(?P<lead>\|\s*`(?P<symbol>MMG(?:3D|2D|S)_[A-Za-z0-9_]+)`\s*\|)"
+    r"\s*(?P<status>Bound|Indirect|Candidate|Excluded|Skipped)\s*(?P<trail>\|.*)$",
+)
+_SUMMARY_RE = re.compile(
+    r"^\|\s*(?P<library>MMG3D|MMG2D|MMGS)\s*\|"
+    r"(?P<values>.*)\|$",
+    re.MULTILINE,
+)
+_COMMENT_RE = re.compile(r"/\*.*?\*/|//[^\r\n]*", re.DOTALL)
+_CPP_LITERAL_RE = re.compile(
+    r'R"(?P<delimiter>[^\s()\\]{0,16})\(.*?\)(?P=delimiter)"'
+    r'|"(?:\\.|[^"\\])*"'
+    r"|'(?:\\.|[^'\\])*'",
+    re.DOTALL,
+)
+_PREPROCESSOR_RE = re.compile(r"^[ \t]*#(?:.*\\\r?\n)*.*$", re.MULTILINE)
+_MMG_VERSION_RE = re.compile(
+    r'CMAKE_RELEASE_VERSION_(MAJOR|MINOR|PATCH)\s+"([0-9]+)"',
+)
+
+
+@dataclass(frozen=True)
+class CoverageRow:
+    """One classified function from the coverage document."""
+
+    symbol: str
+    status: str
+
+
+@dataclass(frozen=True)
+class LibraryAudit:
+    """Coverage facts and validation errors for one MMG library."""
+
+    library: str
+    public_symbols: frozenset[str]
+    rows: tuple[CoverageRow, ...]
+    direct_symbols: frozenset[str]
+
+    @property
+    def documented_symbols(self) -> frozenset[str]:
+        """Set of documented API symbols."""
+        return frozenset(row.symbol for row in self.rows)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        """Counts for every documented status."""
+        return {
+            status: sum(row.status == status for row in self.rows)
+            for status in _STATUSES
+        }
+
+    @property
+    def errors(self) -> tuple[str, ...]:
+        """Deterministic coverage inconsistencies."""
+        errors: list[str] = []
+        missing = sorted(self.public_symbols - self.documented_symbols)
+        removed = sorted(self.documented_symbols - self.public_symbols)
+        if missing:
+            errors.append(f"undocumented public functions: {', '.join(missing)}")
+        if removed:
+            errors.append(
+                f"documented functions absent from header: {', '.join(removed)}"
+            )
+
+        status_by_symbol = {row.symbol: row.status for row in self.rows}
+        stale = sorted(
+            symbol
+            for symbol in self.direct_symbols & self.documented_symbols
+            if status_by_symbol[symbol] != "Bound"
+        )
+        if stale:
+            errors.append(f"directly referenced but not Bound: {', '.join(stale)}")
+
+        unsupported_bound = sorted(
+            symbol
+            for symbol, status in status_by_symbol.items()
+            if status == "Bound" and symbol not in self.direct_symbols
+        )
+        if unsupported_bound:
+            errors.append(
+                "labelled Bound without a binding reference: "
+                + ", ".join(unsupported_bound),
+            )
+        return tuple(errors)
+
+
+def _strip_c_comments(text: str) -> str:
+    """Remove C and C++ comments while preserving declarations."""
+    return _COMMENT_RE.sub(" ", text)
+
+
+def extract_public_symbols(header: Path, prefix: str) -> frozenset[str]:
+    """Extract callable declarations for ``prefix`` from a public MMG header."""
+    text = _strip_c_comments(header.read_text(encoding="utf-8"))
+    text = _PREPROCESSOR_RE.sub("", text)
+    normal = re.compile(rf"\b({prefix}_[A-Za-z0-9_]+)\s*\(")
+    pointer = re.compile(
+        rf"\(\s*\*\s*({prefix}_[A-Za-z0-9_]+)\s*\)\s*\(",
+    )
+    symbols: set[str] = set()
+    for statement in text.split(";"):
+        if "typedef" in statement:
+            continue
+        pointer_match = pointer.search(statement)
+        if pointer_match:
+            symbols.add(pointer_match.group(1))
+            continue
+        matches = normal.findall(statement)
+        if matches:
+            symbols.add(matches[-1])
+    return frozenset(symbols)
+
+
+def extract_public_parameters(header: Path, prefix: str) -> frozenset[str]:
+    """Extract integer and double parameter constants from a public header."""
+    text = _strip_c_comments(header.read_text(encoding="utf-8"))
+    return frozenset(re.findall(rf"\b{prefix}_[ID]PARAM_[A-Za-z0-9_]+\b", text))
+
+
+def parse_document_rows(document: str, library: str) -> tuple[CoverageRow, ...]:
+    """Parse unique coverage rows belonging to ``library``."""
+    rows = [
+        CoverageRow(match.group("symbol"), match.group("status"))
+        for match in _ROW_RE.finditer(document)
+        if match.group("symbol").startswith(f"{library}_")
+    ]
+    symbols = [row.symbol for row in rows]
+    duplicates = sorted({symbol for symbol in symbols if symbols.count(symbol) > 1})
+    if duplicates:
+        msg = f"duplicate {library} coverage rows: {', '.join(duplicates)}"
+        raise ValueError(msg)
+    return tuple(rows)
+
+
+def scan_direct_symbols(
+    bindings_dir: Path, candidates: frozenset[str]
+) -> frozenset[str]:
+    """Return candidate MMG symbols referenced by C++ binding code."""
+    chunks: list[str] = []
+    for path in sorted(bindings_dir.rglob("*")):
+        if path.suffix not in {".cpp", ".h", ".hpp"}:
+            continue
+        text = _strip_c_comments(path.read_text(encoding="utf-8"))
+        chunks.append(_CPP_LITERAL_RE.sub(" ", text))
+    source = "\n".join(chunks)
+    return frozenset(
+        symbol
+        for symbol in candidates
+        if re.search(rf"(?<![A-Za-z0-9_]){re.escape(symbol)}(?![A-Za-z0-9_])", source)
+    )
+
+
+def find_mmg_source(repo_root: Path, explicit: Path | None = None) -> Path:
+    """Locate an MMG source tree containing all three public headers."""
+    candidates = [explicit] if explicit is not None else []
+    candidates.extend(
+        (
+            repo_root / "build" / "_deps" / "mmg-src",
+            repo_root / "_skbuild" / "_deps" / "mmg-src",
+        ),
+    )
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        resolved = candidate.resolve()
+        if all((resolved / relative).is_file() for relative in _HEADER_PATHS.values()):
+            return resolved
+    searched = ", ".join(str(path) for path in candidates if path is not None)
+    msg = (
+        "Unable to locate MMG public headers. Build mmgpy first or pass "
+        f"--mmg-source. Searched: {searched}"
+    )
+    raise FileNotFoundError(msg)
+
+
+def read_pinned_mmg_version(repo_root: Path) -> str:
+    """Read the MMG version selected by mmgpy's build configuration."""
+    with (repo_root / "pyproject.toml").open("rb") as stream:
+        project = tomllib.load(stream)
+    return str(project["tool"]["mmgpy"]["mmg_version"])
+
+
+def read_mmg_source_version(mmg_source: Path) -> str:
+    """Read the release version declared by an MMG source tree."""
+    cmake = (mmg_source / "CMakeLists.txt").read_text(encoding="utf-8")
+    parts = dict(_MMG_VERSION_RE.findall(cmake))
+    required = ("MAJOR", "MINOR", "PATCH")
+    if any(part not in parts for part in required):
+        msg = f"Unable to determine MMG version from {mmg_source / 'CMakeLists.txt'}"
+        raise ValueError(msg)
+    return ".".join(parts[part] for part in required)
+
+
+def validate_mmg_source_version(repo_root: Path, mmg_source: Path) -> None:
+    """Reject a source tree that does not match the version pinned by mmgpy."""
+    pinned = read_pinned_mmg_version(repo_root)
+    actual = read_mmg_source_version(mmg_source)
+    if actual != pinned:
+        msg = f"MMG source version {actual} does not match pinned version {pinned}"
+        raise ValueError(msg)
+
+
+def build_audits(
+    *,
+    mmg_source: Path,
+    bindings_dir: Path,
+    document: str,
+) -> tuple[LibraryAudit, ...]:
+    """Build coverage audits for MMG3D, MMG2D, and MMGS."""
+    audits: list[LibraryAudit] = []
+    for library in _LIBRARIES:
+        public_symbols = extract_public_symbols(
+            mmg_source / _HEADER_PATHS[library],
+            library,
+        )
+        audits.append(
+            LibraryAudit(
+                library=library,
+                public_symbols=public_symbols,
+                rows=parse_document_rows(document, library),
+                direct_symbols=scan_direct_symbols(bindings_dir, public_symbols),
+            ),
+        )
+    return tuple(audits)
+
+
+def _summary_line(audit: LibraryAudit) -> str:
+    """Render one Markdown summary row."""
+    counts = audit.counts
+    functional = counts["Bound"] + counts["Indirect"]
+    percentage = round(100 * functional / len(audit.public_symbols))
+    return (
+        f"| {audit.library:<7} | {len(audit.public_symbols):5d} |"
+        f" {counts['Bound']:5d} | {counts['Indirect']:8d} |"
+        f" {counts['Candidate']:9d} | {counts['Excluded']:8d} |"
+        f" {counts['Skipped']:7d} |"
+        f" {percentage:18d}% |"
+    )
+
+
+def rewrite_document(
+    document: str,
+    audits: tuple[LibraryAudit, ...],
+    *,
+    mmg_source: Path,
+    bindings_dir: Path,
+) -> str:
+    """Mark direct references Bound and regenerate summary rows."""
+    direct = frozenset().union(*(audit.direct_symbols for audit in audits))
+    status_width: int | None = None
+    updated_lines: list[str] = []
+    for line in document.splitlines(keepends=True):
+        stripped = line.rstrip("\r\n")
+        newline = line[len(stripped) :]
+        if stripped.startswith("| --------") and status_width is None:
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) >= 2:
+                status_width = len(cells[1])
+        match = _ROW_LINE_RE.match(stripped)
+        if match and status_width is not None:
+            symbol = match.group("symbol")
+            status = match.group("status")
+            if symbol in direct:
+                status = "Bound"
+            stripped = (
+                f"{match.group('lead')} {status:<{status_width}} {match.group('trail')}"
+            )
+        if not stripped.startswith("|"):
+            status_width = None
+        updated_lines.append(f"{stripped}{newline}")
+
+    updated = "".join(updated_lines)
+    refreshed = build_audits(
+        mmg_source=mmg_source,
+        bindings_dir=bindings_dir,
+        document=updated,
+    )
+    summary_by_library = {audit.library: _summary_line(audit) for audit in refreshed}
+
+    def replace_summary(match: re.Match[str]) -> str:
+        return summary_by_library[match.group("library")]
+
+    return _SUMMARY_RE.sub(replace_summary, updated)
+
+
+def validate_summary(
+    document: str, audits: tuple[LibraryAudit, ...]
+) -> tuple[str, ...]:
+    """Return errors for summary rows that do not match detailed classifications."""
+    summary = {
+        match.group("library"): match.group(0)
+        for match in _SUMMARY_RE.finditer(document)
+    }
+    errors: list[str] = []
+    for audit in audits:
+        expected = _summary_line(audit)
+        if summary.get(audit.library) != expected:
+            errors.append(
+                f"{audit.library}: stale summary row\n"
+                f"  expected: {expected}\n"
+                f"  actual:   {summary.get(audit.library, '<missing>')}",
+            )
+    return tuple(errors)
+
+
+def validate_parameter_coverage(
+    mmg_source: Path, bindings_dir: Path
+) -> tuple[str, ...]:
+    """Ensure every public MMG option is mapped or intentionally indirect."""
+    public: set[str] = set()
+    for library in _LIBRARIES:
+        public.update(
+            extract_public_parameters(mmg_source / _HEADER_PATHS[library], library)
+        )
+    mapped = scan_direct_symbols(bindings_dir, frozenset(public))
+    uncovered = sorted(public - mapped - _INTENTIONALLY_INDIRECT_PARAMS)
+    obsolete = sorted(_INTENTIONALLY_INDIRECT_PARAMS - public)
+    errors: list[str] = []
+    if uncovered:
+        errors.append(f"unmapped public parameters: {', '.join(uncovered)}")
+    if obsolete:
+        errors.append(f"obsolete indirect parameters: {', '.join(obsolete)}")
+    return tuple(errors)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mmg-source", type=Path, help="Path to the MMG source tree")
+    parser.add_argument(
+        "--write", action="store_true", help="Repair statuses and summary"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the coverage audit."""
+    args = _build_parser().parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    document_path = repo_root / "docs" / "reference" / "mmg-api-coverage.md"
+    bindings_dir = repo_root / "src" / "bindings"
+    mmg_source = find_mmg_source(repo_root, args.mmg_source)
+    validate_mmg_source_version(repo_root, mmg_source)
+    document = document_path.read_text(encoding="utf-8")
+
+    audits = build_audits(
+        mmg_source=mmg_source,
+        bindings_dir=bindings_dir,
+        document=document,
+    )
+    if args.write:
+        document = rewrite_document(
+            document,
+            audits,
+            mmg_source=mmg_source,
+            bindings_dir=bindings_dir,
+        )
+        document_path.write_text(document, encoding="utf-8")
+        audits = build_audits(
+            mmg_source=mmg_source,
+            bindings_dir=bindings_dir,
+            document=document,
+        )
+
+    errors = [f"{audit.library}: {error}" for audit in audits for error in audit.errors]
+    errors.extend(validate_summary(document, audits))
+    errors.extend(validate_parameter_coverage(mmg_source, bindings_dir))
+    if errors:
+        print("MMG API coverage audit failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        if not args.write:
+            print("Run with --write to repair direct-binding drift.", file=sys.stderr)
+        return 1
+
+    for audit in audits:
+        print(_summary_line(audit))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -153,6 +153,13 @@ PYBIND11_MODULE(_mmgpy, m) {
            "        hmin: minimum edge size\n"
            "        hmax: maximum edge size\n"
            "        hausd: Hausdorff distance")
+      .def(
+          "set_input_parameter_name",
+          [](MmgMesh &self, const py::object &path) {
+            self.set_input_parameter_name(path_to_variant(path));
+          },
+          py::arg("path"))
+      .def("get_iparameter", &MmgMesh::get_iparameter, py::arg("parameter"))
       // Multi-material and level-set
       .def("set_multi_materials", &MmgMesh::set_multi_materials,
            py::arg("materials"),
@@ -189,6 +196,12 @@ PYBIND11_MODULE(_mmgpy, m) {
            [](const MmgMesh &self, const py::object &path) {
              self.save(path_to_variant(path));
            })
+      .def(
+          "save_tetgen",
+          [](const MmgMesh &self, const py::object &path) {
+            self.save_tetgen(path_to_variant(path));
+          },
+          py::arg("path"))
       .def(
           "load_sol",
           [](MmgMesh &self, const py::object &path,
@@ -335,6 +348,12 @@ PYBIND11_MODULE(_mmgpy, m) {
            "        hmin: minimum edge size\n"
            "        hmax: maximum edge size\n"
            "        hausd: Hausdorff distance")
+      .def(
+          "set_input_parameter_name",
+          [](MmgMesh2D &self, const py::object &path) {
+            self.set_input_parameter_name(path_to_variant(path));
+          },
+          py::arg("path"))
       // Multi-material and level-set
       .def("set_multi_materials", &MmgMesh2D::set_multi_materials,
            py::arg("materials"),
@@ -375,6 +394,12 @@ PYBIND11_MODULE(_mmgpy, m) {
            [](const MmgMesh2D &self, const py::object &path) {
              self.save(path_to_variant(path));
            })
+      .def(
+          "save_tetgen",
+          [](const MmgMesh2D &self, const py::object &path) {
+            self.save_tetgen(path_to_variant(path));
+          },
+          py::arg("path"))
       .def(
           "load_sol",
           [](MmgMesh2D &self, const py::object &path,
@@ -520,6 +545,13 @@ PYBIND11_MODULE(_mmgpy, m) {
            "        hmin: minimum edge size\n"
            "        hmax: maximum edge size\n"
            "        hausd: Hausdorff distance")
+      .def(
+          "set_input_parameter_name",
+          [](MmgMeshS &self, const py::object &path) {
+            self.set_input_parameter_name(path_to_variant(path));
+          },
+          py::arg("path"))
+      .def("get_iparameter", &MmgMeshS::get_iparameter, py::arg("parameter"))
       // Multi-material and level-set
       .def("set_multi_materials", &MmgMeshS::set_multi_materials,
            py::arg("materials"),

--- a/src/bindings/mmg_mesh.cpp
+++ b/src/bindings/mmg_mesh.cpp
@@ -259,6 +259,15 @@ void MmgMesh::save(
   }
 }
 
+void MmgMesh::save_tetgen(
+    const std::variant<std::string, std::filesystem::path> &filename) const {
+  check_not_corrupted("save TetGen mesh");
+  std::string fname = variant_to_string(filename);
+  if (MMG3D_saveTetgenMesh(mesh, fname.c_str()) != 1) {
+    throw std::runtime_error("Failed to save TetGen mesh: " + fname);
+  }
+}
+
 void MmgMesh::load_sol(
     const std::variant<std::string, std::filesystem::path> &filename,
     const std::string &channel) {
@@ -282,7 +291,7 @@ void MmgMesh::save_sol(
 }
 
 namespace {
-constexpr MultiSolApi MMG3D_MULTISOL_API = {
+const MultiSolApi MMG3D_MULTISOL_API = {
     &MMG3D_Set_solsAtVerticesSize,
     &MMG3D_Get_solsAtVerticesSize,
     &MMG3D_Set_ithSols_inSolsAtVertices,
@@ -1047,6 +1056,24 @@ void MmgMesh::set_local_parameters(const py::list &parameters) {
   }
 }
 
+void MmgMesh::set_input_parameter_name(
+    const std::variant<std::string, std::filesystem::path> &filename) {
+  check_not_corrupted("set input parameter name");
+  std::string fname = variant_to_string(filename);
+  if (!std::filesystem::is_regular_file(fname)) {
+    throw std::runtime_error("MMG parameter file not found: " + fname);
+  }
+  if (!MMG3D_Set_inputParamName(mesh, fname.c_str())) {
+    throw std::runtime_error("Failed to set MMG parameter file: " + fname);
+  }
+  has_input_parameter_file_ = true;
+}
+
+int MmgMesh::get_iparameter(MMG5_int parameter) const {
+  check_not_corrupted("get integer parameter");
+  return MMG3D_Get_iparameter(mesh, parameter);
+}
+
 // Multi-material and level-set
 
 void MmgMesh::set_multi_materials(const py::list &materials) {
@@ -1492,6 +1519,12 @@ py::dict MmgMesh::remesh(const py::dict &options) {
   check_not_corrupted("remesh");
   RemeshStats before = collect_mesh_stats_3d(mesh, met);
 
+  if (has_input_parameter_file_) {
+    if (!MMG3D_parsop(mesh, met)) {
+      throw std::runtime_error("Failed to parse MMG3D parameter file");
+    }
+    has_input_parameter_file_ = false;
+  }
   set_mesh_options_3D(mesh, met, options);
 
   // Capture stderr to collect MMG warnings
@@ -1535,6 +1568,12 @@ py::dict MmgMesh::remesh_levelset(const py::array_t<double> &levelset,
 
   set_field("levelset", levelset);
   py::dict ls_options = merge_options_with_default(options, "iso", py::int_(1));
+  if (has_input_parameter_file_) {
+    if (!MMG3D_parsop(mesh, met)) {
+      throw std::runtime_error("Failed to parse MMG3D parameter file");
+    }
+    has_input_parameter_file_ = false;
+  }
   set_mesh_options_3D(mesh, met, ls_options);
 
   // Capture stderr to collect MMG warnings

--- a/src/bindings/mmg_mesh.hpp
+++ b/src/bindings/mmg_mesh.hpp
@@ -95,6 +95,9 @@ public:
 
   // Local parameters
   void set_local_parameters(const py::list &parameters);
+  void set_input_parameter_name(
+      const std::variant<std::string, std::filesystem::path> &filename);
+  int get_iparameter(MMG5_int parameter) const;
 
   // Multi-material and level-set
   void set_multi_materials(const py::list &materials);
@@ -139,6 +142,8 @@ public:
 
   void
   save(const std::variant<std::string, std::filesystem::path> &filename) const;
+  void save_tetgen(
+      const std::variant<std::string, std::filesystem::path> &filename) const;
   void
   load_sol(const std::variant<std::string, std::filesystem::path> &filename,
            const std::string &channel = "metric");
@@ -186,6 +191,7 @@ private:
   void check_not_corrupted(const char *operation) const;
 
   bool corrupted_ = false;
+  bool has_input_parameter_file_ = false;
 };
 
 #endif // MMG_MESH_HPP

--- a/src/bindings/mmg_mesh_2d.cpp
+++ b/src/bindings/mmg_mesh_2d.cpp
@@ -672,6 +672,19 @@ void MmgMesh2D::set_local_parameters(const py::list &parameters) {
   }
 }
 
+void MmgMesh2D::set_input_parameter_name(
+    const std::variant<std::string, std::filesystem::path> &filename) {
+  check_not_corrupted("set input parameter name");
+  std::string fname = variant_to_string(filename);
+  if (!std::filesystem::is_regular_file(fname)) {
+    throw std::runtime_error("MMG parameter file not found: " + fname);
+  }
+  if (!MMG2D_Set_inputParamName(mesh, fname.c_str())) {
+    throw std::runtime_error("Failed to set MMG parameter file: " + fname);
+  }
+  has_input_parameter_file_ = true;
+}
+
 // Multi-material and level-set
 
 void MmgMesh2D::set_multi_materials(const py::list &materials) {
@@ -973,6 +986,15 @@ void MmgMesh2D::save(
   }
 }
 
+void MmgMesh2D::save_tetgen(
+    const std::variant<std::string, std::filesystem::path> &filename) const {
+  check_not_corrupted("save Triangle mesh");
+  std::string fname = variant_to_string(filename);
+  if (MMG2D_saveTetgenMesh(mesh, fname.c_str()) != 1) {
+    throw std::runtime_error("Failed to save Triangle mesh: " + fname);
+  }
+}
+
 void MmgMesh2D::load_sol(
     const std::variant<std::string, std::filesystem::path> &filename,
     const std::string &channel) {
@@ -996,7 +1018,7 @@ void MmgMesh2D::save_sol(
 }
 
 namespace {
-constexpr MultiSolApi MMG2D_MULTISOL_API = {
+const MultiSolApi MMG2D_MULTISOL_API = {
     &MMG2D_Set_solsAtVerticesSize,
     &MMG2D_Get_solsAtVerticesSize,
     &MMG2D_Set_ithSols_inSolsAtVertices,
@@ -1073,6 +1095,12 @@ py::dict MmgMesh2D::remesh(const py::dict &options) {
   check_not_corrupted("remesh");
   RemeshStats before = collect_mesh_stats_2d(mesh, met);
 
+  if (has_input_parameter_file_) {
+    if (!MMG2D_parsop(mesh, met)) {
+      throw std::runtime_error("Failed to parse MMG2D parameter file");
+    }
+    has_input_parameter_file_ = false;
+  }
   set_mesh_options_2D(mesh, met, options);
 
   // Capture stderr to collect MMG warnings
@@ -1119,6 +1147,12 @@ py::dict MmgMesh2D::remesh_levelset(const py::array_t<double> &levelset,
 
   set_field("levelset", levelset);
   py::dict ls_options = merge_options_with_default(options, "iso", py::int_(1));
+  if (has_input_parameter_file_) {
+    if (!MMG2D_parsop(mesh, met)) {
+      throw std::runtime_error("Failed to parse MMG2D parameter file");
+    }
+    has_input_parameter_file_ = false;
+  }
   set_mesh_options_2D(mesh, met, ls_options);
 
   // Capture stderr to collect MMG warnings

--- a/src/bindings/mmg_mesh_2d.hpp
+++ b/src/bindings/mmg_mesh_2d.hpp
@@ -79,6 +79,8 @@ public:
 
   // Local parameters
   void set_local_parameters(const py::list &parameters);
+  void set_input_parameter_name(
+      const std::variant<std::string, std::filesystem::path> &filename);
 
   // Multi-material and level-set
   void set_multi_materials(const py::list &materials);
@@ -107,6 +109,8 @@ public:
   // File I/O
   void
   save(const std::variant<std::string, std::filesystem::path> &filename) const;
+  void save_tetgen(
+      const std::variant<std::string, std::filesystem::path> &filename) const;
   void
   load_sol(const std::variant<std::string, std::filesystem::path> &filename,
            const std::string &channel = "metric");
@@ -153,6 +157,7 @@ private:
   void check_not_corrupted(const char *operation) const;
 
   bool corrupted_ = false;
+  bool has_input_parameter_file_ = false;
 };
 
 #endif // MMG_MESH_2D_HPP

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -698,6 +698,23 @@ void MmgMeshS::set_local_parameters(const py::list &parameters) {
   }
 }
 
+void MmgMeshS::set_input_parameter_name(
+    const std::variant<std::string, std::filesystem::path> &filename) {
+  check_not_corrupted("set input parameter name");
+  std::string fname = variant_to_string(filename);
+  if (!std::filesystem::is_regular_file(fname)) {
+    throw std::runtime_error("MMG parameter file not found: " + fname);
+  }
+  if (!MMGS_Set_inputParamName(mesh, fname.c_str())) {
+    throw std::runtime_error("Failed to set MMG parameter file: " + fname);
+  }
+}
+
+int MmgMeshS::get_iparameter(MMG5_int parameter) const {
+  check_not_corrupted("get integer parameter");
+  return MMGS_Get_iparameter(mesh, parameter);
+}
+
 // Multi-material and level-set
 
 void MmgMeshS::set_multi_materials(const py::list &materials) {
@@ -991,7 +1008,7 @@ void MmgMeshS::save_sol(
 }
 
 namespace {
-constexpr MultiSolApi MMGS_MULTISOL_API = {
+const MultiSolApi MMGS_MULTISOL_API = {
     &MMGS_Set_solsAtVerticesSize,
     &MMGS_Get_solsAtVerticesSize,
     &MMGS_Set_ithSols_inSolsAtVertices,

--- a/src/bindings/mmg_mesh_s.hpp
+++ b/src/bindings/mmg_mesh_s.hpp
@@ -77,6 +77,9 @@ public:
 
   // Local parameters
   void set_local_parameters(const py::list &parameters);
+  void set_input_parameter_name(
+      const std::variant<std::string, std::filesystem::path> &filename);
+  int get_iparameter(MMG5_int parameter) const;
 
   // Multi-material and level-set
   void set_multi_materials(const py::list &materials);

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -1098,6 +1098,15 @@ class MmgMesh3D:
     def is_corrupted(self) -> bool:
         """Whether the mesh is in a corrupted state due to a failed bulk setter."""
 
+    def set_input_parameter_name(self, path: str | Path) -> None:
+        """Select an MMG parameter file to parse before remeshing."""
+
+    def get_iparameter(self, parameter: int) -> int:
+        """Return an MMG3D integer parameter by its ``MMG3D_Param`` value."""
+
+    def save_tetgen(self, path: str | Path) -> None:
+        """Save the mesh in TetGen format."""
+
     def save(self, filename: str | Path) -> None:
         """Save mesh to file.
 
@@ -1950,6 +1959,12 @@ class MmgMesh2D:
     def is_corrupted(self) -> bool:
         """Whether the mesh is in a corrupted state due to a failed bulk setter."""
 
+    def set_input_parameter_name(self, path: str | Path) -> None:
+        """Select an MMG parameter file to parse before remeshing."""
+
+    def save_tetgen(self, path: str | Path) -> None:
+        """Save the mesh in Triangle/TetGen format."""
+
     def save(self, filename: str | Path) -> None:
         """Save mesh to file.
 
@@ -2724,6 +2739,12 @@ class MmgMeshS:
     @property
     def is_corrupted(self) -> bool:
         """Whether the mesh is in a corrupted state due to a failed bulk setter."""
+
+    def set_input_parameter_name(self, path: str | Path) -> None:
+        """Select an MMG parameter file to parse before remeshing."""
+
+    def get_iparameter(self, parameter: int) -> int:
+        """Return an MMGS integer parameter by its ``MMGS_Param`` value."""
 
     def save(self, filename: str | Path) -> None:
         """Save mesh to file.

--- a/tests/api_candidates_test.py
+++ b/tests/api_candidates_test.py
@@ -1,0 +1,49 @@
+"""Tests for the final user-facing MMG C API candidates."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
+
+
+@pytest.mark.parametrize("mesh_type", [MmgMesh3D, MmgMesh2D, MmgMeshS])
+def test_set_input_parameter_name_validates_path(
+    mesh_type: type[MmgMesh3D | MmgMesh2D | MmgMeshS], tmp_path: Path
+) -> None:
+    """All engines bind their native input-parameter filename setter."""
+    mesh = mesh_type()
+    with pytest.raises(RuntimeError, match="parameter file not found"):
+        mesh.set_input_parameter_name(tmp_path / "missing.mmg")
+
+    parameter_file = tmp_path / "local-parameters.mmg"
+    parameter_file.write_text("", encoding="utf-8")
+    mesh.set_input_parameter_name(parameter_file)
+
+
+def test_integer_parameter_getters() -> None:
+    """MMG3D and MMGS expose their native integer-parameter getter."""
+    # In both public enums, zero is the verbosity parameter.
+    assert isinstance(MmgMesh3D().get_iparameter(0), int)
+    assert isinstance(MmgMeshS().get_iparameter(0), int)
+
+
+def test_save_tetgen_3d(
+    cube_mesh: tuple[np.ndarray, np.ndarray], tmp_path: Path
+) -> None:
+    """MMG3D writes the TetGen .node/.ele pair."""
+    vertices, tetrahedra = cube_mesh
+    MmgMesh3D(vertices, tetrahedra).save_tetgen(tmp_path / "mesh.node")
+    assert (tmp_path / "mesh.node").is_file()
+    assert (tmp_path / "mesh.ele").is_file()
+
+
+def test_save_tetgen_2d(
+    square_mesh: tuple[np.ndarray, np.ndarray], tmp_path: Path
+) -> None:
+    """MMG2D writes the Triangle .node/.ele pair."""
+    vertices, triangles = square_mesh
+    MmgMesh2D(vertices, triangles).save_tetgen(tmp_path / "mesh.node")
+    assert (tmp_path / "mesh.node").is_file()
+    assert (tmp_path / "mesh.ele").is_file()

--- a/tests/mmg_api_coverage_test.py
+++ b/tests/mmg_api_coverage_test.py
@@ -1,0 +1,66 @@
+"""Tests for deterministic MMG public API coverage auditing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_mmg_api_coverage import (
+    build_audits,
+    extract_public_parameters,
+    extract_public_symbols,
+    find_mmg_source,
+    read_mmg_source_version,
+    read_pinned_mmg_version,
+    validate_parameter_coverage,
+    validate_summary,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_extract_public_symbols_includes_functions_and_function_pointers(
+    tmp_path: Path,
+) -> None:
+    """Public declarations are found without counting macros and comments."""
+    header = tmp_path / "libmmg3d.h"
+    header.write_text(
+        """
+        /* MMG3D_Fake_comment(); */
+        #define MMG3D_CALL(x) x
+        LIBMMG3D_EXPORT int MMG3D_Do_work(int value);
+        LIBMMG3D_EXPORT extern int (*MMG3D_callback)(double value);
+        typedef int (*MMG3D_CallbackType)(int value);
+        enum MMG3D_Param { MMG3D_IPARAM_example, MMG3D_DPARAM_example };
+        """,
+        encoding="utf-8",
+    )
+
+    assert extract_public_symbols(header, "MMG3D") == {
+        "MMG3D_Do_work",
+        "MMG3D_callback",
+    }
+    assert extract_public_parameters(header, "MMG3D") == {
+        "MMG3D_DPARAM_example",
+        "MMG3D_IPARAM_example",
+    }
+
+
+def test_checked_in_coverage_matches_pinned_mmg_headers() -> None:
+    """Every pinned public MMG callable has one current classification."""
+    mmg_source = find_mmg_source(_REPO_ROOT)
+    assert read_mmg_source_version(mmg_source) == read_pinned_mmg_version(_REPO_ROOT)
+    document = (_REPO_ROOT / "docs" / "reference" / "mmg-api-coverage.md").read_text(
+        encoding="utf-8"
+    )
+    audits = build_audits(
+        mmg_source=mmg_source,
+        bindings_dir=_REPO_ROOT / "src" / "bindings",
+        document=document,
+    )
+
+    errors = [f"{audit.library}: {error}" for audit in audits for error in audit.errors]
+    errors.extend(validate_summary(document, audits))
+    errors.extend(
+        validate_parameter_coverage(mmg_source, _REPO_ROOT / "src" / "bindings")
+    )
+    assert not errors, "\n".join(errors)


### PR DESCRIPTION
## Summary

- add a deterministic audit of every public callable and parameter enum in the pinned MMG headers
- classify the complete MMG3D/MMG2D/MMGS C API and fail CI-style tests on header, binding, or summary drift
- bind the seven remaining direct candidates: MMG3D/MMGS integer getters, all three input-parameter filename setters, and the MMG3D/MMG2D TetGen writers
- parse parameter files before in-memory MMG3D/MMG2D remeshing, with explicit documentation of MMGS's upstream parser limitation
- document the remaining behavioral-parity work and link issues #372, #373, #374, and #375

## Coverage result

| Library | Bound | Indirect | Candidate | Excluded | Skipped | Functional |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| MMG3D | 73 | 48 | 0 | 18 | 1 | 86% |
| MMG2D | 62 | 41 | 0 | 15 | 1 | 87% |
| MMGS | 61 | 37 | 0 | 11 | 0 | 90% |

All 101 public parameter enums are accounted for: 97 are mapped directly and four have intentional portable alternatives.

## Validation

- native extension builds successfully on Windows
- deterministic API audit passes
- scoped Ruff formatting/lint and stub type checking pass
- native/API regression suite: 88 passed, 21 skipped
- full suite: 1120 passed, 38 skipped; 49 existing Windows/PyVista image-baseline and file-I/O integration failures remain outside these binding changes