### PR TITLE
Add first-class boundary-only level-set splitting

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -224,22 +224,18 @@ jobs:
           path: wheelhouse/
       - name: Create venv and install the freshly built wheel
         run: |
-          uv venv .venv
-          # Let uv pick the matching wheel for the venv's Python from
-          # wheelhouse/. We deliberately do NOT `uv sync` here, which would
-          # build mmgpy from source and shadow the wheel under test.
-          # --find-links makes the local wheel win for mmgpy; PyPI is still
-          # used for transitive deps (numpy, pyvista, ...).
-          # mmgpy[pyvista] because the docs codeblocks and examples this
-          # gate validates use pyvista; the slim mmgpy core no longer
-          # pulls pyvista (and therefore Pillow), which crashed
-          # pytest-pyvista's plugin import at module load time.
-          uv pip install --python .venv/bin/python --find-links wheelhouse 'mmgpy[pyvista]'
+          uv venv --python 3.10 .venv
+          shopt -s nullglob
+          wheels=(wheelhouse/mmgpy-*-cp310-cp310-manylinux*.whl)
+          test "${#wheels[@]}" -eq 1
+          # Install the artifact by path so PyPI can never satisfy the mmgpy
+          # requirement. PyPI remains available for runtime dependencies.
+          uv pip install --python .venv/bin/python "${wheels[0]}" 'pyvista>=0.48,<1'
           # fedoo is needed for the elasticity_propagation example.
           uv pip install --python .venv/bin/python pytest pytest-examples pytest-pyvista fedoo
       - name: Verify the installed mmgpy is the wheel
         run: |
-          .venv/bin/python -c "import mmgpy; print(mmgpy.__version__, mmgpy.__file__); assert 'site-packages' in mmgpy.__file__"
+          .venv/bin/python -c "import mmgpy; from mmgpy._mmgpy import MmgMesh3D; print(mmgpy.__version__, mmgpy.__file__); assert 'site-packages' in mmgpy.__file__; assert 'surface_only' in MmgMesh3D.remesh_levelset.__doc__"
       - name: Test documentation code blocks
         env:
           PYVISTA_OFF_SCREEN: "true"

--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -725,9 +725,6 @@ Some differences do not correspond to a missing C callable:
   private, unlike MMG3D and MMG2D. The filename setter is bound, but in-memory MMGS parsing
   needs an upstream API change ([#373](https://github.com/kmarchais/mmgpy/issues/373)).
 
-- Boundary-only level-set splitting is already reachable through the mapped `isosurf`
-  parameter, but lacks a first-class convenience API
-  ([#372](https://github.com/kmarchais/mmgpy/issues/372)).
 - Mixed tetrahedron/prism meshes are supported by the low-level MMG3D bindings, but the
   PyVista conversion path does not currently round-trip VTK wedge cells.
 - Native `MMG3D_mmg3dmov` and `MMG2D_mmg2dmov` are skipped because ELAS is not available

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -125,6 +125,28 @@ remeshed = mesh.mmg.remesh(ar=30)
 
 ## Control Flags
 
+### surface_only
+
+Restrict level-set discretization to the mesh boundary. This keyword is available only
+on `remesh_levelset(...)`.
+
+| Property    | Value                                |
+| ----------- | ------------------------------------ |
+| Type        | `bool`                               |
+| Default     | `False`                              |
+| MMG mapping | `-lssurf`; `MMG*_IPARAM_isosurf = 1` |
+
+<!-- mmgpy-test:skip -->
+
+```python
+boundary_split = mesh.mmg.remesh_levelset(levelset, surface_only=True)
+```
+
+For MMG3D this splits boundary faces without splitting the interior volume into
+level-set regions. MMG2D and MMGS apply the mode to boundary or referenced edges.
+
+---
+
 ### optim
 
 Enable optimization mode (no topology changes).

--- a/docs/tutorials/levelset-extraction.md
+++ b/docs/tutorials/levelset-extraction.md
@@ -173,6 +173,21 @@ MMG requires the relevant boundary entities and references to be present where t
 selected engine uses them; for example, an MMGS mesh needs explicit referenced boundary
 edges.
 
+For MMG3D, the returned `UnstructuredGrid` contains both tetrahedra and the
+referenced boundary triangles. Select a boundary patch through its cell type and
+reference:
+
+<!-- mmgpy-test:skip -->
+
+```python
+import pyvista as pv
+
+is_patch = (boundary_split.celltypes == pv.CellType.TRIANGLE) & (
+    boundary_split.cell_data["refs"] == 3
+)
+patch = boundary_split.extract_cells(is_patch)
+```
+
 ## Controlling Output Quality
 
 Combine level-set extraction with size parameters:

--- a/docs/tutorials/levelset-extraction.md
+++ b/docs/tutorials/levelset-extraction.md
@@ -153,6 +153,26 @@ levelset = vertices[:, 2].reshape(-1, 1)
 discretized = mesh.mmg.remesh_levelset(levelset)
 ```
 
+## Boundary-Only Level-Set Splitting
+
+Set `surface_only=True` to discretize the level set only on the mesh boundary while
+leaving the interior regions unsplit:
+
+<!-- mmgpy-test:skip -->
+
+```python
+boundary_split = mesh.mmg.remesh_levelset(levelset, surface_only=True)
+```
+
+This is MMG's `-lssurf` mode (`*_IPARAM_isosurf`). In 3D it splits boundary faces
+without creating an interior material interface. In 2D and on surface meshes it splits
+the applicable boundary or referenced edges. The default, `surface_only=False`, keeps
+MMG's standard full-domain level-set behavior.
+
+MMG requires the relevant boundary entities and references to be present where the
+selected engine uses them; for example, an MMGS mesh needs explicit referenced boundary
+edges.
+
 ## Controlling Output Quality
 
 Combine level-set extraction with size parameters:

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -28,7 +28,8 @@ import pyvista as pv
 
 import mmgpy  # noqa: F401  -- registers the .mmg accessor
 
-ISOVALUE_X = 0.37
+LEVELSET_CENTER = np.array([0.5, -0.15, 0.5])
+LEVELSET_RADIUS = 0.45
 
 
 def background_mesh(resolution: int = 6) -> pv.UnstructuredGrid:
@@ -47,20 +48,52 @@ def volume_refs(mesh: pv.UnstructuredGrid) -> np.ndarray:
     return np.asarray(mesh.cell_data["refs"])[tetrahedra]
 
 
+def sphere_levelset(points: np.ndarray) -> np.ndarray:
+    """Signed distance from a sphere that intersects the cube's front face."""
+    return np.linalg.norm(points - LEVELSET_CENTER, axis=1) - LEVELSET_RADIUS
+
+
+def boundary_patch_curve(surface: pv.PolyData) -> pv.PolyData:
+    """Extract mesh edges separating the two level-set patches."""
+    faces = surface.regular_faces
+    centers = surface.points[faces].mean(axis=1)
+    negative = sphere_levelset(centers) < 0.0
+    edge_sides: dict[tuple[int, int], bool] = {}
+    curve_edges: list[tuple[int, int]] = []
+
+    for triangle, side in zip(faces, negative, strict=True):
+        for start, end in (
+            (triangle[0], triangle[1]),
+            (triangle[1], triangle[2]),
+            (triangle[2], triangle[0]),
+        ):
+            edge = tuple(sorted((int(start), int(end))))
+            previous_side = edge_sides.get(edge)
+            if previous_side is not None and previous_side != side:
+                curve_edges.append(edge)
+            else:
+                edge_sides[edge] = bool(side)
+
+    lines = np.column_stack(
+        (np.full(len(curve_edges), 2), np.asarray(curve_edges)),
+    ).ravel()
+    return pv.PolyData(surface.points, lines=lines)
+
+
 def main() -> None:
-    """Remesh a plane in both level-set modes and compare the results."""
-    background = background_mesh()
-    levelset = (background.points[:, 0] - ISOVALUE_X).reshape(-1, 1)
+    """Remesh a curved level set in both modes and compare the results."""
+    background = background_mesh(resolution=7)
+    levelset = sphere_levelset(background.points).reshape(-1, 1)
 
     full = background.mmg.remesh_levelset(
         levelset,
-        hmax=0.2,
+        hmax=0.15,
         verbose=False,
     )
     boundary = background.mmg.remesh_levelset(
         levelset,
         surface_only=True,
-        hmax=0.2,
+        hmax=0.15,
         verbose=False,
     )
 
@@ -83,16 +116,11 @@ def main() -> None:
     positive_region = full.extract_cells(
         np.flatnonzero(full_cell_refs == 2),
     ).extract_surface(algorithm="dataset_surface")
-    negative_region.translate((-0.1, 0.0, 0.0), inplace=True)
-    positive_region.translate((0.1, 0.0, 0.0), inplace=True)
+    negative_region.translate((-0.18, -0.2, 0.0), inplace=True)
+    positive_region.translate((0.08, 0.08, 0.0), inplace=True)
 
     surface = boundary.extract_surface(algorithm="dataset_surface")
-    surface_edges = surface.extract_all_edges()
-    edge_vertices = surface_edges.lines.reshape(-1, 3)[:, 1:]
-    edge_x = surface_edges.points[edge_vertices, 0]
-    boundary_trace = surface_edges.extract_cells(
-        np.flatnonzero(np.all(np.isclose(edge_x, ISOVALUE_X), axis=1)),
-    )
+    boundary_trace = boundary_patch_curve(surface)
 
     plotter = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
 
@@ -108,11 +136,12 @@ def main() -> None:
         show_edges=False,
     )
     plotter.add_point_labels(
-        np.array([[0.08, -0.01, 0.5], [0.78, -0.01, 0.5]]),
-        ["ref 3", "ref 2"],
-        font_size=20,
+        np.array([[0.32, -0.21, 0.5], [0.8, 0.07, 0.75]]),
+        ["ref 3\n(curved cap)", "ref 2\n(main volume)"],
+        font_size=17,
         shape=None,
         show_points=False,
+        always_visible=True,
     )
     plotter.add_title("DEFAULT: SPLITS THE VOLUME", font_size=10)
     plotter.add_text(
@@ -139,6 +168,7 @@ def main() -> None:
         font_size=20,
         shape=None,
         show_points=False,
+        always_visible=True,
     )
     plotter.add_title("surface_only=True: SPLITS ONLY THE SURFACE", font_size=10)
     plotter.add_text(

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -80,49 +80,60 @@ def main() -> None:
 
     plotter.subplot(0, 0)
     full_cell_refs = np.asarray(full.cell_data["refs"])
-    exterior = full.extract_cells(np.flatnonzero(full_cell_refs == 2)).extract_surface(
-        algorithm="dataset_surface",
-    )
-    interior = full.extract_cells(np.flatnonzero(full_cell_refs == 3)).extract_surface(
-        algorithm="dataset_surface",
+    full_surface = full.extract_surface(algorithm="dataset_surface")
+    negative_region_surface = full.extract_cells(
+        np.flatnonzero(full_cell_refs == 3),
+    ).extract_surface(algorithm="dataset_surface")
+    interface_centers = negative_region_surface.cell_centers().points
+    interface = negative_region_surface.extract_cells(
+        np.flatnonzero(np.isclose(interface_centers[:, 0], ISOVALUE_X)),
     )
     plotter.add_mesh(
-        exterior,
-        color="steelblue",
-        opacity=0.25,
+        full_surface,
+        color="lightgray",
+        opacity=0.18,
         show_edges=True,
-        edge_color="black",
-        line_width=0.35,
+        edge_color="gray",
+        line_width=0.3,
     )
     plotter.add_mesh(
-        interior,
+        interface,
         color="coral",
-        opacity=0.8,
+        opacity=1.0,
         show_edges=True,
         edge_color="darkred",
-        line_width=0.5,
+        line_width=1.5,
     )
-    plotter.add_title("Default: interior split\nvolume refs 2 and 3", font_size=10)
+    plotter.add_title("Default\ninterface crosses the volume", font_size=10)
+    plotter.add_text("tetrahedron refs: {2, 3}", position="lower_left", font_size=9)
 
     plotter.subplot(0, 1)
     surface = boundary.extract_surface(algorithm="dataset_surface")
-    surface["level-set side"] = (
-        surface.cell_centers().points[:, 0] >= ISOVALUE_X
-    ).astype(np.int8)
+    surface_edges = surface.extract_all_edges()
+    edge_vertices = surface_edges.lines.reshape(-1, 3)[:, 1:]
+    edge_x = surface_edges.points[edge_vertices, 0]
+    boundary_trace = surface_edges.extract_cells(
+        np.flatnonzero(np.all(np.isclose(edge_x, ISOVALUE_X), axis=1)),
+    )
     plotter.add_mesh(
         surface,
-        scalars="level-set side",
-        categories=True,
-        cmap=["steelblue", "coral"],
+        color="lightgray",
+        opacity=0.45,
         show_edges=True,
-        edge_color="black",
-        line_width=0.5,
-        show_scalar_bar=False,
+        edge_color="gray",
+        line_width=0.3,
+    )
+    plotter.add_mesh(
+        boundary_trace,
+        color="coral",
+        line_width=8,
+        render_lines_as_tubes=True,
     )
     plotter.add_title(
-        "surface_only=True: boundary split\nsingle volume ref 0",
+        "surface_only=True\nintersection stays on boundary",
         font_size=10,
     )
+    plotter.add_text("tetrahedron refs: {0}", position="lower_left", font_size=9)
 
     plotter.link_views()
     plotter.camera_position = [(2.4, 2.0, 1.7), (0.5, 0.5, 0.5), (0, 0, 1)]

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -77,21 +77,14 @@ def main() -> None:
         raise RuntimeError(msg)
 
     full_cell_refs = np.asarray(full.cell_data["refs"])
-    negative_region_surface = full.extract_cells(
+    negative_region = full.extract_cells(
         np.flatnonzero(full_cell_refs == 3),
     ).extract_surface(algorithm="dataset_surface")
-    interface_centers = negative_region_surface.cell_centers().points
-    interface = negative_region_surface.extract_cells(
-        np.flatnonzero(np.isclose(interface_centers[:, 0], ISOVALUE_X)),
-    )
-    full_slice = full.slice(normal=(0, 1, 0), origin=(0.5, 0.5, 0.5))
-    full_cross_section = full_slice.extract_cells(
-        np.arange(full_slice.n_verts + full_slice.n_lines, full_slice.n_cells),
-    )
-    interface_line = interface.slice(
-        normal=(0, 1, 0),
-        origin=(0.5, 0.5, 0.5),
-    )
+    positive_region = full.extract_cells(
+        np.flatnonzero(full_cell_refs == 2),
+    ).extract_surface(algorithm="dataset_surface")
+    negative_region.translate((-0.1, 0.0, 0.0), inplace=True)
+    positive_region.translate((0.1, 0.0, 0.0), inplace=True)
 
     surface = boundary.extract_surface(algorithm="dataset_surface")
     surface_edges = surface.extract_all_edges()
@@ -100,85 +93,64 @@ def main() -> None:
     boundary_trace = surface_edges.extract_cells(
         np.flatnonzero(np.all(np.isclose(edge_x, ISOVALUE_X), axis=1)),
     )
-    boundary_slice = boundary.slice(normal=(0, 1, 0), origin=(0.5, 0.5, 0.5))
-    boundary_cross_section = boundary_slice.extract_cells(
-        np.arange(
-            boundary_slice.n_verts + boundary_slice.n_lines,
-            boundary_slice.n_cells,
-        ),
-    )
-    boundary_hits = boundary_trace.slice(
-        normal=(0, 1, 0),
-        origin=(0.5, 0.5, 0.5),
-    )
 
     plotter = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
 
     plotter.subplot(0, 0)
     plotter.add_mesh(
-        full_cross_section,
-        scalars="refs",
-        categories=True,
-        clim=(2, 3),
-        cmap=["steelblue", "coral"],
-        show_edges=True,
-        edge_color="white",
-        line_width=0.3,
-        show_scalar_bar=False,
+        negative_region,
+        color="coral",
+        show_edges=False,
     )
     plotter.add_mesh(
-        interface_line,
-        color="black",
-        line_width=7,
-        render_lines_as_tubes=True,
+        positive_region,
+        color="steelblue",
+        show_edges=False,
     )
     plotter.add_point_labels(
-        np.array([[0.18, 0.5, 0.5], [0.72, 0.5, 0.5]]),
-        ["volume ref 3", "volume ref 2"],
-        font_size=18,
-        point_size=0,
+        np.array([[0.08, -0.01, 0.5], [0.78, -0.01, 0.5]]),
+        ["ref 3", "ref 2"],
+        font_size=20,
         shape=None,
         show_points=False,
     )
-    plotter.add_title("DEFAULT: VOLUME SPLIT", font_size=12)
+    plotter.add_title("DEFAULT: SPLITS THE VOLUME", font_size=10)
     plotter.add_text(
-        "black line = interface inside the volume",
-        position="lower_left",
+        "Tetrahedra become TWO material regions",
+        position=(20, 30),
         font_size=10,
     )
 
     plotter.subplot(0, 1)
     plotter.add_mesh(
-        boundary_cross_section,
+        surface,
         color="lightgray",
-        show_edges=True,
-        edge_color="white",
-        line_width=0.3,
+        show_edges=False,
     )
     plotter.add_mesh(
-        boundary_hits,
+        boundary_trace,
         color="coral",
-        point_size=24,
-        render_points_as_spheres=True,
+        line_width=10,
+        render_lines_as_tubes=True,
     )
     plotter.add_point_labels(
-        np.array([[0.5, 0.5, 0.5]]),
-        ["one volume: ref 0\nNO interior interface"],
-        font_size=18,
-        point_size=0,
+        np.array([[0.65, -0.01, 0.5]]),
+        ["ref 0\n(one volume)"],
+        font_size=20,
         shape=None,
         show_points=False,
     )
-    plotter.add_title("surface_only=True: BOUNDARY ONLY", font_size=12)
+    plotter.add_title("surface_only=True: SPLITS ONLY THE SURFACE", font_size=10)
     plotter.add_text(
-        "orange points = boundary intersections",
-        position="lower_left",
+        "All tetrahedra stay ONE material; orange curve is on the skin",
+        position=(20, 30),
         font_size=10,
     )
 
     plotter.link_views()
-    plotter.camera_position = [(0.5, -3.0, 0.5), (0.5, 0.5, 0.5), (0, 0, 1)]
+    plotter.camera_position = [(1.3, -3.0, 1.8), (0.5, 0.5, 0.5), (0, 0, 1)]
     plotter.enable_parallel_projection()
+    plotter.camera.parallel_scale = 0.85
     plotter.show()
 
 

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -93,66 +93,59 @@ def main() -> None:
         raise RuntimeError(msg)
 
     full_tetrahedra = full.extract_cells(full.celltypes == pv.CellType.TETRA)
-    tetra_centers = full_tetrahedra.cell_centers().points
-    cutaway = full_tetrahedra.extract_cells(tetra_centers[:, 1] >= 0.5)
-    cutaway_ref2 = cutaway.extract_cells(cutaway["refs"] == 2)
-    cutaway_ref3 = cutaway.extract_cells(cutaway["refs"] == 3)
+    cutaway = full_tetrahedra.clip(
+        normal=(0.0, 1.0, 0.0),
+        origin=(0.5, 0.5, 0.5),
+        invert=False,
+    )
 
     boundary_tetrahedra = boundary.extract_cells(
         boundary.celltypes == pv.CellType.TETRA
     )
-    boundary_tetra_centers = boundary_tetrahedra.cell_centers().points
-    boundary_cutaway = boundary_tetrahedra.extract_cells(
-        boundary_tetra_centers[:, 1] >= 0.5
+    boundary_cutaway = boundary_tetrahedra.clip(
+        normal=(0.0, 1.0, 0.0),
+        origin=(0.5, 0.5, 0.5),
+        invert=False,
     )
 
     boundary_patches = boundary.extract_cells(boundary_triangle_mask)
-    patch_centers = boundary_patches.cell_centers().points
-    boundary_patch_cutaway = boundary_patches.extract_cells(patch_centers[:, 1] >= 0.5)
+    boundary_patch_cutaway = boundary_patches.clip(
+        normal=(0.0, 1.0, 0.0),
+        origin=(0.5, 0.5, 0.5),
+        invert=False,
+    )
 
-    plotter = pv.Plotter(shape=(1, 3), window_size=(1800, 650))
+    plotter = pv.Plotter(shape=(1, 2), window_size=(1500, 700))
     plotter.set_background("#eeeeee")
 
     plotter.subplot(0, 0)
     plotter.add_mesh(
-        cutaway_ref2,
-        color="steelblue",
-        opacity=0.92,
+        cutaway,
+        scalars="refs",
+        categories=True,
+        clim=(2, 3),
+        cmap=["steelblue", "coral"],
+        opacity=1.0,
         show_edges=True,
-        edge_color="#244963",
+        edge_color="#dddddd",
         line_width=0.2,
+        show_scalar_bar=False,
     )
-    plotter.add_title("DEFAULT: VOLUME 1 OF 2 (REF 2)", font_size=9)
+    plotter.add_title("DEFAULT: INTERIOR CUT HAS TWO REFS", font_size=10)
     plotter.add_text(
-        "Tetrahedra with volume ref 2",
+        "Cut face: blue volume ref 2 + orange volume ref 3",
         position=(20, 30),
-        font_size=9,
+        font_size=10,
     )
 
     plotter.subplot(0, 1)
     plotter.add_mesh(
-        cutaway_ref3,
-        color="coral",
-        opacity=0.92,
-        show_edges=True,
-        edge_color="#843d26",
-        line_width=0.2,
-    )
-    plotter.add_title("DEFAULT: VOLUME 2 OF 2 (REF 3)", font_size=9)
-    plotter.add_text(
-        "Tetrahedra with volume ref 3",
-        position=(20, 30),
-        font_size=9,
-    )
-
-    plotter.subplot(0, 2)
-    plotter.add_mesh(
         boundary_cutaway,
         color="white",
-        opacity=0.58,
+        opacity=1.0,
         show_edges=True,
         edge_color="gray",
-        line_width=0.3,
+        line_width=0.2,
     )
     plotter.add_mesh(
         boundary_patch_cutaway,
@@ -160,15 +153,15 @@ def main() -> None:
         categories=True,
         clim=(2, 3),
         cmap=["steelblue", "coral"],
-        opacity=0.88,
+        opacity=1.0,
         show_edges=False,
         show_scalar_bar=False,
     )
-    plotter.add_title("surface_only=True: SINGLE VOLUME (REF 0)", font_size=9)
+    plotter.add_title("surface_only=True: INTERIOR CUT STAYS REF 0", font_size=10)
     plotter.add_text(
-        "Colors are boundary triangles, not volumes",
+        "Neutral cut face = one volume; colors exist only on outer walls",
         position=(20, 30),
-        font_size=9,
+        font_size=10,
     )
 
     plotter.link_views()

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -55,6 +55,35 @@ def gyroid_levelset(points: np.ndarray) -> np.ndarray:
     return np.sin(x) * np.cos(y) + np.sin(y) * np.cos(z) + np.sin(z) * np.cos(x) - 0.15
 
 
+def explode_boundary_faces(
+    patches: pv.UnstructuredGrid,
+    distance: float = 0.12,
+) -> list[pv.UnstructuredGrid]:
+    """Move each cube-boundary face outward to expose it as a surface layer."""
+    centers = patches.cell_centers().points
+    face_specs = (
+        (0, 0.0, (-distance, 0.0, 0.0)),
+        (0, 1.0, (distance, 0.0, 0.0)),
+        (1, 0.0, (0.0, -distance, 0.0)),
+        (1, 1.0, (0.0, distance, 0.0)),
+        (2, 0.0, (0.0, 0.0, -distance)),
+        (2, 1.0, (0.0, 0.0, distance)),
+    )
+    exploded = []
+    assigned = np.zeros(patches.n_cells, dtype=bool)
+    for axis, coordinate, offset in face_specs:
+        on_face = np.isclose(centers[:, axis], coordinate)
+        assigned |= on_face
+        face = patches.extract_cells(on_face)
+        face.translate(offset, inplace=True)
+        exploded.append(face)
+
+    if not assigned.all():
+        msg = "some boundary triangles are not on a cube face"
+        raise RuntimeError(msg)
+    return exploded
+
+
 def main() -> None:
     """Remesh a curved level set in both modes and compare the results."""
     background = background_mesh(resolution=10)
@@ -101,14 +130,8 @@ def main() -> None:
     boundary_tetrahedra = boundary.extract_cells(
         boundary.celltypes == pv.CellType.TETRA
     )
-    boundary_tetra_centers = boundary_tetrahedra.cell_centers().points
-    boundary_cutaway = boundary_tetrahedra.extract_cells(
-        boundary_tetra_centers[:, 1] >= 0.5
-    )
-
     boundary_patches = boundary.extract_cells(boundary_triangle_mask)
-    patch_centers = boundary_patches.cell_centers().points
-    boundary_patch_cutaway = boundary_patches.extract_cells(patch_centers[:, 1] >= 0.5)
+    exploded_patches = explode_boundary_faces(boundary_patches)
 
     plotter = pv.Plotter(shape=(1, 3), window_size=(1800, 650))
     plotter.set_background("#eeeeee")
@@ -147,26 +170,27 @@ def main() -> None:
 
     plotter.subplot(0, 2)
     plotter.add_mesh(
-        boundary_cutaway,
-        color="white",
-        opacity=0.58,
+        boundary_tetrahedra,
+        color="gainsboro",
+        opacity=1.0,
         show_edges=True,
         edge_color="gray",
-        line_width=0.3,
+        line_width=0.2,
     )
-    plotter.add_mesh(
-        boundary_patch_cutaway,
-        scalars="refs",
-        categories=True,
-        clim=(2, 3),
-        cmap=["steelblue", "coral"],
-        opacity=0.88,
-        show_edges=False,
-        show_scalar_bar=False,
-    )
-    plotter.add_title("surface_only=True: SINGLE VOLUME (REF 0)", font_size=9)
+    for face in exploded_patches:
+        plotter.add_mesh(
+            face,
+            scalars="refs",
+            categories=True,
+            clim=(2, 3),
+            cmap=["steelblue", "coral"],
+            opacity=1.0,
+            show_edges=False,
+            show_scalar_bar=False,
+        )
+    plotter.add_title("surface_only=True: EXPLODED BOUNDARY SKIN", font_size=9)
     plotter.add_text(
-        "Colors are boundary triangles, not volumes",
+        "Colored faces pulled away from the single neutral volume (ref 0)",
         position=(20, 30),
         font_size=9,
     )

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -16,6 +16,10 @@ different references to tetrahedra on either side. Passing
 ``surface_only=True`` selects MMG's ``-lssurf`` mode instead: boundary faces
 conform to the isovalue, but the interior volume is not split into materials.
 
+The gyroid-like level set used here makes the distinction visible: standard
+level-set remeshing creates a winding interface throughout the cube, whereas
+boundary-only mode keeps only its contour network on the cube's outer faces.
+
 Run with::
 
     uv run python examples/mmg3d/boundary_levelset.py
@@ -27,9 +31,6 @@ import numpy as np
 import pyvista as pv
 
 import mmgpy  # noqa: F401  -- registers the .mmg accessor
-
-LEVELSET_CENTER = np.array([0.5, -0.15, 0.5])
-LEVELSET_RADIUS = 0.45
 
 
 def background_mesh(resolution: int = 6) -> pv.UnstructuredGrid:
@@ -48,16 +49,17 @@ def volume_refs(mesh: pv.UnstructuredGrid) -> np.ndarray:
     return np.asarray(mesh.cell_data["refs"])[tetrahedra]
 
 
-def sphere_levelset(points: np.ndarray) -> np.ndarray:
-    """Signed distance from a sphere that intersects the cube's front face."""
-    return np.linalg.norm(points - LEVELSET_CENTER, axis=1) - LEVELSET_RADIUS
+def gyroid_levelset(points: np.ndarray) -> np.ndarray:
+    """Evaluate a winding gyroid-like level set over the unit cube."""
+    x, y, z = (2.0 * np.pi * points).T
+    return np.sin(x) * np.cos(y) + np.sin(y) * np.cos(z) + np.sin(z) * np.cos(x) - 0.15
 
 
 def boundary_patch_curve(surface: pv.PolyData) -> pv.PolyData:
     """Extract mesh edges separating the two level-set patches."""
     faces = surface.regular_faces
     centers = surface.points[faces].mean(axis=1)
-    negative = sphere_levelset(centers) < 0.0
+    negative = gyroid_levelset(centers) < 0.0
     edge_sides: dict[tuple[int, int], bool] = {}
     curve_edges: list[tuple[int, int]] = []
 
@@ -82,18 +84,18 @@ def boundary_patch_curve(surface: pv.PolyData) -> pv.PolyData:
 
 def main() -> None:
     """Remesh a curved level set in both modes and compare the results."""
-    background = background_mesh(resolution=7)
-    levelset = sphere_levelset(background.points).reshape(-1, 1)
+    background = background_mesh(resolution=10)
+    levelset = gyroid_levelset(background.points).reshape(-1, 1)
 
     full = background.mmg.remesh_levelset(
         levelset,
-        hmax=0.15,
+        hmax=0.1,
         verbose=False,
     )
     boundary = background.mmg.remesh_levelset(
         levelset,
         surface_only=True,
-        hmax=0.15,
+        hmax=0.1,
         verbose=False,
     )
 
@@ -110,14 +112,18 @@ def main() -> None:
         raise RuntimeError(msg)
 
     full_cell_refs = np.asarray(full.cell_data["refs"])
-    negative_region = full.extract_cells(
+    negative_region_surface = full.extract_cells(
         np.flatnonzero(full_cell_refs == 3),
     ).extract_surface(algorithm="dataset_surface")
-    positive_region = full.extract_cells(
-        np.flatnonzero(full_cell_refs == 2),
-    ).extract_surface(algorithm="dataset_surface")
-    negative_region.translate((-0.18, -0.2, 0.0), inplace=True)
-    positive_region.translate((0.08, 0.08, 0.0), inplace=True)
+    interface_centers = negative_region_surface.cell_centers().points
+    on_cube_boundary = np.any(
+        np.isclose(interface_centers, 0.0) | np.isclose(interface_centers, 1.0),
+        axis=1,
+    )
+    internal_interface = negative_region_surface.extract_cells(
+        np.flatnonzero(~on_cube_boundary),
+    )
+    full_surface = full.extract_surface(algorithm="dataset_surface")
 
     surface = boundary.extract_surface(algorithm="dataset_surface")
     boundary_trace = boundary_patch_curve(surface)
@@ -126,26 +132,20 @@ def main() -> None:
 
     plotter.subplot(0, 0)
     plotter.add_mesh(
-        negative_region,
-        color="coral",
+        full_surface,
+        color="lightgray",
+        opacity=0.12,
         show_edges=False,
     )
     plotter.add_mesh(
-        positive_region,
-        color="steelblue",
+        internal_interface,
+        color="coral",
+        opacity=0.95,
         show_edges=False,
     )
-    plotter.add_point_labels(
-        np.array([[0.32, -0.21, 0.5], [0.8, 0.07, 0.75]]),
-        ["ref 3\n(curved cap)", "ref 2\n(main volume)"],
-        font_size=17,
-        shape=None,
-        show_points=False,
-        always_visible=True,
-    )
-    plotter.add_title("DEFAULT: SPLITS THE VOLUME", font_size=10)
+    plotter.add_title("DEFAULT: INTERNAL LEVEL-SET SHEET", font_size=10)
     plotter.add_text(
-        "Tetrahedra become TWO material regions",
+        "Volume tetrahedra split into refs 2 and 3",
         position=(20, 30),
         font_size=10,
     )
@@ -162,25 +162,15 @@ def main() -> None:
         line_width=10,
         render_lines_as_tubes=True,
     )
-    plotter.add_point_labels(
-        np.array([[0.65, -0.01, 0.5]]),
-        ["ref 0\n(one volume)"],
-        font_size=20,
-        shape=None,
-        show_points=False,
-        always_visible=True,
-    )
-    plotter.add_title("surface_only=True: SPLITS ONLY THE SURFACE", font_size=10)
+    plotter.add_title("surface_only=True: BOUNDARY CONTOURS ONLY", font_size=10)
     plotter.add_text(
-        "All tetrahedra stay ONE material; orange curve is on the skin",
+        "Same level set; every tetrahedron remains ref 0",
         position=(20, 30),
         font_size=10,
     )
 
     plotter.link_views()
-    plotter.camera_position = [(1.3, -3.0, 1.8), (0.5, 0.5, 0.5), (0, 0, 1)]
-    plotter.enable_parallel_projection()
-    plotter.camera.parallel_scale = 0.85
+    plotter.camera_position = [(2.4, -3.0, 2.0), (0.5, 0.5, 0.5), (0, 0, 1)]
     plotter.show()
 
 

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -1,0 +1,133 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "mmgpy",
+#     "numpy",
+#     "pyvista",
+# ]
+#
+# [tool.uv.sources]
+# mmgpy = { path = "../.." }
+# ///
+"""Compare full-domain and boundary-only level-set splitting.
+
+MMG3D normally discretizes a level set throughout a volume and assigns
+different references to tetrahedra on either side. Passing
+``surface_only=True`` selects MMG's ``-lssurf`` mode instead: boundary faces
+conform to the isovalue, but the interior volume is not split into materials.
+
+Run with::
+
+    uv run python examples/mmg3d/boundary_levelset.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyvista as pv
+
+import mmgpy  # noqa: F401  -- registers the .mmg accessor
+
+ISOVALUE_X = 0.37
+
+
+def background_mesh(resolution: int = 6) -> pv.UnstructuredGrid:
+    """Create a tetrahedral background mesh of the unit cube."""
+    coordinates = np.linspace(0.0, 1.0, resolution)
+    points = np.stack(
+        np.meshgrid(coordinates, coordinates, coordinates, indexing="ij"),
+        axis=-1,
+    ).reshape(-1, 3)
+    return pv.PolyData(points).delaunay_3d()
+
+
+def volume_refs(mesh: pv.UnstructuredGrid) -> np.ndarray:
+    """Return MMG references for tetrahedral cells only."""
+    tetrahedra = mesh.celltypes == pv.CellType.TETRA
+    return np.asarray(mesh.cell_data["refs"])[tetrahedra]
+
+
+def main() -> None:
+    """Remesh a plane in both level-set modes and compare the results."""
+    background = background_mesh()
+    levelset = (background.points[:, 0] - ISOVALUE_X).reshape(-1, 1)
+
+    full = background.mmg.remesh_levelset(
+        levelset,
+        hmax=0.2,
+        verbose=False,
+    )
+    boundary = background.mmg.remesh_levelset(
+        levelset,
+        surface_only=True,
+        hmax=0.2,
+        verbose=False,
+    )
+
+    full_refs = volume_refs(full)
+    boundary_refs = volume_refs(boundary)
+    print(f"Full-domain volume refs: {np.unique(full_refs).tolist()}")
+    print(f"Boundary-only volume refs: {np.unique(boundary_refs).tolist()}")
+
+    if not {2, 3}.issubset(set(full_refs)):
+        msg = "full-domain level-set remeshing did not create both material refs"
+        raise RuntimeError(msg)
+    if set(boundary_refs) != {0}:
+        msg = "boundary-only level-set remeshing unexpectedly split the volume refs"
+        raise RuntimeError(msg)
+
+    plotter = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
+
+    plotter.subplot(0, 0)
+    full_cell_refs = np.asarray(full.cell_data["refs"])
+    exterior = full.extract_cells(np.flatnonzero(full_cell_refs == 2)).extract_surface(
+        algorithm="dataset_surface",
+    )
+    interior = full.extract_cells(np.flatnonzero(full_cell_refs == 3)).extract_surface(
+        algorithm="dataset_surface",
+    )
+    plotter.add_mesh(
+        exterior,
+        color="steelblue",
+        opacity=0.25,
+        show_edges=True,
+        edge_color="black",
+        line_width=0.35,
+    )
+    plotter.add_mesh(
+        interior,
+        color="coral",
+        opacity=0.8,
+        show_edges=True,
+        edge_color="darkred",
+        line_width=0.5,
+    )
+    plotter.add_title("Default: interior split\nvolume refs 2 and 3", font_size=10)
+
+    plotter.subplot(0, 1)
+    surface = boundary.extract_surface(algorithm="dataset_surface")
+    surface["level-set side"] = (
+        surface.cell_centers().points[:, 0] >= ISOVALUE_X
+    ).astype(np.int8)
+    plotter.add_mesh(
+        surface,
+        scalars="level-set side",
+        categories=True,
+        cmap=["steelblue", "coral"],
+        show_edges=True,
+        edge_color="black",
+        line_width=0.5,
+        show_scalar_bar=False,
+    )
+    plotter.add_title(
+        "surface_only=True: boundary split\nsingle volume ref 0",
+        font_size=10,
+    )
+
+    plotter.link_views()
+    plotter.camera_position = [(2.4, 2.0, 1.7), (0.5, 0.5, 0.5), (0, 0, 1)]
+    plotter.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -110,34 +110,46 @@ def main() -> None:
     patch_centers = boundary_patches.cell_centers().points
     boundary_patch_cutaway = boundary_patches.extract_cells(patch_centers[:, 1] >= 0.5)
 
-    plotter = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
+    plotter = pv.Plotter(shape=(1, 3), window_size=(1800, 650))
     plotter.set_background("#eeeeee")
 
     plotter.subplot(0, 0)
     plotter.add_mesh(
         cutaway_ref2,
         color="steelblue",
-        opacity=0.68,
-        show_edges=False,
+        opacity=0.92,
+        show_edges=True,
+        edge_color="#244963",
+        line_width=0.2,
     )
-    plotter.add_mesh(
-        cutaway_ref3,
-        color="coral",
-        opacity=0.68,
-        show_edges=False,
-    )
-    plotter.add_title("DEFAULT: TWO VOLUME REGIONS", font_size=10)
+    plotter.add_title("DEFAULT: VOLUME 1 OF 2 (REF 2)", font_size=9)
     plotter.add_text(
-        "Front half removed; colored tetrahedra have refs 2 and 3",
+        "Tetrahedra with volume ref 2",
         position=(20, 30),
-        font_size=10,
+        font_size=9,
     )
 
     plotter.subplot(0, 1)
     plotter.add_mesh(
+        cutaway_ref3,
+        color="coral",
+        opacity=0.92,
+        show_edges=True,
+        edge_color="#843d26",
+        line_width=0.2,
+    )
+    plotter.add_title("DEFAULT: VOLUME 2 OF 2 (REF 3)", font_size=9)
+    plotter.add_text(
+        "Tetrahedra with volume ref 3",
+        position=(20, 30),
+        font_size=9,
+    )
+
+    plotter.subplot(0, 2)
+    plotter.add_mesh(
         boundary_cutaway,
         color="white",
-        opacity=0.38,
+        opacity=0.58,
         show_edges=True,
         edge_color="gray",
         line_width=0.3,
@@ -148,15 +160,15 @@ def main() -> None:
         categories=True,
         clim=(2, 3),
         cmap=["steelblue", "coral"],
-        opacity=0.76,
+        opacity=0.88,
         show_edges=False,
         show_scalar_bar=False,
     )
-    plotter.add_title("surface_only=True: BOUNDARY PATCHES ONLY", font_size=10)
+    plotter.add_title("surface_only=True: SINGLE VOLUME (REF 0)", font_size=9)
     plotter.add_text(
-        "Same cutaway: colored boundary patches, white volume (ref 0)",
+        "Colors are boundary triangles, not volumes",
         position=(20, 30),
-        font_size=10,
+        font_size=9,
     )
 
     plotter.link_views()

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -55,33 +55,6 @@ def gyroid_levelset(points: np.ndarray) -> np.ndarray:
     return np.sin(x) * np.cos(y) + np.sin(y) * np.cos(z) + np.sin(z) * np.cos(x) - 0.15
 
 
-def boundary_patch_curve(surface: pv.PolyData) -> pv.PolyData:
-    """Extract mesh edges separating the two level-set patches."""
-    faces = surface.regular_faces
-    centers = surface.points[faces].mean(axis=1)
-    negative = gyroid_levelset(centers) < 0.0
-    edge_sides: dict[tuple[int, int], bool] = {}
-    curve_edges: list[tuple[int, int]] = []
-
-    for triangle, side in zip(faces, negative, strict=True):
-        for start, end in (
-            (triangle[0], triangle[1]),
-            (triangle[1], triangle[2]),
-            (triangle[2], triangle[0]),
-        ):
-            edge = tuple(sorted((int(start), int(end))))
-            previous_side = edge_sides.get(edge)
-            if previous_side is not None and previous_side != side:
-                curve_edges.append(edge)
-            else:
-                edge_sides[edge] = bool(side)
-
-    lines = np.column_stack(
-        (np.full(len(curve_edges), 2), np.asarray(curve_edges)),
-    ).ravel()
-    return pv.PolyData(surface.points, lines=lines)
-
-
 def main() -> None:
     """Remesh a curved level set in both modes and compare the results."""
     background = background_mesh(resolution=10)
@@ -111,60 +84,77 @@ def main() -> None:
         msg = "boundary-only level-set remeshing unexpectedly split the volume refs"
         raise RuntimeError(msg)
 
-    full_cell_refs = np.asarray(full.cell_data["refs"])
-    negative_region_surface = full.extract_cells(
-        np.flatnonzero(full_cell_refs == 3),
-    ).extract_surface(algorithm="dataset_surface")
-    interface_centers = negative_region_surface.cell_centers().points
-    on_cube_boundary = np.any(
-        np.isclose(interface_centers, 0.0) | np.isclose(interface_centers, 1.0),
-        axis=1,
-    )
-    internal_interface = negative_region_surface.extract_cells(
-        np.flatnonzero(~on_cube_boundary),
-    )
-    full_surface = full.extract_surface(algorithm="dataset_surface")
+    boundary_triangle_mask = boundary.celltypes == pv.CellType.TRIANGLE
+    boundary_triangle_refs = np.asarray(boundary.cell_data["refs"])[
+        boundary_triangle_mask
+    ]
+    if not {2, 3}.issubset(set(boundary_triangle_refs)):
+        msg = "boundary-only remeshing did not create both surface patch refs"
+        raise RuntimeError(msg)
 
-    surface = boundary.extract_surface(algorithm="dataset_surface")
-    boundary_trace = boundary_patch_curve(surface)
+    full_tetrahedra = full.extract_cells(full.celltypes == pv.CellType.TETRA)
+    tetra_centers = full_tetrahedra.cell_centers().points
+    cutaway = full_tetrahedra.extract_cells(tetra_centers[:, 1] >= 0.5)
+    cutaway_ref2 = cutaway.extract_cells(cutaway["refs"] == 2)
+    cutaway_ref3 = cutaway.extract_cells(cutaway["refs"] == 3)
+
+    boundary_tetrahedra = boundary.extract_cells(
+        boundary.celltypes == pv.CellType.TETRA
+    )
+    boundary_tetra_centers = boundary_tetrahedra.cell_centers().points
+    boundary_cutaway = boundary_tetrahedra.extract_cells(
+        boundary_tetra_centers[:, 1] >= 0.5
+    )
+
+    boundary_patches = boundary.extract_cells(boundary_triangle_mask)
+    patch_centers = boundary_patches.cell_centers().points
+    boundary_patch_cutaway = boundary_patches.extract_cells(patch_centers[:, 1] >= 0.5)
 
     plotter = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
+    plotter.set_background("#eeeeee")
 
     plotter.subplot(0, 0)
     plotter.add_mesh(
-        full_surface,
-        color="lightgray",
-        opacity=0.12,
+        cutaway_ref2,
+        color="steelblue",
+        opacity=0.68,
         show_edges=False,
     )
     plotter.add_mesh(
-        internal_interface,
+        cutaway_ref3,
         color="coral",
-        opacity=0.95,
+        opacity=0.68,
         show_edges=False,
     )
-    plotter.add_title("DEFAULT: INTERNAL LEVEL-SET SHEET", font_size=10)
+    plotter.add_title("DEFAULT: TWO VOLUME REGIONS", font_size=10)
     plotter.add_text(
-        "Volume tetrahedra split into refs 2 and 3",
+        "Front half removed; colored tetrahedra have refs 2 and 3",
         position=(20, 30),
         font_size=10,
     )
 
     plotter.subplot(0, 1)
     plotter.add_mesh(
-        surface,
-        color="lightgray",
-        show_edges=False,
+        boundary_cutaway,
+        color="white",
+        opacity=0.38,
+        show_edges=True,
+        edge_color="gray",
+        line_width=0.3,
     )
     plotter.add_mesh(
-        boundary_trace,
-        color="coral",
-        line_width=10,
-        render_lines_as_tubes=True,
+        boundary_patch_cutaway,
+        scalars="refs",
+        categories=True,
+        clim=(2, 3),
+        cmap=["steelblue", "coral"],
+        opacity=0.76,
+        show_edges=False,
+        show_scalar_bar=False,
     )
-    plotter.add_title("surface_only=True: BOUNDARY CONTOURS ONLY", font_size=10)
+    plotter.add_title("surface_only=True: BOUNDARY PATCHES ONLY", font_size=10)
     plotter.add_text(
-        "Same level set; every tetrahedron remains ref 0",
+        "Same cutaway: colored boundary patches, white volume (ref 0)",
         position=(20, 30),
         font_size=10,
     )

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -76,11 +76,7 @@ def main() -> None:
         msg = "boundary-only level-set remeshing unexpectedly split the volume refs"
         raise RuntimeError(msg)
 
-    plotter = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
-
-    plotter.subplot(0, 0)
     full_cell_refs = np.asarray(full.cell_data["refs"])
-    full_surface = full.extract_surface(algorithm="dataset_surface")
     negative_region_surface = full.extract_cells(
         np.flatnonzero(full_cell_refs == 3),
     ).extract_surface(algorithm="dataset_surface")
@@ -88,26 +84,15 @@ def main() -> None:
     interface = negative_region_surface.extract_cells(
         np.flatnonzero(np.isclose(interface_centers[:, 0], ISOVALUE_X)),
     )
-    plotter.add_mesh(
-        full_surface,
-        color="lightgray",
-        opacity=0.18,
-        show_edges=True,
-        edge_color="gray",
-        line_width=0.3,
+    full_slice = full.slice(normal=(0, 1, 0), origin=(0.5, 0.5, 0.5))
+    full_cross_section = full_slice.extract_cells(
+        np.arange(full_slice.n_verts + full_slice.n_lines, full_slice.n_cells),
     )
-    plotter.add_mesh(
-        interface,
-        color="coral",
-        opacity=1.0,
-        show_edges=True,
-        edge_color="darkred",
-        line_width=1.5,
+    interface_line = interface.slice(
+        normal=(0, 1, 0),
+        origin=(0.5, 0.5, 0.5),
     )
-    plotter.add_title("Default\ninterface crosses the volume", font_size=10)
-    plotter.add_text("tetrahedron refs: {2, 3}", position="lower_left", font_size=9)
 
-    plotter.subplot(0, 1)
     surface = boundary.extract_surface(algorithm="dataset_surface")
     surface_edges = surface.extract_all_edges()
     edge_vertices = surface_edges.lines.reshape(-1, 3)[:, 1:]
@@ -115,28 +100,85 @@ def main() -> None:
     boundary_trace = surface_edges.extract_cells(
         np.flatnonzero(np.all(np.isclose(edge_x, ISOVALUE_X), axis=1)),
     )
+    boundary_slice = boundary.slice(normal=(0, 1, 0), origin=(0.5, 0.5, 0.5))
+    boundary_cross_section = boundary_slice.extract_cells(
+        np.arange(
+            boundary_slice.n_verts + boundary_slice.n_lines,
+            boundary_slice.n_cells,
+        ),
+    )
+    boundary_hits = boundary_trace.slice(
+        normal=(0, 1, 0),
+        origin=(0.5, 0.5, 0.5),
+    )
+
+    plotter = pv.Plotter(shape=(1, 2), window_size=(1400, 700))
+
+    plotter.subplot(0, 0)
     plotter.add_mesh(
-        surface,
-        color="lightgray",
-        opacity=0.45,
+        full_cross_section,
+        scalars="refs",
+        categories=True,
+        clim=(2, 3),
+        cmap=["steelblue", "coral"],
         show_edges=True,
-        edge_color="gray",
+        edge_color="white",
+        line_width=0.3,
+        show_scalar_bar=False,
+    )
+    plotter.add_mesh(
+        interface_line,
+        color="black",
+        line_width=7,
+        render_lines_as_tubes=True,
+    )
+    plotter.add_point_labels(
+        np.array([[0.18, 0.5, 0.5], [0.72, 0.5, 0.5]]),
+        ["volume ref 3", "volume ref 2"],
+        font_size=18,
+        point_size=0,
+        shape=None,
+        show_points=False,
+    )
+    plotter.add_title("DEFAULT: VOLUME SPLIT", font_size=12)
+    plotter.add_text(
+        "black line = interface inside the volume",
+        position="lower_left",
+        font_size=10,
+    )
+
+    plotter.subplot(0, 1)
+    plotter.add_mesh(
+        boundary_cross_section,
+        color="lightgray",
+        show_edges=True,
+        edge_color="white",
         line_width=0.3,
     )
     plotter.add_mesh(
-        boundary_trace,
+        boundary_hits,
         color="coral",
-        line_width=8,
-        render_lines_as_tubes=True,
+        point_size=24,
+        render_points_as_spheres=True,
     )
-    plotter.add_title(
-        "surface_only=True\nintersection stays on boundary",
+    plotter.add_point_labels(
+        np.array([[0.5, 0.5, 0.5]]),
+        ["one volume: ref 0\nNO interior interface"],
+        font_size=18,
+        point_size=0,
+        shape=None,
+        show_points=False,
+    )
+    plotter.add_title("surface_only=True: BOUNDARY ONLY", font_size=12)
+    plotter.add_text(
+        "orange points = boundary intersections",
+        position="lower_left",
         font_size=10,
     )
-    plotter.add_text("tetrahedron refs: {0}", position="lower_left", font_size=9)
 
     plotter.link_views()
-    plotter.camera_position = [(2.4, 2.0, 1.7), (0.5, 0.5, 0.5), (0, 0, 1)]
+    plotter.camera_position = [(0.5, -3.0, 0.5), (0.5, 0.5, 0.5), (0, 0, 1)]
+    plotter.enable_parallel_projection()
     plotter.show()
 
 

--- a/examples/mmg3d/boundary_levelset.py
+++ b/examples/mmg3d/boundary_levelset.py
@@ -93,59 +93,66 @@ def main() -> None:
         raise RuntimeError(msg)
 
     full_tetrahedra = full.extract_cells(full.celltypes == pv.CellType.TETRA)
-    cutaway = full_tetrahedra.clip(
-        normal=(0.0, 1.0, 0.0),
-        origin=(0.5, 0.5, 0.5),
-        invert=False,
-    )
+    tetra_centers = full_tetrahedra.cell_centers().points
+    cutaway = full_tetrahedra.extract_cells(tetra_centers[:, 1] >= 0.5)
+    cutaway_ref2 = cutaway.extract_cells(cutaway["refs"] == 2)
+    cutaway_ref3 = cutaway.extract_cells(cutaway["refs"] == 3)
 
     boundary_tetrahedra = boundary.extract_cells(
         boundary.celltypes == pv.CellType.TETRA
     )
-    boundary_cutaway = boundary_tetrahedra.clip(
-        normal=(0.0, 1.0, 0.0),
-        origin=(0.5, 0.5, 0.5),
-        invert=False,
+    boundary_tetra_centers = boundary_tetrahedra.cell_centers().points
+    boundary_cutaway = boundary_tetrahedra.extract_cells(
+        boundary_tetra_centers[:, 1] >= 0.5
     )
 
     boundary_patches = boundary.extract_cells(boundary_triangle_mask)
-    boundary_patch_cutaway = boundary_patches.clip(
-        normal=(0.0, 1.0, 0.0),
-        origin=(0.5, 0.5, 0.5),
-        invert=False,
-    )
+    patch_centers = boundary_patches.cell_centers().points
+    boundary_patch_cutaway = boundary_patches.extract_cells(patch_centers[:, 1] >= 0.5)
 
-    plotter = pv.Plotter(shape=(1, 2), window_size=(1500, 700))
+    plotter = pv.Plotter(shape=(1, 3), window_size=(1800, 650))
     plotter.set_background("#eeeeee")
 
     plotter.subplot(0, 0)
     plotter.add_mesh(
-        cutaway,
-        scalars="refs",
-        categories=True,
-        clim=(2, 3),
-        cmap=["steelblue", "coral"],
-        opacity=1.0,
+        cutaway_ref2,
+        color="steelblue",
+        opacity=0.92,
         show_edges=True,
-        edge_color="#dddddd",
+        edge_color="#244963",
         line_width=0.2,
-        show_scalar_bar=False,
     )
-    plotter.add_title("DEFAULT: INTERIOR CUT HAS TWO REFS", font_size=10)
+    plotter.add_title("DEFAULT: VOLUME 1 OF 2 (REF 2)", font_size=9)
     plotter.add_text(
-        "Cut face: blue volume ref 2 + orange volume ref 3",
+        "Tetrahedra with volume ref 2",
         position=(20, 30),
-        font_size=10,
+        font_size=9,
     )
 
     plotter.subplot(0, 1)
     plotter.add_mesh(
+        cutaway_ref3,
+        color="coral",
+        opacity=0.92,
+        show_edges=True,
+        edge_color="#843d26",
+        line_width=0.2,
+    )
+    plotter.add_title("DEFAULT: VOLUME 2 OF 2 (REF 3)", font_size=9)
+    plotter.add_text(
+        "Tetrahedra with volume ref 3",
+        position=(20, 30),
+        font_size=9,
+    )
+
+    plotter.subplot(0, 2)
+    plotter.add_mesh(
         boundary_cutaway,
         color="white",
-        opacity=1.0,
+        opacity=0.58,
         show_edges=True,
         edge_color="gray",
-        line_width=0.2,
+        line_width=0.3,
     )
     plotter.add_mesh(
         boundary_patch_cutaway,
@@ -153,15 +160,15 @@ def main() -> None:
         categories=True,
         clim=(2, 3),
         cmap=["steelblue", "coral"],
-        opacity=1.0,
+        opacity=0.88,
         show_edges=False,
         show_scalar_bar=False,
     )
-    plotter.add_title("surface_only=True: INTERIOR CUT STAYS REF 0", font_size=10)
+    plotter.add_title("surface_only=True: SINGLE VOLUME (REF 0)", font_size=9)
     plotter.add_text(
-        "Neutral cut face = one volume; colors exist only on outer walls",
+        "Colors are boundary triangles, not volumes",
         position=(20, 30),
-        font_size=10,
+        font_size=9,
     )
 
     plotter.link_views()

--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -36,6 +36,23 @@ py::dict kwargs_to_options(const py::kwargs &kwargs) {
   }
   return options;
 }
+
+// Translate the Python convenience flag to MMG's mutually exclusive
+// level-set modes. Raw iso/isosurf kwargs remain available for compatibility
+// when surface_only is false.
+py::dict levelset_options(bool surface_only, const py::kwargs &kwargs) {
+  if (surface_only && (kwargs.contains("iso") || kwargs.contains("isosurf"))) {
+    throw py::type_error(
+        "surface_only cannot be combined with raw iso or isosurf options");
+  }
+
+  py::dict options = kwargs_to_options(kwargs);
+  if (surface_only) {
+    options["iso"] = py::int_(0);
+    options["isosurf"] = py::int_(1);
+  }
+  return options;
+}
 } // namespace
 
 PYBIND11_MODULE(_mmgpy, m) {
@@ -244,13 +261,15 @@ PYBIND11_MODULE(_mmgpy, m) {
       .def(
           "remesh_levelset",
           [](MmgMesh &self, const py::array_t<double> &levelset,
-             py::kwargs kwargs) {
-            return self.remesh_levelset(levelset, kwargs_to_options(kwargs));
+             bool surface_only, py::kwargs kwargs) {
+            return self.remesh_levelset(levelset,
+                                        levelset_options(surface_only, kwargs));
           },
-          py::arg("levelset"),
+          py::arg("levelset"), py::kw_only(), py::arg("surface_only") = false,
           "Remesh the mesh to conform to a level-set isosurface.\n\n"
           "Args:\n"
           "    levelset: Nx1 array of scalar level-set values per vertex.\n"
+          "    surface_only: Split only boundary faces, like MMG's -lssurf.\n"
           "    **kwargs: Remeshing options (hmax, hmin, verbose, etc.).\n"
           "              ls: Isovalue to discretize (default=0.0).\n"
           "              iso: Enable level-set mode (default=1).")
@@ -442,13 +461,15 @@ PYBIND11_MODULE(_mmgpy, m) {
       .def(
           "remesh_levelset",
           [](MmgMesh2D &self, const py::array_t<double> &levelset,
-             py::kwargs kwargs) {
-            return self.remesh_levelset(levelset, kwargs_to_options(kwargs));
+             bool surface_only, py::kwargs kwargs) {
+            return self.remesh_levelset(levelset,
+                                        levelset_options(surface_only, kwargs));
           },
-          py::arg("levelset"),
+          py::arg("levelset"), py::kw_only(), py::arg("surface_only") = false,
           "Remesh the mesh to conform to a level-set isoline.\n\n"
           "Args:\n"
           "    levelset: Nx1 array of scalar level-set values per vertex.\n"
+          "    surface_only: Split only boundary edges, like MMG's -lssurf.\n"
           "    **kwargs: Remeshing options (hmax, hmin, verbose, etc.).\n"
           "              ls: Isovalue to discretize (default=0.0).\n"
           "              iso: Enable level-set mode (default=1).")
@@ -627,13 +648,16 @@ PYBIND11_MODULE(_mmgpy, m) {
       .def(
           "remesh_levelset",
           [](MmgMeshS &self, const py::array_t<double> &levelset,
-             py::kwargs kwargs) {
-            return self.remesh_levelset(levelset, kwargs_to_options(kwargs));
+             bool surface_only, py::kwargs kwargs) {
+            return self.remesh_levelset(levelset,
+                                        levelset_options(surface_only, kwargs));
           },
-          py::arg("levelset"),
+          py::arg("levelset"), py::kw_only(), py::arg("surface_only") = false,
           "Remesh the mesh to conform to a level-set isoline.\n\n"
           "Args:\n"
           "    levelset: Nx1 array of scalar level-set values per vertex.\n"
+          "    surface_only: Split only referenced boundary edges, like "
+          "MMG's -lssurf.\n"
           "    **kwargs: Remeshing options (hmax, hmin, verbose, etc.).\n"
           "              ls: Isovalue to discretize (default=0.0).\n"
           "              iso: Enable level-set mode (default=1).")

--- a/src/bindings/mmg_common.cpp
+++ b/src/bindings/mmg_common.cpp
@@ -186,14 +186,13 @@ std::string path_to_string(const py::object &path) {
   }
 }
 
-py::dict merge_options_with_default(const py::dict &options, const char *key,
-                                    py::object default_value) {
+py::dict prepare_levelset_options(const py::dict &options) {
   py::dict merged;
   for (auto item : options) {
     merged[item.first] = item.second;
   }
-  if (!merged.contains(key)) {
-    merged[key] = default_value;
+  if (!merged.contains("iso") && !merged.contains("isosurf")) {
+    merged["iso"] = py::int_(1);
   }
   return merged;
 }

--- a/src/bindings/mmg_common.cpp
+++ b/src/bindings/mmg_common.cpp
@@ -191,8 +191,13 @@ py::dict prepare_levelset_options(const py::dict &options) {
   for (auto item : options) {
     merged[item.first] = item.second;
   }
-  if (!merged.contains("iso") && !merged.contains("isosurf")) {
-    merged["iso"] = py::int_(1);
+  const bool has_iso = merged.contains("iso");
+  const bool has_isosurf = merged.contains("isosurf");
+  if (!has_iso) {
+    merged["iso"] = py::int_(has_isosurf ? 0 : 1);
+  }
+  if (!has_isosurf) {
+    merged["isosurf"] = py::int_(0);
   }
   return merged;
 }

--- a/src/bindings/mmg_common.hpp
+++ b/src/bindings/mmg_common.hpp
@@ -119,7 +119,7 @@ void set_mesh_options_surface(MMG5_pMesh mesh, MMG5_pSol met,
 
 std::string path_to_string(const py::object &path);
 
-// Enable standard level-set mode unless the caller selected iso or isosurf.
+// Select the requested level-set mode and explicitly clear the inactive mode.
 py::dict prepare_levelset_options(const py::dict &options);
 
 // Build the remesh result dictionary from before/after stats

--- a/src/bindings/mmg_common.hpp
+++ b/src/bindings/mmg_common.hpp
@@ -119,9 +119,8 @@ void set_mesh_options_surface(MMG5_pMesh mesh, MMG5_pSol met,
 
 std::string path_to_string(const py::object &path);
 
-// Helper to merge options with a default value
-py::dict merge_options_with_default(const py::dict &options, const char *key,
-                                    py::object default_value);
+// Enable standard level-set mode unless the caller selected iso or isosurf.
+py::dict prepare_levelset_options(const py::dict &options);
 
 // Build the remesh result dictionary from before/after stats
 py::dict build_remesh_result(const RemeshStats &before,

--- a/src/bindings/mmg_mesh.cpp
+++ b/src/bindings/mmg_mesh.cpp
@@ -1567,7 +1567,7 @@ py::dict MmgMesh::remesh_levelset(const py::array_t<double> &levelset,
   RemeshStats before = collect_mesh_stats_3d(mesh, met);
 
   set_field("levelset", levelset);
-  py::dict ls_options = merge_options_with_default(options, "iso", py::int_(1));
+  py::dict ls_options = prepare_levelset_options(options);
   if (has_input_parameter_file_) {
     if (!MMG3D_parsop(mesh, met)) {
       throw std::runtime_error("Failed to parse MMG3D parameter file");

--- a/src/bindings/mmg_mesh_2d.cpp
+++ b/src/bindings/mmg_mesh_2d.cpp
@@ -1146,7 +1146,7 @@ py::dict MmgMesh2D::remesh_levelset(const py::array_t<double> &levelset,
   RemeshStats before = collect_mesh_stats_2d(mesh, met);
 
   set_field("levelset", levelset);
-  py::dict ls_options = merge_options_with_default(options, "iso", py::int_(1));
+  py::dict ls_options = prepare_levelset_options(options);
   if (has_input_parameter_file_) {
     if (!MMG2D_parsop(mesh, met)) {
       throw std::runtime_error("Failed to parse MMG2D parameter file");

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -1119,7 +1119,7 @@ py::dict MmgMeshS::remesh_levelset(const py::array_t<double> &levelset,
   RemeshStats before = collect_mesh_stats_surface(mesh, met);
 
   set_field("levelset", levelset);
-  py::dict ls_options = merge_options_with_default(options, "iso", py::int_(1));
+  py::dict ls_options = prepare_levelset_options(options);
   set_mesh_options_surface(mesh, met, ls_options);
 
   // Capture stderr to collect MMG warnings

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -2707,6 +2707,7 @@ class Mesh:
         *,
         include_refs: bool = True,
         include_edges: bool = False,
+        include_boundary: bool = False,
     ) -> pv.UnstructuredGrid | pv.PolyData:
         """Convert to PyVista mesh.
 
@@ -2721,6 +2722,9 @@ class Mesh:
             matches typical downstream code (matplotlib tripcolor, area
             computations, etc.). Set True for round-trip / file-save
             workflows that need to preserve edge markers.
+        include_boundary : bool
+            Include MMG3D boundary faces as TRIANGLE cells, with their
+            references in ``cell_data["refs"]``. Ignored for MMG2D and MMGS.
 
         Returns
         -------
@@ -2734,6 +2738,7 @@ class Mesh:
             self._impl,
             include_refs=include_refs,
             include_edges=include_edges,
+            include_boundary=include_boundary,
         )
 
     @property

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -2256,6 +2256,7 @@ class Mesh:
         self,
         levelset: NDArray[np.float64],
         *,
+        surface_only: bool = False,
         progress: ProgressParam = True,
         **kwargs: Any,  # noqa: ANN401
     ) -> RemeshResult:
@@ -2265,6 +2266,10 @@ class Mesh:
         ----------
         levelset : ndarray
             Level-set field for each vertex.
+        surface_only : bool, default=False
+            If ``True``, split only the mesh boundary at the isovalue,
+            corresponding to MMG's ``-lssurf`` / ``*_IPARAM_isosurf`` mode.
+            The default ``False`` preserves full-domain level-set splitting.
         progress : bool | Callable[[ProgressEvent], bool] | None, default=True
             Progress reporting option:
             - True: Show Rich progress bar (default)
@@ -2311,7 +2316,11 @@ class Mesh:
             ):
                 raise CancellationError(phase="remesh")
 
-            stats = self._impl.remesh_levelset(levelset, **kwargs)  # type: ignore[arg-type]
+            stats = self._impl.remesh_levelset(  # type: ignore[arg-type]
+                levelset,
+                surface_only=surface_only,
+                **kwargs,
+            )
             final_vertices = len(self._impl.get_vertices())
 
             if do_rcm:

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -1242,6 +1242,7 @@ class MmgMesh3D:
         hausd: float | None = None,
         hgrad: float | None = None,
         verbose: int | bool | None = None,
+        surface_only: bool = False,
         iso: int | None = None,
         **kwargs: float | None,
     ) -> dict[str, Any]:
@@ -1268,6 +1269,9 @@ class MmgMesh3D:
             Gradation parameter.
         verbose : int | bool | None
             Verbosity level.
+        surface_only : bool
+            Split only boundary faces, corresponding to MMG's ``-lssurf`` /
+            ``MMG3D_IPARAM_isosurf`` mode. Defaults to ``False``.
         iso : int | None
             Enable level-set mode (default 1).
         **kwargs : float | int | None
@@ -2096,6 +2100,7 @@ class MmgMesh2D:
         hausd: float | None = None,
         hgrad: float | None = None,
         verbose: int | bool | None = None,
+        surface_only: bool = False,
         iso: int | None = None,
         **kwargs: float | None,
     ) -> dict[str, Any]:
@@ -2119,6 +2124,9 @@ class MmgMesh2D:
             Gradation parameter.
         verbose : int | bool | None
             Verbosity level.
+        surface_only : bool
+            Split only boundary edges, corresponding to MMG's ``-lssurf`` /
+            ``MMG2D_IPARAM_isosurf`` mode. Defaults to ``False``.
         iso : int | None
             Enable level-set mode (default 1).
         **kwargs : float | int | None
@@ -2877,6 +2885,7 @@ class MmgMeshS:
         hausd: float | None = None,
         hgrad: float | None = None,
         verbose: int | bool | None = None,
+        surface_only: bool = False,
         iso: int | None = None,
         **kwargs: float | None,
     ) -> dict[str, Any]:
@@ -2900,6 +2909,9 @@ class MmgMeshS:
             Gradation parameter.
         verbose : int | bool | None
             Verbosity level.
+        surface_only : bool
+            Split only referenced boundary edges, corresponding to MMG's
+            ``-lssurf`` / ``MMGS_IPARAM_isosurf`` mode. Defaults to ``False``.
         iso : int | None
             Enable level-set mode (default 1).
         **kwargs : float | int | None

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -1108,6 +1108,7 @@ class MmgAccessor:
         self,
         levelset: NDArray[np.float64],
         *,
+        surface_only: bool = False,
         local_sizing: list[Mapping[str, Any]] | None = None,
         **options: Any,  # noqa: ANN401  -- forwarded to Mesh.remesh_levelset
     ) -> pv.UnstructuredGrid | pv.PolyData:
@@ -1118,6 +1119,10 @@ class MmgAccessor:
         levelset : ndarray
             Per-vertex level-set field; the zero isosurface becomes an
             explicit boundary in the output mesh.
+        surface_only : bool, default=False
+            If ``True``, split only boundary entities at the isovalue using
+            MMG's ``-lssurf`` / ``*_IPARAM_isosurf`` mode. The interior
+            domain is not split into level-set materials.
         local_sizing : list of dict, optional
             Sizing constraints; see :meth:`remesh`.
         **options : object
@@ -1136,7 +1141,7 @@ class MmgAccessor:
         _apply_constraint_markers(mesh, self._dataset, constraints)
         _apply_local_sizing_specs(mesh, local_sizing)
         _apply_pending_mmg_config(mesh, self._dataset)
-        mesh.remesh_levelset(levelset, **options)
+        mesh.remesh_levelset(levelset, surface_only=surface_only, **options)
         return _to_pyvista_with_user_fields(mesh)
 
     def remesh_optimize(

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -236,6 +236,8 @@ def _build_mesh_with_mmg_fields(dataset: pv.UnstructuredGrid | pv.PolyData) -> _
 
 def _to_pyvista_with_user_fields(
     mesh: _Mesh,
+    *,
+    include_boundary: bool = False,
 ) -> pv.UnstructuredGrid | pv.PolyData:
     """Convert *mesh* back to PyVista, restoring any non-MMG point_data.
 
@@ -249,10 +251,15 @@ def _to_pyvista_with_user_fields(
     -------
     pv.UnstructuredGrid or pv.PolyData
         The PyVista dataset with user fields re-attached where their
-        length matches the new vertex count.
+        length matches the new vertex count. When requested, an MMG3D
+        result also includes referenced boundary faces as TRIANGLE cells.
 
     """
-    result = mesh.to_pyvista(include_refs=True, include_edges=True)
+    result = mesh.to_pyvista(
+        include_refs=True,
+        include_edges=True,
+        include_boundary=include_boundary,
+    )
     n_points = result.n_points
     for name, arr in mesh.get_user_fields().items():
         if arr.shape[0] != n_points:
@@ -1122,7 +1129,8 @@ class MmgAccessor:
         surface_only : bool, default=False
             If ``True``, split only boundary entities at the isovalue using
             MMG's ``-lssurf`` / ``*_IPARAM_isosurf`` mode. The interior
-            domain is not split into level-set materials.
+            domain is not split into level-set materials. MMG3D results
+            include the referenced boundary faces as TRIANGLE cells.
         local_sizing : list of dict, optional
             Sizing constraints; see :meth:`remesh`.
         **options : object
@@ -1142,7 +1150,7 @@ class MmgAccessor:
         _apply_local_sizing_specs(mesh, local_sizing)
         _apply_pending_mmg_config(mesh, self._dataset)
         mesh.remesh_levelset(levelset, surface_only=surface_only, **options)
-        return _to_pyvista_with_user_fields(mesh)
+        return _to_pyvista_with_user_fields(mesh, include_boundary=surface_only)
 
     def remesh_optimize(
         self,

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -916,6 +916,7 @@ def to_pyvista(
     *,
     include_refs: bool = True,
     include_edges: bool = False,
+    include_boundary: bool = False,
 ) -> pv.UnstructuredGrid: ...
 
 
@@ -925,6 +926,7 @@ def to_pyvista(
     *,
     include_refs: bool = True,
     include_edges: bool = False,
+    include_boundary: bool = False,
 ) -> pv.PolyData: ...
 
 
@@ -934,6 +936,7 @@ def to_pyvista(
     *,
     include_refs: bool = True,
     include_edges: bool = False,
+    include_boundary: bool = False,
 ) -> pv.PolyData: ...
 
 
@@ -942,6 +945,7 @@ def to_pyvista(
     *,
     include_refs: bool = True,
     include_edges: bool = False,
+    include_boundary: bool = False,
 ) -> pv.UnstructuredGrid | pv.PolyData:
     """Convert an mmgpy mesh to a PyVista mesh.
 
@@ -957,6 +961,11 @@ def to_pyvista(
         contains only the primary cell type, matching common downstream
         expectations (e.g. matplotlib ``tripcolor``). Set ``True`` for
         round-trip / file-save workflows that must preserve edge markers.
+    include_boundary : bool
+        If ``True`` for an ``MmgMesh3D``, include MMG boundary faces as
+        TRIANGLE cells. Their references share the ``cell_data["refs"]``
+        array with the tetrahedra. Ignored for MMG2D and MMGS, whose
+        triangles are already the primary cells.
 
     Returns
     -------
@@ -985,6 +994,7 @@ def to_pyvista(
             mesh,
             include_refs=include_refs,
             include_edges=include_edges,
+            include_boundary=include_boundary,
         )
     if isinstance(mesh, MmgMesh2D):
         return _mmg2d_to_pyvista(
@@ -1017,18 +1027,62 @@ def _build_lines_array(edges: NDArray[np.int32]) -> NDArray[np.int32]:
     ).ravel()
 
 
+def _get_mmg3d_edges(
+    mesh: MmgMesh3D,
+    *,
+    include_refs: bool,
+    include_edges: bool,
+) -> tuple[NDArray[np.int32], NDArray[np.int64] | None]:
+    """Return optional MMG3D edges and references.
+
+    Returns
+    -------
+    tuple
+        Edge connectivity and, when requested, edge references.
+
+    """
+    if not include_edges:
+        return np.empty((0, 2), dtype=np.int32), None
+    if include_refs:
+        return mesh.get_edges_with_refs()
+    return mesh.get_edges(), None
+
+
+def _get_mmg3d_boundary(
+    mesh: MmgMesh3D,
+    *,
+    include_refs: bool,
+    include_boundary: bool,
+) -> tuple[NDArray[np.int32], NDArray[np.int64] | None]:
+    """Return optional MMG3D boundary triangles and references.
+
+    Returns
+    -------
+    tuple
+        Triangle connectivity and, when requested, triangle references.
+
+    """
+    if not include_boundary:
+        return np.empty((0, 3), dtype=np.int32), None
+    if include_refs:
+        return mesh.get_triangles_with_refs()
+    return mesh.get_triangles(), None
+
+
 def _mmg3d_to_pyvista(
     mesh: MmgMesh3D,
     *,
     include_refs: bool,
     include_edges: bool,
+    include_boundary: bool,
 ) -> pv.UnstructuredGrid:
     """Convert MmgMesh3D to PyVista UnstructuredGrid.
 
     Returns
     -------
     pv.UnstructuredGrid
-        Tetrahedral cells, with refs (and edges) attached when requested.
+        Tetrahedral cells, with refs, boundary triangles, and edges attached
+        when requested.
 
     """
     vertices = mesh.get_vertices()
@@ -1039,23 +1093,31 @@ def _mmg3d_to_pyvista(
         elements = mesh.get_elements()
         refs = None
 
-    edges, edge_refs = (np.empty((0, 2), dtype=np.int32), None)
-    if include_edges:
-        if include_refs:
-            edges, edge_refs = mesh.get_edges_with_refs()
-        else:
-            edges = mesh.get_edges()
+    edges, edge_refs = _get_mmg3d_edges(
+        mesh,
+        include_refs=include_refs,
+        include_edges=include_edges,
+    )
+    triangles, triangle_refs = _get_mmg3d_boundary(
+        mesh,
+        include_refs=include_refs,
+        include_boundary=include_boundary,
+    )
 
     cells_dict: dict[int, NDArray[np.int32]] = {pv.CellType.TETRA: elements}
+    if len(triangles) > 0:
+        cells_dict[pv.CellType.TRIANGLE] = triangles
     if len(edges) > 0:
         cells_dict[pv.CellType.LINE] = edges
     grid = pv.UnstructuredGrid(cells_dict, vertices)
 
     if refs is not None:
+        refs_by_type: list[NDArray[np.int64]] = [refs]
+        if len(triangles) > 0 and triangle_refs is not None:
+            refs_by_type.append(triangle_refs)
         if len(edges) > 0 and edge_refs is not None:
-            grid.cell_data["refs"] = np.concatenate([refs, edge_refs])
-        else:
-            grid.cell_data["refs"] = refs
+            refs_by_type.append(edge_refs)
+        grid.cell_data["refs"] = np.concatenate(refs_by_type)
 
     return grid
 

--- a/tests/levelset_test.py
+++ b/tests/levelset_test.py
@@ -53,6 +53,32 @@ class TestLevelset3D:
         assert {2, 3}.issubset(set(boundary_refs))
         assert np.any(np.isclose(mesh.get_vertices()[:, 0], 0.37, atol=1e-8))
 
+    def test_surface_only_mode_does_not_leak_into_next_call(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """Each call resets MMG's mutable iso and isosurf mode flags."""
+        vertices, elements = dense_3d_mesh
+        mesh = MmgMesh3D(vertices, elements)
+
+        mesh.remesh_levelset(
+            (vertices[:, 0] - 0.37).reshape(-1, 1),
+            surface_only=True,
+            hmax=0.25,
+            verbose=False,
+        )
+        _, surface_only_refs = mesh.get_elements_with_refs()
+        assert set(surface_only_refs) == {0}
+
+        remeshed_vertices = mesh.get_vertices()
+        mesh.remesh_levelset(
+            (remeshed_vertices[:, 0] - 0.63).reshape(-1, 1),
+            hmax=0.25,
+            verbose=False,
+        )
+        _, default_refs = mesh.get_elements_with_refs()
+        assert {2, 3}.issubset(set(default_refs))
+
     def test_remesh_levelset_element_refs(
         self,
         dense_3d_mesh_fine: tuple[np.ndarray, np.ndarray],

--- a/tests/levelset_test.py
+++ b/tests/levelset_test.py
@@ -1,6 +1,7 @@
 """Tests for level-set discretization functionality."""
 
 import numpy as np
+import pytest
 
 from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
 
@@ -28,6 +29,29 @@ class TestLevelset3D:
 
         assert len(new_vertices) > 0
         assert len(new_elements) > 0
+
+    def test_surface_only_splits_boundary_not_volume(
+        self,
+        dense_3d_mesh: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        """``surface_only`` splits boundary faces without materializing an interior."""
+        vertices, elements = dense_3d_mesh
+        mesh = MmgMesh3D(vertices, elements)
+        levelset = (vertices[:, 0] - 0.37).reshape(-1, 1)
+
+        mesh.remesh_levelset(
+            levelset,
+            surface_only=True,
+            hmax=0.25,
+            verbose=False,
+        )
+
+        _, element_refs = mesh.get_elements_with_refs()
+        _, boundary_refs = mesh.get_triangles_with_refs()
+
+        assert set(element_refs) == {0}
+        assert {2, 3}.issubset(set(boundary_refs))
+        assert np.any(np.isclose(mesh.get_vertices()[:, 0], 0.37, atol=1e-8))
 
     def test_remesh_levelset_element_refs(
         self,
@@ -187,6 +211,30 @@ class TestLevelset2D:
         assert len(new_vertices) > 0
         assert len(new_triangles) > 0
 
+    def test_surface_only_splits_reference_edges_not_triangles(self) -> None:
+        """MMG2D ``lssurf`` preserves area refs and splits reference edges."""
+        vertices = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+            dtype=np.float64,
+        )
+        triangles = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+        mesh = MmgMesh2D()
+        mesh.set_mesh_size(vertices=4, triangles=2)
+        mesh.set_vertices(vertices)
+        mesh.set_triangles(triangles, refs=np.array([4, 8], dtype=np.int64))
+
+        mesh.remesh_levelset(
+            (vertices[:, 0] - 0.37).reshape(-1, 1),
+            surface_only=True,
+            hmax=0.3,
+            verbose=False,
+        )
+
+        _, triangle_refs = mesh.get_triangles_with_refs()
+        _, edge_refs = mesh.get_edges_with_refs()
+        assert set(triangle_refs) == {4, 8}
+        assert {2, 3}.issubset(set(edge_refs))
+
     def test_remesh_levelset_element_refs(
         self,
         dense_2d_mesh_fine: tuple[np.ndarray, np.ndarray],
@@ -277,3 +325,48 @@ class TestLevelsetSurface:
 
         assert len(new_vertices) > 0
         assert len(new_triangles) > 0
+
+    def test_surface_only_splits_reference_edges_not_surface(self) -> None:
+        """MMGS ``lssurf`` splits referenced edges without splitting faces."""
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ],
+            dtype=np.float64,
+        )
+        triangles = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+        edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=np.int32)
+        mesh = MmgMeshS()
+        mesh.set_mesh_size(vertices=4, triangles=2, edges=4)
+        mesh.set_vertices(vertices)
+        mesh.set_triangles(triangles, refs=np.ones(2, dtype=np.int64))
+        mesh.set_edges(edges, refs=np.ones(4, dtype=np.int64))
+
+        mesh.remesh_levelset(
+            (vertices[:, 0] - 0.37).reshape(-1, 1),
+            surface_only=True,
+            hmax=0.3,
+            verbose=False,
+        )
+
+        _, triangle_refs = mesh.get_triangles_with_refs()
+        _, edge_refs = mesh.get_edges_with_refs()
+        assert set(triangle_refs) == {1}
+        assert {2, 3}.issubset(set(edge_refs))
+
+
+@pytest.mark.parametrize("mesh_type", [MmgMesh3D, MmgMesh2D, MmgMeshS])
+def test_surface_only_rejects_raw_mode_options(
+    mesh_type: type[MmgMesh3D | MmgMesh2D | MmgMeshS],
+) -> None:
+    """The typed mode cannot be combined with MMG's mutually exclusive flags."""
+    mesh = mesh_type()
+    with pytest.raises(TypeError, match="surface_only cannot be combined"):
+        mesh.remesh_levelset(
+            np.empty((0, 1), dtype=np.float64),
+            surface_only=True,
+            iso=1,
+        )

--- a/tests/pv_plugin_test.py
+++ b/tests/pv_plugin_test.py
@@ -360,7 +360,10 @@ def test_accessor_remesh_levelset_surface_only_preserves_volume_refs() -> None:
     )
 
     tetrahedra = split.celltypes == pv.CellType.TETRA
+    boundary_triangles = split.celltypes == pv.CellType.TRIANGLE
     assert set(split.cell_data["refs"][tetrahedra]) == {0}
+    assert boundary_triangles.any()
+    assert {2, 3}.issubset(set(split.cell_data["refs"][boundary_triangles]))
     assert np.any(np.isclose(split.points[:, 0], 0.37, atol=1e-8))
 
 

--- a/tests/pv_plugin_test.py
+++ b/tests/pv_plugin_test.py
@@ -347,6 +347,23 @@ def test_accessor_remesh_levelset_carves_isosurface() -> None:
     assert carved.n_cells > 0
 
 
+def test_accessor_remesh_levelset_surface_only_preserves_volume_refs() -> None:
+    """The accessor exposes boundary-only splitting without raw MMG options."""
+    tets = _dense_tets()
+    levelset = (tets.points[:, 0] - 0.37).reshape(-1, 1).astype(np.float64)
+
+    split = tets.mmg.remesh_levelset(
+        levelset,
+        surface_only=True,
+        hmax=0.25,
+        verbose=False,
+    )
+
+    tetrahedra = split.celltypes == pv.CellType.TETRA
+    assert set(split.cell_data["refs"][tetrahedra]) == {0}
+    assert np.any(np.isclose(split.points[:, 0], 0.37, atol=1e-8))
+
+
 def test_accessor_save_sol_round_trip(tmp_path: Path) -> None:
     """save_sol followed by load_sol produces a matching scalar field."""
     grid = _make_tet_mesh()

--- a/tests/pyvista_test.py
+++ b/tests/pyvista_test.py
@@ -289,6 +289,37 @@ class TestToPyvista:
 
         np.testing.assert_array_equal(converted_cells, original_elements)
 
+    def test_mmg3d_boundary_triangles_can_be_included(self) -> None:
+        """Boundary triangles and their refs are exposed as mixed VTK cells."""
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        tetrahedra = np.array([[0, 1, 2, 3]], dtype=np.int32)
+        triangles = np.array(
+            [[0, 2, 1], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
+            dtype=np.int32,
+        )
+        mesh = MmgMesh3D()
+        mesh.set_mesh_size(vertices=4, tetrahedra=1, triangles=4)
+        mesh.set_vertices(vertices)
+        mesh.set_tetrahedra(tetrahedra, refs=np.array([7], dtype=np.int64))
+        mesh.set_triangles(triangles, refs=np.array([2, 2, 3, 3], dtype=np.int64))
+
+        grid = to_pyvista(mesh, include_boundary=True)
+        tetra_mask = grid.celltypes == pv.CellType.TETRA
+        triangle_mask = grid.celltypes == pv.CellType.TRIANGLE
+
+        assert tetra_mask.sum() == 1
+        assert triangle_mask.sum() == 4
+        assert grid.cell_data["refs"][tetra_mask].tolist() == [7]
+        assert grid.cell_data["refs"][triangle_mask].tolist() == [2, 2, 3, 3]
+
 
 # Round-trip tests
 


### PR DESCRIPTION
## Summary

- add a first-class `surface_only=True` option to level-set remeshing
- support MMG3D, MMG2D, and MMGS through both native mesh classes and the PyVista accessor
- map the option to MMG's `-lssurf` / `*_IPARAM_isosurf` mode while preserving the existing full-domain default
- reset both mutable MMG mode flags on every level-set call so switching modes on one mesh is safe
- expose referenced MMG3D boundary triangles through `to_pyvista(include_boundary=True)` and include them automatically in boundary-only PyVista results
- add a finer MMG3D gyroid example with two volume regions versus an exploded boundary skin around one neutral volume
- document selecting boundary patches by VTK cell type and MMG reference
- make release validation install the downloaded wheel artifact by explicit path and verify the new API

## Why

Boundary-only level-set splitting was technically reachable through raw MMG options, but it was undiscoverable and unsafe: mmgpy always injected `iso=1`, which could combine the mutually exclusive `iso` and `isosurf` modes. The new typed option selects `isosurf` explicitly, rejects conflicting raw mode flags, and normalizes both MMG flags on every invocation so mode state cannot leak between calls on a mutable mesh.

For the result to be useful through PyVista, MMG's referenced boundary triangles also need to survive conversion. They are now exposed as mixed `TRIANGLE` cells sharing `cell_data["refs"]` with the tetrahedra, so callers can select each boundary-condition patch directly.

## Validation

- repository hooks on all changed files (all passed, including Ruff, ty, ClangFormat, and Complexipy)
- `uv run pytest tests/pyvista_test.py tests/pv_plugin_test.py tests/levelset_test.py -q` (82 passed)
- `uv run pytest tests/examples_test.py -q -k boundary_levelset` (1 passed)
- `uv run pytest tests/docs_test.py -q` (22 passed)
- `uv run pytest --ignore=tests/examples_test.py --ignore=tests/docs_test.py -q` (1145 passed, 37 skipped)
- GitHub Build Wheels workflow, including `Validate release` against the explicitly installed PR wheel (passed)
- off-screen render of the final finer-resolution example visually inspected

Closes #372
