### PR TITLE
Support native MMG parameter files

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Native MMG parameter-file support through `parameter_file=` on file,
+  in-memory, level-set, and PyVista remeshing APIs for MMG3D, MMG2D, and MMGS.
+  Explicit Python options are applied after file settings and take precedence.
 - `mmgpy.mmg2d.generate(boundary_vertices, boundary_edges, ...)` triangulates a 2D domain from a vertex+edge outline via MMG2D's mesh-generation path. The `.mmg` accessor auto-routes line-only `pv.PolyData` through the same path so `outline.mmg.remesh(hmax=...)` produces a triangulation directly.
 - Promoted six high-value MMG flags to typed fields on the options dataclasses: `nreg` and `anisosize` on all three (`Mmg3DOptions`, `Mmg2DOptions`, `MmgSOptions`); `opnbdy` and `nofem` on `Mmg3DOptions` / `Mmg2DOptions`; `optim_les` on `Mmg3DOptions` (forwarded as `optimLES`); `keep_ref` on `MmgSOptions` (forwarded as `keepRef`). Niche options (`octree`, `numsubdomain`, `isoref`, `nosizreq`, `xreg`, `xreg_val`, `rmc`, `3dmedit`) remain as `**kwargs` on `remesh(...)`.
 

--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -12,8 +12,8 @@ corresponding Python binding in mmgpy. Functions are sourced from the official M
 
 | Library | Total | Bound | Indirect | Candidate | Excluded | Skipped | Functional Coverage |
 | ------- | ----: | ----: | -------: | --------: | -------: | ------: | ------------------: |
-| MMG3D   |   140 |    73 |       48 |         0 |       18 |       1 |                 86% |
-| MMG2D   |   119 |    62 |       41 |         0 |       15 |       1 |                 87% |
+| MMG3D   |   140 |    72 |       49 |         0 |       18 |       1 |                 86% |
+| MMG2D   |   119 |    61 |       42 |         0 |       15 |       1 |                 87% |
 | MMGS    |   109 |    61 |       37 |         0 |       11 |       0 |                 90% |
 
 **Functional coverage** = (Bound + Indirect) / Total. "Indirect" means the functionality
@@ -299,7 +299,7 @@ Excluded functions fall into categories that should not become one-to-one Python
 | ---------------------- | -------- | ----------------------------------------------------- |
 | `MMG3D_defaultValues`  | Excluded | Prints default values to stdout; CLI utility          |
 | `MMG3D_parsar`         | Excluded | Command-line argument parser; not relevant for Python |
-| `MMG3D_parsop`         | Bound    | Invoked internally before in-memory remeshing         |
+| `MMG3D_parsop`         | Indirect | Native format handled by mmgpy's shared safe parser   |
 | `MMG3D_usage`          | Excluded | Prints usage text; CLI utility                        |
 | `MMG3D_Set_commonFunc` | Excluded | Internal MMG function pointer setup                   |
 | `MMG3D_setfunc`        | Bound    | Initializes `MMG3D_doSol` for `build_size_map()`      |
@@ -509,7 +509,7 @@ Excluded functions fall into categories that should not become one-to-one Python
 | ---------------------- | -------- | ----------------------------------------------------- |
 | `MMG2D_defaultValues`  | Excluded | Prints default values to stdout; CLI utility          |
 | `MMG2D_parsar`         | Excluded | Command-line argument parser; not relevant for Python |
-| `MMG2D_parsop`         | Bound    | Invoked internally before in-memory remeshing         |
+| `MMG2D_parsop`         | Indirect | Native format handled by mmgpy's shared safe parser   |
 | `MMG2D_usage`          | Excluded | Prints usage text; CLI utility                        |
 | `MMG2D_Set_commonFunc` | Excluded | Internal MMG function pointer setup                   |
 | `MMG2D_setfunc`        | Bound    | Initializes `MMG2D_doSol` for `build_size_map()`      |
@@ -720,10 +720,6 @@ detailed tables has been reviewed and should not be ported one-to-one.
 ## Capability-Level Differences
 
 Some differences do not correspond to a missing C callable:
-
-- MMGS publicly exposes `MMGS_Set_inputParamName` but keeps its parameter-file parser
-  private, unlike MMG3D and MMG2D. mmgpy mirrors that small native parser through
-  MMGS's public setters so `parameter_file=` behaves consistently for all engines.
 
 - Mixed tetrahedron/prism meshes are supported by the low-level MMG3D bindings, but the
   PyVista conversion path does not currently round-trip VTK wedge cells.

--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -637,13 +637,13 @@ Excluded functions fall into categories that should not become one-to-one Python
 
 ### I/O Configuration
 
-| Function                  | Status | Notes                                  |
-| ------------------------- | ------ | -------------------------------------- |
-| `MMGS_Set_inputMeshName`  | Bound  | Used in `mmgs.remesh()` file-based API |
-| `MMGS_Set_outputMeshName` | Bound  | Used in `mmgs.remesh()` file-based API |
-| `MMGS_Set_inputSolName`   | Bound  | Used in `mmgs.remesh()` file-based API |
-| `MMGS_Set_outputSolName`  | Bound  | Used in `mmgs.remesh()` file-based API |
-| `MMGS_Set_inputParamName` | Bound  | `MmgMeshS.set_input_parameter_name()`  |
+| Function                  | Status | Notes                                                       |
+| ------------------------- | ------ | ----------------------------------------------------------- |
+| `MMGS_Set_inputMeshName`  | Bound  | Used in `mmgs.remesh()` file-based API                      |
+| `MMGS_Set_outputMeshName` | Bound  | Used in `mmgs.remesh()` file-based API                      |
+| `MMGS_Set_inputSolName`   | Bound  | Used in `mmgs.remesh()` file-based API                      |
+| `MMGS_Set_outputSolName`  | Bound  | Used in `mmgs.remesh()` file-based API                      |
+| `MMGS_Set_inputParamName` | Bound  | `MmgMeshS.set_input_parameter_name()` and `parameter_file=` |
 
 ### File I/O
 
@@ -722,8 +722,8 @@ detailed tables has been reviewed and should not be ported one-to-one.
 Some differences do not correspond to a missing C callable:
 
 - MMGS publicly exposes `MMGS_Set_inputParamName` but keeps its parameter-file parser
-  private, unlike MMG3D and MMG2D. The filename setter is bound, but in-memory MMGS parsing
-  needs an upstream API change ([#373](https://github.com/kmarchais/mmgpy/issues/373)).
+  private, unlike MMG3D and MMG2D. mmgpy mirrors that small native parser through
+  MMGS's public setters so `parameter_file=` behaves consistently for all engines.
 
 - Mixed tetrahedron/prism meshes are supported by the low-level MMG3D bindings, but the
   PyVista conversion path does not currently round-trip VTK wedge cells.

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -32,6 +32,9 @@ The same keyword is available on `Mesh.remesh(...)`,
 Both strings and path-like objects are accepted. Missing or unreadable files
 raise a `RuntimeError` before remeshing starts.
 
+mmgpy uses the same parser for all three engines and applies the parsed values
+through each engine's public MMG setters.
+
 MMG parameter files define local sizing by entity reference. For example, this
 `.mmg3d` file targets tetrahedra whose reference is `7`:
 

--- a/docs/reference/mmg-parameters.md
+++ b/docs/reference/mmg-parameters.md
@@ -8,6 +8,47 @@ mesh = pv.read("input.mesh")
 
 Complete reference for the keyword arguments accepted by `dataset.mmg.remesh(...)` (and its variants `remesh_optimize`, `remesh_uniform`, `remesh_levelset`, `move`). Each call returns a fresh PyVista dataset; the input is not mutated.
 
+## Native parameter files
+
+All three engines accept MMG's native local-parameter files through the
+`parameter_file` keyword. Pass a `.mmg3d` file for tetrahedral meshes, a
+`.mmg2d` file for planar meshes, or a `.mmgs` file for surface meshes:
+
+<!-- mmgpy-test:skip -->
+
+```python
+from pathlib import Path
+
+parameter_file = Path("local.mmg3d")
+remeshed = mesh.mmg.remesh(
+    parameter_file=parameter_file,
+    verbose=-1,
+)
+```
+
+The same keyword is available on `Mesh.remesh(...)`,
+`Mesh.remesh_levelset(...)`, and the file APIs such as
+`mmgpy.mmg3d.remesh("in.mesh", "out.mesh", parameter_file=parameter_file)`.
+Both strings and path-like objects are accepted. Missing or unreadable files
+raise a `RuntimeError` before remeshing starts.
+
+MMG parameter files define local sizing by entity reference. For example, this
+`.mmg3d` file targets tetrahedra whose reference is `7`:
+
+```text
+parameters
+1
+7 tetrahedra 0.02 0.08 0.01
+```
+
+The final three values are `hmin`, `hmax`, and `hausd`. MMG3D accepts
+`triangle(s)` and `tetrahedron(s)` references, MMG2D accepts `edge(s)` and
+`triangle(s)`, and MMGS accepts `triangle(s)`. Native `lsreferences` and
+`lsbasereferences` sections are supported as well.
+
+Parameter files are parsed first. Explicit Python options are applied second,
+so Python settings take precedence when both configure the same MMG parameter.
+
 ## Size Parameters
 
 ### hmin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,11 +189,9 @@ ignore = [
 ]
 "src/mmgpy/_remesh.py" = [
     "N801",    # class names match C++ API (mmg2d, mmg3d, mmgs)
-    "PLR0913", # public file APIs expose independent path and remesh controls
 ]
 "src/mmgpy/_mesh.py" = [
     "PLR0904", # Mesh exposes the full public API (auto-detected 2D/3D/surface)
-    "PLR0913", # remesh exposes independent solution, parameter, progress, and transfer controls
 ]
 "src/mmgpy/_pv_plugin.py" = [
     "PLR0904", # PyVista accessor exposes the full public API surface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,9 +189,11 @@ ignore = [
 ]
 "src/mmgpy/_remesh.py" = [
     "N801",    # class names match C++ API (mmg2d, mmg3d, mmgs)
+    "PLR0913", # public file APIs expose independent path and remesh controls
 ]
 "src/mmgpy/_mesh.py" = [
     "PLR0904", # Mesh exposes the full public API (auto-detected 2D/3D/surface)
+    "PLR0913", # remesh exposes independent solution, parameter, progress, and transfer controls
 ]
 "src/mmgpy/_pv_plugin.py" = [
     "PLR0904", # PyVista accessor exposes the full public API surface

--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -1,5 +1,6 @@
 #include "bindings.h"
 #include "mmg/common/mmgversion.h"
+#include "mmg_common.hpp"
 #include "mmg_mesh.hpp"
 #include "mmg_mesh_2d.hpp"
 #include "mmg_mesh_s.hpp"
@@ -8,10 +9,18 @@ namespace {
 // Convert a Python str or Path object to a std::variant for C++ file I/O.
 std::variant<std::string, std::filesystem::path>
 path_to_variant(const py::object &path) {
-  if (py::isinstance<py::str>(path)) {
-    return path.cast<std::string>();
+  return path_to_string(path);
+}
+
+template <typename MeshType>
+void apply_parameter_file(MeshType &mesh, py::kwargs &kwargs) {
+  if (!kwargs.contains("parameter_file")) {
+    return;
   }
-  return std::filesystem::path(path.attr("__str__")().cast<std::string>());
+  py::object path = kwargs.attr("pop")("parameter_file");
+  if (!path.is_none()) {
+    mesh.set_input_parameter_name(path_to_variant(path));
+  }
 }
 
 // MMG verbose level constants for Pythonic bool conversion
@@ -254,6 +263,7 @@ PYBIND11_MODULE(_mmgpy, m) {
       .def(
           "remesh",
           [](MmgMesh &self, py::kwargs kwargs) {
+            apply_parameter_file(self, kwargs);
             return self.remesh(kwargs_to_options(kwargs));
           },
           "Remesh the mesh in-place. Common options: hmax, hmin, hsiz, hausd, "
@@ -262,6 +272,7 @@ PYBIND11_MODULE(_mmgpy, m) {
           "remesh_levelset",
           [](MmgMesh &self, const py::array_t<double> &levelset,
              bool surface_only, py::kwargs kwargs) {
+            apply_parameter_file(self, kwargs);
             return self.remesh_levelset(levelset,
                                         levelset_options(surface_only, kwargs));
           },
@@ -454,6 +465,7 @@ PYBIND11_MODULE(_mmgpy, m) {
       .def(
           "remesh",
           [](MmgMesh2D &self, py::kwargs kwargs) {
+            apply_parameter_file(self, kwargs);
             return self.remesh(kwargs_to_options(kwargs));
           },
           "Remesh the mesh in-place. Common options: hmax, hmin, hsiz, hausd, "
@@ -462,6 +474,7 @@ PYBIND11_MODULE(_mmgpy, m) {
           "remesh_levelset",
           [](MmgMesh2D &self, const py::array_t<double> &levelset,
              bool surface_only, py::kwargs kwargs) {
+            apply_parameter_file(self, kwargs);
             return self.remesh_levelset(levelset,
                                         levelset_options(surface_only, kwargs));
           },
@@ -641,6 +654,7 @@ PYBIND11_MODULE(_mmgpy, m) {
       .def(
           "remesh",
           [](MmgMeshS &self, py::kwargs kwargs) {
+            apply_parameter_file(self, kwargs);
             return self.remesh(kwargs_to_options(kwargs));
           },
           "Remesh the mesh in-place. Common options: hmax, hmin, hsiz, hausd, "
@@ -649,6 +663,7 @@ PYBIND11_MODULE(_mmgpy, m) {
           "remesh_levelset",
           [](MmgMeshS &self, const py::array_t<double> &levelset,
              bool surface_only, py::kwargs kwargs) {
+            apply_parameter_file(self, kwargs);
             return self.remesh_levelset(levelset,
                                         levelset_options(surface_only, kwargs));
           },
@@ -687,19 +702,22 @@ PYBIND11_MODULE(_mmgpy, m) {
                   py::arg("input_sol") = py::none(),
                   py::arg("output_mesh") = py::none(),
                   py::arg("output_sol") = py::none(),
-                  py::arg("options") = py::dict());
+                  py::arg("options") = py::dict(),
+                  py::arg("parameter_file") = py::none());
 
   py::class_<mmg2d>(m, "mmg2d")
       .def_static("remesh", remesh_2d, py::arg("input_mesh"),
                   py::arg("input_sol") = py::none(),
                   py::arg("output_mesh") = py::none(),
                   py::arg("output_sol") = py::none(),
-                  py::arg("options") = py::dict());
+                  py::arg("options") = py::dict(),
+                  py::arg("parameter_file") = py::none());
 
   py::class_<mmgs>(m, "mmgs").def_static(
       "remesh", remesh_s, py::arg("input_mesh"),
       py::arg("input_sol") = py::none(), py::arg("output_mesh") = py::none(),
-      py::arg("output_sol") = py::none(), py::arg("options") = py::dict());
+      py::arg("output_sol") = py::none(), py::arg("options") = py::dict(),
+      py::arg("parameter_file") = py::none());
 
   m.attr("MMG_VERSION") = MMG_VERSION_RELEASE;
 }

--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -185,6 +185,7 @@ PYBIND11_MODULE(_mmgpy, m) {
             self.set_input_parameter_name(path_to_variant(path));
           },
           py::arg("path"))
+      .def("_apply_input_parameter_file", &MmgMesh::apply_input_parameter_file)
       .def("get_iparameter", &MmgMesh::get_iparameter, py::arg("parameter"))
       // Multi-material and level-set
       .def("set_multi_materials", &MmgMesh::set_multi_materials,
@@ -384,6 +385,8 @@ PYBIND11_MODULE(_mmgpy, m) {
             self.set_input_parameter_name(path_to_variant(path));
           },
           py::arg("path"))
+      .def("_apply_input_parameter_file",
+           &MmgMesh2D::apply_input_parameter_file)
       // Multi-material and level-set
       .def("set_multi_materials", &MmgMesh2D::set_multi_materials,
            py::arg("materials"),
@@ -585,6 +588,7 @@ PYBIND11_MODULE(_mmgpy, m) {
             self.set_input_parameter_name(path_to_variant(path));
           },
           py::arg("path"))
+      .def("_apply_input_parameter_file", &MmgMeshS::apply_input_parameter_file)
       .def("get_iparameter", &MmgMeshS::get_iparameter, py::arg("parameter"))
       // Multi-material and level-set
       .def("set_multi_materials", &MmgMeshS::set_multi_materials,

--- a/src/bindings/bindings.h
+++ b/src/bindings/bindings.h
@@ -14,14 +14,14 @@ class mmgs {};
 // MMG3D functions
 bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
                const py::object &output_mesh, const py::object &output_sol,
-               py::dict options);
+               py::dict options, const py::object &parameter_file);
 
 // MMG2D functions
 bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
                const py::object &output_mesh, const py::object &output_sol,
-               py::dict options);
+               py::dict options, const py::object &parameter_file);
 
 // MMGS functions
 bool remesh_s(const py::object &input_mesh, const py::object &input_sol,
               const py::object &output_mesh, const py::object &output_sol,
-              py::dict options);
+              py::dict options, const py::object &parameter_file);

--- a/src/bindings/mmg2d.cpp
+++ b/src/bindings/mmg2d.cpp
@@ -51,7 +51,7 @@ bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
   std::string parameter_file_str =
       parameter_file.is_none() ? "" : path_to_string(parameter_file);
   if (!parameter_file_str.empty()) {
-    validate_native_parameter_file(parameter_file_str, ".mmg2d");
+    validate_parameter_file(parameter_file_str);
   }
 
   // Initialize structures
@@ -114,11 +114,9 @@ bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
       }
     }
 
-    // Parameter-file settings are applied first so Python options override
-    // them.
-    if (!parameter_file_str.empty() && !MMG2D_parsop(mesh, met)) {
-      throw std::runtime_error("Failed to parse MMG2D parameter file: " +
-                               parameter_file_str);
+    if (!parameter_file_str.empty()) {
+      parse_parameter_file(mesh, met, parameter_file_str,
+                           MmgParameterFileKind::Mmg2D);
     }
 
     // Set all mesh options

--- a/src/bindings/mmg2d.cpp
+++ b/src/bindings/mmg2d.cpp
@@ -51,7 +51,7 @@ bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
   std::string parameter_file_str =
       parameter_file.is_none() ? "" : path_to_string(parameter_file);
   if (!parameter_file_str.empty()) {
-    validate_parameter_file(parameter_file_str);
+    validate_native_parameter_file(parameter_file_str, ".mmg2d");
   }
 
   // Initialize structures

--- a/src/bindings/mmg2d.cpp
+++ b/src/bindings/mmg2d.cpp
@@ -39,7 +39,7 @@ int mmg2d_save_mesh(MMG5_pMesh mesh, MMG5_pSol met,
 
 bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
                const py::object &output_mesh, const py::object &output_sol,
-               py::dict options) {
+               py::dict options, const py::object &parameter_file) {
   // Convert paths to strings
   std::string input_mesh_str = path_to_string(input_mesh);
   std::string input_sol_str =
@@ -48,6 +48,11 @@ bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
       output_mesh.is_none() ? "" : path_to_string(output_mesh);
   std::string output_sol_str =
       output_sol.is_none() ? "" : path_to_string(output_sol);
+  std::string parameter_file_str =
+      parameter_file.is_none() ? "" : path_to_string(parameter_file);
+  if (!parameter_file_str.empty()) {
+    validate_parameter_file(parameter_file_str);
+  }
 
   // Initialize structures
   auto [mesh, met, disp, ls] = init_mmg2d_structures();
@@ -79,6 +84,14 @@ bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
   }
   MMG2D_Set_outputMeshName(mesh, output_mesh_str.c_str());
 
+  if (!parameter_file_str.empty()) {
+    if (!MMG2D_Set_inputParamName(mesh, parameter_file_str.c_str())) {
+      cleanup_mmg2d_structures(mesh, met, disp, ls);
+      throw std::runtime_error("Failed to set MMG parameter file: " +
+                               parameter_file_str);
+    }
+  }
+
   if (!input_sol_str.empty()) {
     MMG2D_Set_inputSolName(mesh, met, input_sol_str.c_str());
   }
@@ -99,6 +112,13 @@ bool remesh_2d(const py::object &input_mesh, const py::object &input_sol,
       if (MMG2D_loadSol(mesh, met, input_sol_str.c_str()) != 1) {
         throw std::runtime_error("Failed to load solution file");
       }
+    }
+
+    // Parameter-file settings are applied first so Python options override
+    // them.
+    if (!parameter_file_str.empty() && !MMG2D_parsop(mesh, met)) {
+      throw std::runtime_error("Failed to parse MMG2D parameter file: " +
+                               parameter_file_str);
     }
 
     // Set all mesh options

--- a/src/bindings/mmg3d.cpp
+++ b/src/bindings/mmg3d.cpp
@@ -51,7 +51,7 @@ bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
   std::string parameter_file_str =
       parameter_file.is_none() ? "" : path_to_string(parameter_file);
   if (!parameter_file_str.empty()) {
-    validate_parameter_file(parameter_file_str);
+    validate_native_parameter_file(parameter_file_str, ".mmg3d");
   }
 
   // Initialize structures

--- a/src/bindings/mmg3d.cpp
+++ b/src/bindings/mmg3d.cpp
@@ -39,7 +39,7 @@ int mmg3d_save_mesh(MMG5_pMesh mesh, MMG5_pSol met,
 
 bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
                const py::object &output_mesh, const py::object &output_sol,
-               py::dict options) {
+               py::dict options, const py::object &parameter_file) {
   // Convert paths to strings
   std::string input_mesh_str = path_to_string(input_mesh);
   std::string output_mesh_str =
@@ -48,6 +48,11 @@ bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
       input_sol.is_none() ? "" : path_to_string(input_sol);
   std::string output_sol_str =
       output_sol.is_none() ? "" : path_to_string(output_sol);
+  std::string parameter_file_str =
+      parameter_file.is_none() ? "" : path_to_string(parameter_file);
+  if (!parameter_file_str.empty()) {
+    validate_parameter_file(parameter_file_str);
+  }
 
   // Initialize structures
   auto [mesh, met, disp, ls] = init_mmg3d_structures();
@@ -55,6 +60,14 @@ bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
   // Set mesh names
   MMG3D_Set_inputMeshName(mesh, input_mesh_str.c_str());
   MMG3D_Set_outputMeshName(mesh, output_mesh_str.c_str());
+
+  if (!parameter_file_str.empty()) {
+    if (!MMG3D_Set_inputParamName(mesh, parameter_file_str.c_str())) {
+      cleanup_mmg3d_structures(mesh, met, disp, ls);
+      throw std::runtime_error("Failed to set MMG parameter file: " +
+                               parameter_file_str);
+    }
+  }
 
   if (!input_sol_str.empty()) {
     MMG3D_Set_inputSolName(mesh, met, input_sol_str.c_str());
@@ -77,6 +90,13 @@ bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
       if (MMG3D_loadSol(mesh, met, input_sol_str.c_str()) != 1) {
         throw std::runtime_error("Failed to load solution file");
       }
+    }
+
+    // Parameter-file settings are applied first so Python options override
+    // them.
+    if (!parameter_file_str.empty() && !MMG3D_parsop(mesh, met)) {
+      throw std::runtime_error("Failed to parse MMG3D parameter file: " +
+                               parameter_file_str);
     }
 
     // Set all mesh options

--- a/src/bindings/mmg3d.cpp
+++ b/src/bindings/mmg3d.cpp
@@ -51,7 +51,7 @@ bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
   std::string parameter_file_str =
       parameter_file.is_none() ? "" : path_to_string(parameter_file);
   if (!parameter_file_str.empty()) {
-    validate_native_parameter_file(parameter_file_str, ".mmg3d");
+    validate_parameter_file(parameter_file_str);
   }
 
   // Initialize structures
@@ -92,11 +92,9 @@ bool remesh_3d(const py::object &input_mesh, const py::object &input_sol,
       }
     }
 
-    // Parameter-file settings are applied first so Python options override
-    // them.
-    if (!parameter_file_str.empty() && !MMG3D_parsop(mesh, met)) {
-      throw std::runtime_error("Failed to parse MMG3D parameter file: " +
-                               parameter_file_str);
+    if (!parameter_file_str.empty()) {
+      parse_parameter_file(mesh, met, parameter_file_str,
+                           MmgParameterFileKind::Mmg3D);
     }
 
     // Set all mesh options

--- a/src/bindings/mmg_common.cpp
+++ b/src/bindings/mmg_common.cpp
@@ -1,5 +1,6 @@
 #include "mmg_common.hpp"
 
+#include "mmg/mmg2d/libmmg2d.h"
 #include "mmg/mmgs/libmmgs.h"
 
 #include <algorithm>
@@ -28,6 +29,79 @@ typedef SSIZE_T ssize_t;
 
 namespace {
 
+using SetIntegerParameter = int (*)(MMG5_pMesh, MMG5_pSol, int, MMG5_int);
+using SetLocalParameter = int (*)(MMG5_pMesh, MMG5_pSol, int, MMG5_int, double,
+                                  double, double);
+using SetMultiMaterial = int (*)(MMG5_pMesh, MMG5_pSol, MMG5_int, int, MMG5_int,
+                                 MMG5_int);
+using SetLsBaseReference = int (*)(MMG5_pMesh, MMG5_pSol, MMG5_int);
+
+struct ParameterApi {
+  const char *name;
+  int local_parameter_count;
+  int material_count;
+  int base_reference_count;
+  int secondary_entity_type;
+  const char *secondary_entity;
+  const char *secondary_entities;
+  SetIntegerParameter set_integer;
+  SetLocalParameter set_local;
+  SetMultiMaterial set_material;
+  SetLsBaseReference set_base_reference;
+};
+
+const ParameterApi &parameter_api(MmgParameterFileKind kind) {
+  static const ParameterApi mmg2d{
+      "MMG2D",
+      MMG2D_IPARAM_numberOfLocalParam,
+      MMG2D_IPARAM_numberOfMat,
+      MMG2D_IPARAM_numberOfLSBaseReferences,
+      MMG5_Edg,
+      "edge",
+      "edges",
+      &MMG2D_Set_iparameter,
+      &MMG2D_Set_localParameter,
+      &MMG2D_Set_multiMat,
+      &MMG2D_Set_lsBaseReference,
+  };
+  static const ParameterApi mmg3d{
+      "MMG3D",
+      MMG3D_IPARAM_numberOfLocalParam,
+      MMG3D_IPARAM_numberOfMat,
+      MMG3D_IPARAM_numberOfLSBaseReferences,
+      MMG5_Tetrahedron,
+      "tetrahedron",
+      "tetrahedra",
+      &MMG3D_Set_iparameter,
+      &MMG3D_Set_localParameter,
+      &MMG3D_Set_multiMat,
+      &MMG3D_Set_lsBaseReference,
+  };
+  static const ParameterApi mmgs{
+      "MMGS",
+      MMGS_IPARAM_numberOfLocalParam,
+      MMGS_IPARAM_numberOfMat,
+      MMGS_IPARAM_numberOfLSBaseReferences,
+      MMG5_Noentity,
+      nullptr,
+      nullptr,
+      &MMGS_Set_iparameter,
+      &MMGS_Set_localParameter,
+      &MMGS_Set_multiMat,
+      &MMGS_Set_lsBaseReference,
+  };
+
+  switch (kind) {
+  case MmgParameterFileKind::Mmg2D:
+    return mmg2d;
+  case MmgParameterFileKind::Mmg3D:
+    return mmg3d;
+  case MmgParameterFileKind::MmgS:
+    return mmgs;
+  }
+  throw std::logic_error("Unknown MMG parameter-file kind");
+}
+
 std::string lowercase(std::string value) {
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return std::tolower(c); });
@@ -45,11 +119,103 @@ T read_parameter_value(std::istream &input, const std::string &filename,
   return value;
 }
 
-void require_mmgs_success(int success, const std::string &filename,
-                          const std::string &operation) {
+void require_parameter_success(const ParameterApi &api, int success,
+                               const std::string &filename,
+                               const std::string &operation) {
   if (!success) {
-    throw std::runtime_error("Invalid MMGS parameter file '" + filename +
-                             "': failed to " + operation);
+    throw std::runtime_error("Invalid " + std::string(api.name) +
+                             " parameter file '" + filename + "': failed to " +
+                             operation);
+  }
+}
+
+int parameter_entity_type(const ParameterApi &api, const std::string &entity,
+                          const std::string &filename) {
+  if (entity == "triangle" || entity == "triangles") {
+    return MMG5_Triangle;
+  }
+  if (api.secondary_entity != nullptr &&
+      (entity == api.secondary_entity || entity == api.secondary_entities)) {
+    return api.secondary_entity_type;
+  }
+  throw std::runtime_error("Invalid " + std::string(api.name) +
+                           " parameter file '" + filename +
+                           "': unsupported entity type '" + entity + "'");
+}
+
+void parse_local_parameters(std::istream &input, MMG5_pMesh mesh, MMG5_pSol met,
+                            const std::string &filename,
+                            const ParameterApi &api) {
+  int count = read_parameter_value<int>(input, filename, "parameter count");
+  require_parameter_success(
+      api, api.set_integer(mesh, met, api.local_parameter_count, count),
+      filename, "set the local-parameter count");
+  for (int i = 0; i < count; ++i) {
+    MMG5_int ref =
+        read_parameter_value<MMG5_int>(input, filename, "entity reference");
+    std::string entity = lowercase(
+        read_parameter_value<std::string>(input, filename, "entity type"));
+    double hmin = read_parameter_value<double>(input, filename, "minimum size");
+    double hmax = read_parameter_value<double>(input, filename, "maximum size");
+    double hausd =
+        read_parameter_value<double>(input, filename, "Hausdorff distance");
+    int entity_type = parameter_entity_type(api, entity, filename);
+    require_parameter_success(
+        api, api.set_local(mesh, met, entity_type, ref, hmin, hmax, hausd),
+        filename, "set local parameter for reference " + std::to_string(ref));
+  }
+}
+
+void parse_base_references(std::istream &input, MMG5_pMesh mesh, MMG5_pSol met,
+                           const std::string &filename,
+                           const ParameterApi &api) {
+  int count =
+      read_parameter_value<int>(input, filename, "LS base-reference count");
+  require_parameter_success(
+      api, api.set_integer(mesh, met, api.base_reference_count, count),
+      filename, "set the LS base-reference count");
+  for (int i = 0; i < count; ++i) {
+    MMG5_int ref =
+        read_parameter_value<MMG5_int>(input, filename, "LS base reference");
+    require_parameter_success(api, api.set_base_reference(mesh, met, ref),
+                              filename,
+                              "set LS base reference " + std::to_string(ref));
+  }
+}
+
+void parse_materials(std::istream &input, MMG5_pMesh mesh, MMG5_pSol met,
+                     const std::string &filename, const ParameterApi &api) {
+  int count = read_parameter_value<int>(input, filename, "LS reference count");
+  require_parameter_success(
+      api, api.set_integer(mesh, met, api.material_count, count), filename,
+      "set the LS reference count");
+  for (int i = 0; i < count; ++i) {
+    MMG5_int ref =
+        read_parameter_value<MMG5_int>(input, filename, "LS reference");
+    std::string split_token = read_parameter_value<std::string>(
+        input, filename, "'nosplit' or inside reference");
+    int split = MMG5_MMAT_NoSplit;
+    MMG5_int ref_minus = ref;
+    MMG5_int ref_plus = ref;
+    if (lowercase(split_token) != "nosplit") {
+      try {
+        std::size_t parsed = 0;
+        ref_minus = static_cast<MMG5_int>(std::stoll(split_token, &parsed, 10));
+        if (parsed != split_token.size()) {
+          throw std::invalid_argument("trailing characters");
+        }
+      } catch (const std::exception &) {
+        throw std::runtime_error(
+            "Invalid " + std::string(api.name) + " parameter file '" +
+            filename + "': expected 'nosplit' or an inside reference");
+      }
+      ref_plus =
+          read_parameter_value<MMG5_int>(input, filename, "outside reference");
+      split = MMG5_MMAT_Split;
+    }
+    require_parameter_success(
+        api, api.set_material(mesh, met, ref, split, ref_minus, ref_plus),
+        filename, "set LS reference " + std::to_string(ref));
   }
 }
 
@@ -68,114 +234,25 @@ void validate_parameter_file(const std::string &filename) {
   }
 }
 
-void validate_native_parameter_file(const std::string &filename,
-                                    const std::string &parser_extension) {
-  constexpr std::size_t buffer_capacity = 256;
-
-  // Mirror MMG5_Get_filenameExt: it only recognizes '/' as a path separator,
-  // treats a leading dot and the suffix ".o" as no extension, then appends the
-  // engine-specific extension. Both the initial strcpy and later strcat must
-  // leave room for the null terminator.
-  std::size_t stem_length = filename.size();
-  std::size_t dot = filename.find_last_of('.');
-  std::size_t slash = filename.find_last_of('/');
-  bool has_extension = dot != std::string::npos && dot != 0 &&
-                       (slash == std::string::npos || slash < dot) &&
-                       filename.substr(dot) != ".o";
-  if (has_extension) {
-    stem_length = dot;
-  }
-
-  if (filename.size() >= buffer_capacity ||
-      stem_length + parser_extension.size() >= buffer_capacity) {
-    throw std::runtime_error(
-        "MMG parameter file path is too long for the native parser: " +
-        filename);
-  }
+void parse_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,
+                          const std::string &filename,
+                          MmgParameterFileKind kind) {
   validate_parameter_file(filename);
-}
-
-void parse_mmgs_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,
-                               const std::string &filename) {
-  validate_parameter_file(filename);
+  const ParameterApi &api = parameter_api(kind);
   std::ifstream input(filename);
   std::string section;
 
   while (input >> section) {
     section = lowercase(section);
     if (section == "parameters") {
-      int count = read_parameter_value<int>(input, filename, "parameter count");
-      require_mmgs_success(
-          MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_numberOfLocalParam, count),
-          filename, "set the local-parameter count");
-      for (int i = 0; i < count; ++i) {
-        MMG5_int ref =
-            read_parameter_value<MMG5_int>(input, filename, "entity reference");
-        std::string entity = lowercase(
-            read_parameter_value<std::string>(input, filename, "entity type"));
-        double hmin =
-            read_parameter_value<double>(input, filename, "minimum size");
-        double hmax =
-            read_parameter_value<double>(input, filename, "maximum size");
-        double hausd =
-            read_parameter_value<double>(input, filename, "Hausdorff distance");
-        if (entity != "triangle" && entity != "triangles") {
-          throw std::runtime_error(
-              "Invalid MMGS parameter file '" + filename +
-              "': local parameters only support triangle references");
-        }
-        require_mmgs_success(MMGS_Set_localParameter(mesh, met, MMG5_Triangle,
-                                                     ref, hmin, hmax, hausd),
-                             filename,
-                             "set local parameter for reference " +
-                                 std::to_string(ref));
-      }
+      parse_local_parameters(input, mesh, met, filename, api);
     } else if (section == "lsbasereferences") {
-      int count =
-          read_parameter_value<int>(input, filename, "LS base-reference count");
-      require_mmgs_success(
-          MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_numberOfLSBaseReferences,
-                              count),
-          filename, "set the LS base-reference count");
-      for (int i = 0; i < count; ++i) {
-        MMG5_int ref = read_parameter_value<MMG5_int>(input, filename,
-                                                      "LS base reference");
-        require_mmgs_success(MMGS_Set_lsBaseReference(mesh, met, ref), filename,
-                             "set LS base reference " + std::to_string(ref));
-      }
+      parse_base_references(input, mesh, met, filename, api);
     } else if (section == "lsreferences") {
-      int count =
-          read_parameter_value<int>(input, filename, "LS reference count");
-      require_mmgs_success(
-          MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_numberOfMat, count),
-          filename, "set the LS reference count");
-      for (int i = 0; i < count; ++i) {
-        MMG5_int ref =
-            read_parameter_value<MMG5_int>(input, filename, "LS reference");
-        std::string split_token = read_parameter_value<std::string>(
-            input, filename, "'nosplit' or inside reference");
-        int split = MMG5_MMAT_NoSplit;
-        MMG5_int ref_minus = ref;
-        MMG5_int ref_plus = ref;
-        if (lowercase(split_token) != "nosplit") {
-          try {
-            ref_minus = static_cast<MMG5_int>(std::stoll(split_token));
-          } catch (const std::exception &) {
-            throw std::runtime_error("Invalid MMGS parameter file '" +
-                                     filename +
-                                     "': expected 'nosplit' or "
-                                     "an inside reference");
-          }
-          ref_plus = read_parameter_value<MMG5_int>(input, filename,
-                                                    "outside reference");
-          split = MMG5_MMAT_Split;
-        }
-        require_mmgs_success(
-            MMGS_Set_multiMat(mesh, met, ref, split, ref_minus, ref_plus),
-            filename, "set LS reference " + std::to_string(ref));
-      }
+      parse_materials(input, mesh, met, filename, api);
     } else {
-      throw std::runtime_error("Invalid MMGS parameter file '" + filename +
+      throw std::runtime_error("Invalid " + std::string(api.name) +
+                               " parameter file '" + filename +
                                "': unknown section '" + section + "'");
     }
   }

--- a/src/bindings/mmg_common.cpp
+++ b/src/bindings/mmg_common.cpp
@@ -68,6 +68,33 @@ void validate_parameter_file(const std::string &filename) {
   }
 }
 
+void validate_native_parameter_file(const std::string &filename,
+                                    const std::string &parser_extension) {
+  constexpr std::size_t buffer_capacity = 256;
+
+  // Mirror MMG5_Get_filenameExt: it only recognizes '/' as a path separator,
+  // treats a leading dot and the suffix ".o" as no extension, then appends the
+  // engine-specific extension. Both the initial strcpy and later strcat must
+  // leave room for the null terminator.
+  std::size_t stem_length = filename.size();
+  std::size_t dot = filename.find_last_of('.');
+  std::size_t slash = filename.find_last_of('/');
+  bool has_extension = dot != std::string::npos && dot != 0 &&
+                       (slash == std::string::npos || slash < dot) &&
+                       filename.substr(dot) != ".o";
+  if (has_extension) {
+    stem_length = dot;
+  }
+
+  if (filename.size() >= buffer_capacity ||
+      stem_length + parser_extension.size() >= buffer_capacity) {
+    throw std::runtime_error(
+        "MMG parameter file path is too long for the native parser: " +
+        filename);
+  }
+  validate_parameter_file(filename);
+}
+
 void parse_mmgs_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,
                                const std::string &filename) {
   validate_parameter_file(filename);

--- a/src/bindings/mmg_common.cpp
+++ b/src/bindings/mmg_common.cpp
@@ -1,7 +1,11 @@
 #include "mmg_common.hpp"
 
+#include "mmg/mmgs/libmmgs.h"
+
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
+#include <fstream>
 #include <regex>
 #include <sstream>
 
@@ -21,6 +25,134 @@ typedef SSIZE_T ssize_t;
 #include <cstdlib>
 #include <unistd.h>
 #endif
+
+namespace {
+
+std::string lowercase(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return value;
+}
+
+template <typename T>
+T read_parameter_value(std::istream &input, const std::string &filename,
+                       const char *description) {
+  T value{};
+  if (!(input >> value)) {
+    throw std::runtime_error("Invalid MMG parameter file '" + filename +
+                             "': expected " + description);
+  }
+  return value;
+}
+
+void require_mmgs_success(int success, const std::string &filename,
+                          const std::string &operation) {
+  if (!success) {
+    throw std::runtime_error("Invalid MMGS parameter file '" + filename +
+                             "': failed to " + operation);
+  }
+}
+
+} // namespace
+
+void validate_parameter_file(const std::string &filename) {
+  std::error_code error;
+  bool is_file = std::filesystem::is_regular_file(filename, error);
+  if (error || !is_file) {
+    throw std::runtime_error("MMG parameter file not found: " + filename);
+  }
+
+  std::ifstream input(filename);
+  if (!input.is_open()) {
+    throw std::runtime_error("MMG parameter file is not readable: " + filename);
+  }
+}
+
+void parse_mmgs_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,
+                               const std::string &filename) {
+  validate_parameter_file(filename);
+  std::ifstream input(filename);
+  std::string section;
+
+  while (input >> section) {
+    section = lowercase(section);
+    if (section == "parameters") {
+      int count = read_parameter_value<int>(input, filename, "parameter count");
+      require_mmgs_success(
+          MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_numberOfLocalParam, count),
+          filename, "set the local-parameter count");
+      for (int i = 0; i < count; ++i) {
+        MMG5_int ref =
+            read_parameter_value<MMG5_int>(input, filename, "entity reference");
+        std::string entity = lowercase(
+            read_parameter_value<std::string>(input, filename, "entity type"));
+        double hmin =
+            read_parameter_value<double>(input, filename, "minimum size");
+        double hmax =
+            read_parameter_value<double>(input, filename, "maximum size");
+        double hausd =
+            read_parameter_value<double>(input, filename, "Hausdorff distance");
+        if (entity != "triangle" && entity != "triangles") {
+          throw std::runtime_error(
+              "Invalid MMGS parameter file '" + filename +
+              "': local parameters only support triangle references");
+        }
+        require_mmgs_success(MMGS_Set_localParameter(mesh, met, MMG5_Triangle,
+                                                     ref, hmin, hmax, hausd),
+                             filename,
+                             "set local parameter for reference " +
+                                 std::to_string(ref));
+      }
+    } else if (section == "lsbasereferences") {
+      int count =
+          read_parameter_value<int>(input, filename, "LS base-reference count");
+      require_mmgs_success(
+          MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_numberOfLSBaseReferences,
+                              count),
+          filename, "set the LS base-reference count");
+      for (int i = 0; i < count; ++i) {
+        MMG5_int ref = read_parameter_value<MMG5_int>(input, filename,
+                                                      "LS base reference");
+        require_mmgs_success(MMGS_Set_lsBaseReference(mesh, met, ref), filename,
+                             "set LS base reference " + std::to_string(ref));
+      }
+    } else if (section == "lsreferences") {
+      int count =
+          read_parameter_value<int>(input, filename, "LS reference count");
+      require_mmgs_success(
+          MMGS_Set_iparameter(mesh, met, MMGS_IPARAM_numberOfMat, count),
+          filename, "set the LS reference count");
+      for (int i = 0; i < count; ++i) {
+        MMG5_int ref =
+            read_parameter_value<MMG5_int>(input, filename, "LS reference");
+        std::string split_token = read_parameter_value<std::string>(
+            input, filename, "'nosplit' or inside reference");
+        int split = MMG5_MMAT_NoSplit;
+        MMG5_int ref_minus = ref;
+        MMG5_int ref_plus = ref;
+        if (lowercase(split_token) != "nosplit") {
+          try {
+            ref_minus = static_cast<MMG5_int>(std::stoll(split_token));
+          } catch (const std::exception &) {
+            throw std::runtime_error("Invalid MMGS parameter file '" +
+                                     filename +
+                                     "': expected 'nosplit' or "
+                                     "an inside reference");
+          }
+          ref_plus = read_parameter_value<MMG5_int>(input, filename,
+                                                    "outside reference");
+          split = MMG5_MMAT_Split;
+        }
+        require_mmgs_success(
+            MMGS_Set_multiMat(mesh, met, ref, split, ref_minus, ref_plus),
+            filename, "set LS reference " + std::to_string(ref));
+      }
+    } else {
+      throw std::runtime_error("Invalid MMGS parameter file '" + filename +
+                               "': unknown section '" + section + "'");
+    }
+  }
+}
 
 // StderrCapture implementation using temporary files.
 // Unlike pipes, temp files have no buffer limit, so MMG can write
@@ -178,12 +310,8 @@ std::vector<std::string> parse_mmg_warnings(const std::string &output) {
 }
 
 std::string path_to_string(const py::object &path) {
-  if (py::isinstance<py::str>(path)) {
-    return path.cast<std::string>();
-  } else {
-    // Assume it's a Path object and convert to string
-    return path.attr("__str__")().cast<std::string>();
-  }
+  py::object filesystem_path = py::module_::import("os").attr("fspath")(path);
+  return filesystem_path.cast<std::string>();
 }
 
 py::dict prepare_levelset_options(const py::dict &options) {

--- a/src/bindings/mmg_common.hpp
+++ b/src/bindings/mmg_common.hpp
@@ -119,6 +119,14 @@ void set_mesh_options_surface(MMG5_pMesh mesh, MMG5_pSol met,
 
 std::string path_to_string(const py::object &path);
 
+// Validate that an MMG parameter file exists and can be opened for reading.
+void validate_parameter_file(const std::string &filename);
+
+// MMGS keeps its native parameter-file parser private, unlike MMG2D/MMG3D.
+// Parse the same public file format and apply it through the public MMGS API.
+void parse_mmgs_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,
+                               const std::string &filename);
+
 // Select the requested level-set mode and explicitly clear the inactive mode.
 py::dict prepare_levelset_options(const py::dict &options);
 

--- a/src/bindings/mmg_common.hpp
+++ b/src/bindings/mmg_common.hpp
@@ -119,19 +119,13 @@ void set_mesh_options_surface(MMG5_pMesh mesh, MMG5_pSol met,
 
 std::string path_to_string(const py::object &path);
 
-// Validate that an MMG parameter file exists and can be opened for reading.
 void validate_parameter_file(const std::string &filename);
 
-// Validate a file before passing its name to MMG2D/MMG3D's native parser.
-// Those parsers use fixed 256-byte stack buffers for the original filename
-// and for the filename after replacing its extension.
-void validate_native_parameter_file(const std::string &filename,
-                                    const std::string &parser_extension);
+enum class MmgParameterFileKind { Mmg2D, Mmg3D, MmgS };
 
-// MMGS keeps its native parameter-file parser private, unlike MMG2D/MMG3D.
-// Parse the same public file format and apply it through the public MMGS API.
-void parse_mmgs_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,
-                               const std::string &filename);
+void parse_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,
+                          const std::string &filename,
+                          MmgParameterFileKind kind);
 
 // Select the requested level-set mode and explicitly clear the inactive mode.
 py::dict prepare_levelset_options(const py::dict &options);

--- a/src/bindings/mmg_common.hpp
+++ b/src/bindings/mmg_common.hpp
@@ -122,6 +122,12 @@ std::string path_to_string(const py::object &path);
 // Validate that an MMG parameter file exists and can be opened for reading.
 void validate_parameter_file(const std::string &filename);
 
+// Validate a file before passing its name to MMG2D/MMG3D's native parser.
+// Those parsers use fixed 256-byte stack buffers for the original filename
+// and for the filename after replacing its extension.
+void validate_native_parameter_file(const std::string &filename,
+                                    const std::string &parser_extension);
+
 // MMGS keeps its native parameter-file parser private, unlike MMG2D/MMG3D.
 // Parse the same public file format and apply it through the public MMGS API.
 void parse_mmgs_parameter_file(MMG5_pMesh mesh, MMG5_pSol met,

--- a/src/bindings/mmg_mesh.cpp
+++ b/src/bindings/mmg_mesh.cpp
@@ -1060,9 +1060,7 @@ void MmgMesh::set_input_parameter_name(
     const std::variant<std::string, std::filesystem::path> &filename) {
   check_not_corrupted("set input parameter name");
   std::string fname = variant_to_string(filename);
-  if (!std::filesystem::is_regular_file(fname)) {
-    throw std::runtime_error("MMG parameter file not found: " + fname);
-  }
+  validate_parameter_file(fname);
   if (!MMG3D_Set_inputParamName(mesh, fname.c_str())) {
     throw std::runtime_error("Failed to set MMG parameter file: " + fname);
   }

--- a/src/bindings/mmg_mesh.cpp
+++ b/src/bindings/mmg_mesh.cpp
@@ -1060,21 +1060,20 @@ void MmgMesh::set_input_parameter_name(
     const std::variant<std::string, std::filesystem::path> &filename) {
   check_not_corrupted("set input parameter name");
   std::string fname = variant_to_string(filename);
-  validate_native_parameter_file(fname, ".mmg3d");
+  validate_parameter_file(fname);
   if (!MMG3D_Set_inputParamName(mesh, fname.c_str())) {
     throw std::runtime_error("Failed to set MMG parameter file: " + fname);
   }
-  has_input_parameter_file_ = true;
+  input_parameter_file_ = fname;
 }
 
 void MmgMesh::apply_input_parameter_file() {
-  if (!has_input_parameter_file_) {
+  if (input_parameter_file_.empty()) {
     return;
   }
-  if (!MMG3D_parsop(mesh, met)) {
-    throw std::runtime_error("Failed to parse MMG3D parameter file");
-  }
-  has_input_parameter_file_ = false;
+  parse_parameter_file(mesh, met, input_parameter_file_,
+                       MmgParameterFileKind::Mmg3D);
+  input_parameter_file_.clear();
 }
 
 int MmgMesh::get_iparameter(MMG5_int parameter) const {

--- a/src/bindings/mmg_mesh.cpp
+++ b/src/bindings/mmg_mesh.cpp
@@ -1060,11 +1060,21 @@ void MmgMesh::set_input_parameter_name(
     const std::variant<std::string, std::filesystem::path> &filename) {
   check_not_corrupted("set input parameter name");
   std::string fname = variant_to_string(filename);
-  validate_parameter_file(fname);
+  validate_native_parameter_file(fname, ".mmg3d");
   if (!MMG3D_Set_inputParamName(mesh, fname.c_str())) {
     throw std::runtime_error("Failed to set MMG parameter file: " + fname);
   }
   has_input_parameter_file_ = true;
+}
+
+void MmgMesh::apply_input_parameter_file() {
+  if (!has_input_parameter_file_) {
+    return;
+  }
+  if (!MMG3D_parsop(mesh, met)) {
+    throw std::runtime_error("Failed to parse MMG3D parameter file");
+  }
+  has_input_parameter_file_ = false;
 }
 
 int MmgMesh::get_iparameter(MMG5_int parameter) const {
@@ -1517,12 +1527,7 @@ py::dict MmgMesh::remesh(const py::dict &options) {
   check_not_corrupted("remesh");
   RemeshStats before = collect_mesh_stats_3d(mesh, met);
 
-  if (has_input_parameter_file_) {
-    if (!MMG3D_parsop(mesh, met)) {
-      throw std::runtime_error("Failed to parse MMG3D parameter file");
-    }
-    has_input_parameter_file_ = false;
-  }
+  apply_input_parameter_file();
   set_mesh_options_3D(mesh, met, options);
 
   // Capture stderr to collect MMG warnings
@@ -1566,12 +1571,7 @@ py::dict MmgMesh::remesh_levelset(const py::array_t<double> &levelset,
 
   set_field("levelset", levelset);
   py::dict ls_options = prepare_levelset_options(options);
-  if (has_input_parameter_file_) {
-    if (!MMG3D_parsop(mesh, met)) {
-      throw std::runtime_error("Failed to parse MMG3D parameter file");
-    }
-    has_input_parameter_file_ = false;
-  }
+  apply_input_parameter_file();
   set_mesh_options_3D(mesh, met, ls_options);
 
   // Capture stderr to collect MMG warnings

--- a/src/bindings/mmg_mesh.hpp
+++ b/src/bindings/mmg_mesh.hpp
@@ -97,6 +97,7 @@ public:
   void set_local_parameters(const py::list &parameters);
   void set_input_parameter_name(
       const std::variant<std::string, std::filesystem::path> &filename);
+  void apply_input_parameter_file();
   int get_iparameter(MMG5_int parameter) const;
 
   // Multi-material and level-set

--- a/src/bindings/mmg_mesh.hpp
+++ b/src/bindings/mmg_mesh.hpp
@@ -192,7 +192,7 @@ private:
   void check_not_corrupted(const char *operation) const;
 
   bool corrupted_ = false;
-  bool has_input_parameter_file_ = false;
+  std::string input_parameter_file_;
 };
 
 #endif // MMG_MESH_HPP

--- a/src/bindings/mmg_mesh_2d.cpp
+++ b/src/bindings/mmg_mesh_2d.cpp
@@ -676,9 +676,7 @@ void MmgMesh2D::set_input_parameter_name(
     const std::variant<std::string, std::filesystem::path> &filename) {
   check_not_corrupted("set input parameter name");
   std::string fname = variant_to_string(filename);
-  if (!std::filesystem::is_regular_file(fname)) {
-    throw std::runtime_error("MMG parameter file not found: " + fname);
-  }
+  validate_parameter_file(fname);
   if (!MMG2D_Set_inputParamName(mesh, fname.c_str())) {
     throw std::runtime_error("Failed to set MMG parameter file: " + fname);
   }

--- a/src/bindings/mmg_mesh_2d.cpp
+++ b/src/bindings/mmg_mesh_2d.cpp
@@ -676,21 +676,20 @@ void MmgMesh2D::set_input_parameter_name(
     const std::variant<std::string, std::filesystem::path> &filename) {
   check_not_corrupted("set input parameter name");
   std::string fname = variant_to_string(filename);
-  validate_native_parameter_file(fname, ".mmg2d");
+  validate_parameter_file(fname);
   if (!MMG2D_Set_inputParamName(mesh, fname.c_str())) {
     throw std::runtime_error("Failed to set MMG parameter file: " + fname);
   }
-  has_input_parameter_file_ = true;
+  input_parameter_file_ = fname;
 }
 
 void MmgMesh2D::apply_input_parameter_file() {
-  if (!has_input_parameter_file_) {
+  if (input_parameter_file_.empty()) {
     return;
   }
-  if (!MMG2D_parsop(mesh, met)) {
-    throw std::runtime_error("Failed to parse MMG2D parameter file");
-  }
-  has_input_parameter_file_ = false;
+  parse_parameter_file(mesh, met, input_parameter_file_,
+                       MmgParameterFileKind::Mmg2D);
+  input_parameter_file_.clear();
 }
 
 // Multi-material and level-set

--- a/src/bindings/mmg_mesh_2d.cpp
+++ b/src/bindings/mmg_mesh_2d.cpp
@@ -676,11 +676,21 @@ void MmgMesh2D::set_input_parameter_name(
     const std::variant<std::string, std::filesystem::path> &filename) {
   check_not_corrupted("set input parameter name");
   std::string fname = variant_to_string(filename);
-  validate_parameter_file(fname);
+  validate_native_parameter_file(fname, ".mmg2d");
   if (!MMG2D_Set_inputParamName(mesh, fname.c_str())) {
     throw std::runtime_error("Failed to set MMG parameter file: " + fname);
   }
   has_input_parameter_file_ = true;
+}
+
+void MmgMesh2D::apply_input_parameter_file() {
+  if (!has_input_parameter_file_) {
+    return;
+  }
+  if (!MMG2D_parsop(mesh, met)) {
+    throw std::runtime_error("Failed to parse MMG2D parameter file");
+  }
+  has_input_parameter_file_ = false;
 }
 
 // Multi-material and level-set
@@ -1093,12 +1103,7 @@ py::dict MmgMesh2D::remesh(const py::dict &options) {
   check_not_corrupted("remesh");
   RemeshStats before = collect_mesh_stats_2d(mesh, met);
 
-  if (has_input_parameter_file_) {
-    if (!MMG2D_parsop(mesh, met)) {
-      throw std::runtime_error("Failed to parse MMG2D parameter file");
-    }
-    has_input_parameter_file_ = false;
-  }
+  apply_input_parameter_file();
   set_mesh_options_2D(mesh, met, options);
 
   // Capture stderr to collect MMG warnings
@@ -1145,12 +1150,7 @@ py::dict MmgMesh2D::remesh_levelset(const py::array_t<double> &levelset,
 
   set_field("levelset", levelset);
   py::dict ls_options = prepare_levelset_options(options);
-  if (has_input_parameter_file_) {
-    if (!MMG2D_parsop(mesh, met)) {
-      throw std::runtime_error("Failed to parse MMG2D parameter file");
-    }
-    has_input_parameter_file_ = false;
-  }
+  apply_input_parameter_file();
   set_mesh_options_2D(mesh, met, ls_options);
 
   // Capture stderr to collect MMG warnings

--- a/src/bindings/mmg_mesh_2d.hpp
+++ b/src/bindings/mmg_mesh_2d.hpp
@@ -158,7 +158,7 @@ private:
   void check_not_corrupted(const char *operation) const;
 
   bool corrupted_ = false;
-  bool has_input_parameter_file_ = false;
+  std::string input_parameter_file_;
 };
 
 #endif // MMG_MESH_2D_HPP

--- a/src/bindings/mmg_mesh_2d.hpp
+++ b/src/bindings/mmg_mesh_2d.hpp
@@ -81,6 +81,7 @@ public:
   void set_local_parameters(const py::list &parameters);
   void set_input_parameter_name(
       const std::variant<std::string, std::filesystem::path> &filename);
+  void apply_input_parameter_file();
 
   // Multi-material and level-set
   void set_multi_materials(const py::list &materials);

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -702,12 +702,11 @@ void MmgMeshS::set_input_parameter_name(
     const std::variant<std::string, std::filesystem::path> &filename) {
   check_not_corrupted("set input parameter name");
   std::string fname = variant_to_string(filename);
-  if (!std::filesystem::is_regular_file(fname)) {
-    throw std::runtime_error("MMG parameter file not found: " + fname);
-  }
+  validate_parameter_file(fname);
   if (!MMGS_Set_inputParamName(mesh, fname.c_str())) {
     throw std::runtime_error("Failed to set MMG parameter file: " + fname);
   }
+  input_parameter_file_ = fname;
 }
 
 int MmgMeshS::get_iparameter(MMG5_int parameter) const {
@@ -1074,6 +1073,10 @@ py::dict MmgMeshS::remesh(const py::dict &options) {
   check_not_corrupted("remesh");
   RemeshStats before = collect_mesh_stats_surface(mesh, met);
 
+  if (!input_parameter_file_.empty()) {
+    parse_mmgs_parameter_file(mesh, met, input_parameter_file_);
+    input_parameter_file_.clear();
+  }
   set_mesh_options_surface(mesh, met, options);
 
   // Capture stderr to collect MMG warnings
@@ -1120,6 +1123,10 @@ py::dict MmgMeshS::remesh_levelset(const py::array_t<double> &levelset,
 
   set_field("levelset", levelset);
   py::dict ls_options = prepare_levelset_options(options);
+  if (!input_parameter_file_.empty()) {
+    parse_mmgs_parameter_file(mesh, met, input_parameter_file_);
+    input_parameter_file_.clear();
+  }
   set_mesh_options_surface(mesh, met, ls_options);
 
   // Capture stderr to collect MMG warnings

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -713,7 +713,8 @@ void MmgMeshS::apply_input_parameter_file() {
   if (input_parameter_file_.empty()) {
     return;
   }
-  parse_mmgs_parameter_file(mesh, met, input_parameter_file_);
+  parse_parameter_file(mesh, met, input_parameter_file_,
+                       MmgParameterFileKind::MmgS);
   input_parameter_file_.clear();
 }
 

--- a/src/bindings/mmg_mesh_s.cpp
+++ b/src/bindings/mmg_mesh_s.cpp
@@ -709,6 +709,14 @@ void MmgMeshS::set_input_parameter_name(
   input_parameter_file_ = fname;
 }
 
+void MmgMeshS::apply_input_parameter_file() {
+  if (input_parameter_file_.empty()) {
+    return;
+  }
+  parse_mmgs_parameter_file(mesh, met, input_parameter_file_);
+  input_parameter_file_.clear();
+}
+
 int MmgMeshS::get_iparameter(MMG5_int parameter) const {
   check_not_corrupted("get integer parameter");
   return MMGS_Get_iparameter(mesh, parameter);
@@ -1073,10 +1081,7 @@ py::dict MmgMeshS::remesh(const py::dict &options) {
   check_not_corrupted("remesh");
   RemeshStats before = collect_mesh_stats_surface(mesh, met);
 
-  if (!input_parameter_file_.empty()) {
-    parse_mmgs_parameter_file(mesh, met, input_parameter_file_);
-    input_parameter_file_.clear();
-  }
+  apply_input_parameter_file();
   set_mesh_options_surface(mesh, met, options);
 
   // Capture stderr to collect MMG warnings
@@ -1123,10 +1128,7 @@ py::dict MmgMeshS::remesh_levelset(const py::array_t<double> &levelset,
 
   set_field("levelset", levelset);
   py::dict ls_options = prepare_levelset_options(options);
-  if (!input_parameter_file_.empty()) {
-    parse_mmgs_parameter_file(mesh, met, input_parameter_file_);
-    input_parameter_file_.clear();
-  }
+  apply_input_parameter_file();
   set_mesh_options_surface(mesh, met, ls_options);
 
   // Capture stderr to collect MMG warnings

--- a/src/bindings/mmg_mesh_s.hpp
+++ b/src/bindings/mmg_mesh_s.hpp
@@ -152,6 +152,7 @@ private:
   void check_not_corrupted(const char *operation) const;
 
   bool corrupted_ = false;
+  std::string input_parameter_file_;
 };
 
 #endif // MMG_MESH_S_HPP

--- a/src/bindings/mmg_mesh_s.hpp
+++ b/src/bindings/mmg_mesh_s.hpp
@@ -79,6 +79,7 @@ public:
   void set_local_parameters(const py::list &parameters);
   void set_input_parameter_name(
       const std::variant<std::string, std::filesystem::path> &filename);
+  void apply_input_parameter_file();
   int get_iparameter(MMG5_int parameter) const;
 
   // Multi-material and level-set

--- a/src/bindings/mmgs.cpp
+++ b/src/bindings/mmgs.cpp
@@ -101,10 +101,9 @@ bool remesh_s(const py::object &input_mesh, const py::object &input_sol,
       }
     }
 
-    // MMGS keeps its native parser private; mirror it through public APIs.
-    // Parse first so explicit Python options take precedence.
     if (!parameter_file_str.empty()) {
-      parse_mmgs_parameter_file(mesh, met, parameter_file_str);
+      parse_parameter_file(mesh, met, parameter_file_str,
+                           MmgParameterFileKind::MmgS);
     }
 
     // Set all mesh options

--- a/src/bindings/mmgs.cpp
+++ b/src/bindings/mmgs.cpp
@@ -37,7 +37,7 @@ int mmgs_save_mesh(MMG5_pMesh mesh, MMG5_pSol met,
 
 bool remesh_s(const py::object &input_mesh, const py::object &input_sol,
               const py::object &output_mesh, const py::object &output_sol,
-              py::dict options) {
+              py::dict options, const py::object &parameter_file) {
   // Convert paths to strings
   std::string input_mesh_str = path_to_string(input_mesh);
   std::string input_sol_str =
@@ -46,6 +46,11 @@ bool remesh_s(const py::object &input_mesh, const py::object &input_sol,
       output_mesh.is_none() ? "" : path_to_string(output_mesh);
   std::string output_sol_str =
       output_sol.is_none() ? "" : path_to_string(output_sol);
+  std::string parameter_file_str =
+      parameter_file.is_none() ? "" : path_to_string(parameter_file);
+  if (!parameter_file_str.empty()) {
+    validate_parameter_file(parameter_file_str);
+  }
 
   // Initialize structures
   auto [mesh, met, ls] = init_mmgs_structures();
@@ -53,6 +58,14 @@ bool remesh_s(const py::object &input_mesh, const py::object &input_sol,
   // Set mesh names
   MMGS_Set_inputMeshName(mesh, input_mesh_str.c_str());
   MMGS_Set_outputMeshName(mesh, output_mesh_str.c_str());
+
+  if (!parameter_file_str.empty()) {
+    if (!MMGS_Set_inputParamName(mesh, parameter_file_str.c_str())) {
+      cleanup_mmgs_structures(mesh, met, ls);
+      throw std::runtime_error("Failed to set MMG parameter file: " +
+                               parameter_file_str);
+    }
+  }
 
   if (!input_sol_str.empty()) {
     MMGS_Set_inputSolName(mesh, met, input_sol_str.c_str());
@@ -86,6 +99,12 @@ bool remesh_s(const py::object &input_mesh, const py::object &input_sol,
           throw std::runtime_error("Failed to load solution");
         }
       }
+    }
+
+    // MMGS keeps its native parser private; mirror it through public APIs.
+    // Parse first so explicit Python options take precedence.
+    if (!parameter_file_str.empty()) {
+      parse_mmgs_parameter_file(mesh, met, parameter_file_str);
     }
 
     // Set all mesh options

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -2075,6 +2075,7 @@ class Mesh:
         options: Mmg3DOptions | Mmg2DOptions | MmgSOptions | None = None,
         *,
         input_sol: str | Path | NDArray[np.float64] | None = None,
+        parameter_file: str | Path | None = None,
         progress: ProgressParam = True,
         transfer_fields: FieldTransferParam = False,
         interpolation: str = "linear",
@@ -2090,6 +2091,10 @@ class Mesh:
             Solution data for adaptive remeshing.  Can be a path to a
             Medit .sol file, or a numpy array (scalar metric, Nx3/Nx6
             anisotropic tensor, or Nx2/Nx3 displacement vector).
+        parameter_file : str or Path, optional
+            Native MMG local-parameter file (``.mmg3d``, ``.mmg2d``, or
+            ``.mmgs``). Explicit Python options are applied afterward and
+            therefore take precedence.
         progress : bool | Callable[[ProgressEvent], bool] | None, default=True
             Progress reporting option:
             - True: Show Rich progress bar (default)
@@ -2223,7 +2228,10 @@ class Mesh:
                 raise CancellationError(phase="remesh")
 
             # Call raw C++ method and convert result
-            stats = self._impl.remesh(**kwargs)
+            stats = self._impl.remesh(
+                parameter_file=parameter_file,
+                **kwargs,
+            )
             final_vertices = len(self._impl.get_vertices())
 
             self._update_fields_after_remesh(
@@ -2257,6 +2265,7 @@ class Mesh:
         levelset: NDArray[np.float64],
         *,
         surface_only: bool = False,
+        parameter_file: str | Path | None = None,
         progress: ProgressParam = True,
         **kwargs: Any,  # noqa: ANN401
     ) -> RemeshResult:
@@ -2270,6 +2279,9 @@ class Mesh:
             If ``True``, split only the mesh boundary at the isovalue,
             corresponding to MMG's ``-lssurf`` / ``*_IPARAM_isosurf`` mode.
             The default ``False`` preserves full-domain level-set splitting.
+        parameter_file : str or Path, optional
+            Native MMG local-parameter file. Explicit Python options take
+            precedence over settings loaded from the file.
         progress : bool | Callable[[ProgressEvent], bool] | None, default=True
             Progress reporting option:
             - True: Show Rich progress bar (default)
@@ -2319,6 +2331,7 @@ class Mesh:
             stats = self._impl.remesh_levelset(  # type: ignore[arg-type]
                 levelset,
                 surface_only=surface_only,
+                parameter_file=parameter_file,
                 **kwargs,
             )
             final_vertices = len(self._impl.get_vertices())

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -2075,7 +2075,6 @@ class Mesh:
         options: Mmg3DOptions | Mmg2DOptions | MmgSOptions | None = None,
         *,
         input_sol: str | Path | NDArray[np.float64] | None = None,
-        parameter_file: str | Path | None = None,
         progress: ProgressParam = True,
         transfer_fields: FieldTransferParam = False,
         interpolation: str = "linear",
@@ -2165,6 +2164,7 @@ class Mesh:
         )
         from mmgpy._progress import CancellationError, _emit_event  # noqa: PLC0415
 
+        parameter_file = kwargs.pop("parameter_file", None)
         self._load_remesh_input_solution(input_sol)
 
         # Validate interpolation method

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -38,6 +38,7 @@ class mmg3d:  # noqa: N801
         output_mesh: str | Path | None = None,
         output_sol: str | Path | None = None,
         options: dict[str, float | int] | None = None,
+        parameter_file: str | Path | None = None,
     ) -> bool:
         """Remesh a 3D mesh file using MMG3D.
 
@@ -53,6 +54,8 @@ class mmg3d:  # noqa: N801
             Path for output solution file.
         options : dict[str, float | int] | None
             Remeshing options (hmin, hmax, hsiz, hausd, hgrad, verbose, etc.).
+        parameter_file : str | Path | None
+            Native ``.mmg3d`` parameter file. Explicit options take precedence.
 
         Returns
         -------
@@ -71,6 +74,7 @@ class mmg2d:  # noqa: N801
         output_mesh: str | Path | None = None,
         output_sol: str | Path | None = None,
         options: dict[str, float | int] | None = None,
+        parameter_file: str | Path | None = None,
     ) -> bool:
         """Remesh a 2D mesh file using MMG2D.
 
@@ -86,6 +90,8 @@ class mmg2d:  # noqa: N801
             Path for output solution file.
         options : dict[str, float | int] | None
             Remeshing options (hmin, hmax, hsiz, hausd, hgrad, verbose, etc.).
+        parameter_file : str | Path | None
+            Native ``.mmg2d`` parameter file. Explicit options take precedence.
 
         Returns
         -------
@@ -104,6 +110,7 @@ class mmgs:  # noqa: N801
         output_mesh: str | Path | None = None,
         output_sol: str | Path | None = None,
         options: dict[str, float | int] | None = None,
+        parameter_file: str | Path | None = None,
     ) -> bool:
         """Remesh a surface mesh file using MMGS.
 
@@ -119,6 +126,8 @@ class mmgs:  # noqa: N801
             Path for output solution file.
         options : dict[str, float | int] | None
             Remeshing options (hmin, hmax, hsiz, hausd, hgrad, verbose, etc.).
+        parameter_file : str | Path | None
+            Native ``.mmgs`` parameter file. Explicit options take precedence.
 
         Returns
         -------
@@ -1182,6 +1191,7 @@ class MmgMesh3D:
     def remesh(
         self,
         *,
+        parameter_file: str | Path | None = None,
         hmin: float | None = None,
         hmax: float | None = None,
         hsiz: float | None = None,
@@ -1199,6 +1209,8 @@ class MmgMesh3D:
 
         Parameters
         ----------
+        parameter_file : str | Path | None
+            Native ``.mmg3d`` parameter file. Explicit options take precedence.
         hmin : float | None
             Minimum edge size.
         hmax : float | None
@@ -1235,6 +1247,7 @@ class MmgMesh3D:
         self,
         levelset: NDArray[np.float64],
         *,
+        parameter_file: str | Path | None = None,
         ls: float | None = None,
         hmin: float | None = None,
         hmax: float | None = None,
@@ -1255,6 +1268,8 @@ class MmgMesh3D:
         ----------
         levelset : NDArray[np.float64]
             Level-set values, shape (n_vertices, 1).
+        parameter_file : str | Path | None
+            Native ``.mmg3d`` parameter file. Explicit options take precedence.
         ls : float | None
             Isovalue to discretize (default 0.0).
         hmin : float | None
@@ -2043,6 +2058,7 @@ class MmgMesh2D:
     def remesh(
         self,
         *,
+        parameter_file: str | Path | None = None,
         hmin: float | None = None,
         hmax: float | None = None,
         hsiz: float | None = None,
@@ -2059,6 +2075,8 @@ class MmgMesh2D:
 
         Parameters
         ----------
+        parameter_file : str | Path | None
+            Native ``.mmg2d`` parameter file. Explicit options take precedence.
         hmin : float | None
             Minimum edge size.
         hmax : float | None
@@ -2093,6 +2111,7 @@ class MmgMesh2D:
         self,
         levelset: NDArray[np.float64],
         *,
+        parameter_file: str | Path | None = None,
         ls: float | None = None,
         hmin: float | None = None,
         hmax: float | None = None,
@@ -2110,6 +2129,8 @@ class MmgMesh2D:
         ----------
         levelset : NDArray[np.float64]
             Level-set values, shape (n_vertices, 1).
+        parameter_file : str | Path | None
+            Native ``.mmg2d`` parameter file. Explicit options take precedence.
         ls : float | None
             Isovalue to discretize (default 0.0).
         hmin : float | None
@@ -2828,6 +2849,7 @@ class MmgMeshS:
     def remesh(
         self,
         *,
+        parameter_file: str | Path | None = None,
         hmin: float | None = None,
         hmax: float | None = None,
         hsiz: float | None = None,
@@ -2844,6 +2866,8 @@ class MmgMeshS:
 
         Parameters
         ----------
+        parameter_file : str | Path | None
+            Native ``.mmgs`` parameter file. Explicit options take precedence.
         hmin : float | None
             Minimum edge size.
         hmax : float | None
@@ -2878,6 +2902,7 @@ class MmgMeshS:
         self,
         levelset: NDArray[np.float64],
         *,
+        parameter_file: str | Path | None = None,
         ls: float | None = None,
         hmin: float | None = None,
         hmax: float | None = None,
@@ -2895,6 +2920,8 @@ class MmgMeshS:
         ----------
         levelset : NDArray[np.float64]
             Level-set values, shape (n_vertices, 1).
+        parameter_file : str | Path | None
+            Native ``.mmgs`` parameter file. Explicit options take precedence.
         ls : float | None
             Isovalue to discretize (default 0.0).
         hmin : float | None

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -1110,6 +1110,9 @@ class MmgMesh3D:
     def set_input_parameter_name(self, path: str | Path) -> None:
         """Select an MMG parameter file to parse before remeshing."""
 
+    def _apply_input_parameter_file(self) -> None:
+        """Parse the selected MMG parameter file immediately."""
+
     def get_iparameter(self, parameter: int) -> int:
         """Return an MMG3D integer parameter by its ``MMG3D_Param`` value."""
 
@@ -1981,6 +1984,9 @@ class MmgMesh2D:
     def set_input_parameter_name(self, path: str | Path) -> None:
         """Select an MMG parameter file to parse before remeshing."""
 
+    def _apply_input_parameter_file(self) -> None:
+        """Parse the selected MMG parameter file immediately."""
+
     def save_tetgen(self, path: str | Path) -> None:
         """Save the mesh in Triangle/TetGen format."""
 
@@ -2771,6 +2777,9 @@ class MmgMeshS:
 
     def set_input_parameter_name(self, path: str | Path) -> None:
         """Select an MMG parameter file to parse before remeshing."""
+
+    def _apply_input_parameter_file(self) -> None:
+        """Parse the selected MMG parameter file immediately."""
 
     def get_iparameter(self, parameter: int) -> int:
         """Return an MMGS integer parameter by its ``MMGS_Param`` value."""

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -939,6 +939,37 @@ def _apply_metric_kwarg(
         mesh["metric"] = _coerce_metric_kwarg(metric, int(dataset.n_points))
 
 
+def _line_only_remesh_error(
+    metric: NDArray[np.float64] | None,
+    local_sizing: list[Mapping[str, Any]] | None,
+    parameter_file: str | Path | None,
+) -> str | None:
+    """Describe an input unsupported by the line-to-2D generation path.
+
+    Returns
+    -------
+    str or None
+        The validation error, or ``None`` when all inputs are supported.
+
+    """
+    if local_sizing:
+        return (
+            "local_sizing is not supported when generating a 2D mesh "
+            "from a line-only PolyData"
+        )
+    if metric is not None:
+        return (
+            "metric is not supported when generating a 2D mesh "
+            "from a line-only PolyData"
+        )
+    if parameter_file is not None:
+        return (
+            "parameter_file is not supported when generating a 2D mesh "
+            "from a line-only PolyData"
+        )
+    return None
+
+
 # ---------------------------------------------------------------------------
 # .mmg dataset accessor
 # ---------------------------------------------------------------------------
@@ -985,6 +1016,7 @@ class MmgAccessor:
         *,
         metric: NDArray[np.float64] | None = None,
         local_sizing: list[Mapping[str, Any]] | None = None,
+        parameter_file: str | Path | None = None,
         **options: Any,  # noqa: ANN401  -- forwarded to Mesh.remesh; see docstring
     ) -> pv.UnstructuredGrid | pv.PolyData:
         """Remesh the underlying dataset and return a new PyVista dataset.
@@ -1004,6 +1036,9 @@ class MmgAccessor:
             ``"shape"`` key (``"sphere"``, ``"box"``, ``"cylinder"``, or
             ``"from_point"``) plus the parameters of the matching
             ``Mesh.set_size_*`` method.
+        parameter_file : str or Path, optional
+            Native MMG local-parameter file. Explicit Python options take
+            precedence over settings loaded from the file.
         **options : object
             Forwarded to :meth:`mmgpy.Mesh.remesh`. Common knobs include
             ``hmin``, ``hmax``, ``hsiz``, and ``hausd``. The reserved
@@ -1049,18 +1084,13 @@ class MmgAccessor:
                     msg = "pass either an options object or kwargs, not both"
                     raise TypeError(msg)
                 options = dict(opts.to_dict())
-            if local_sizing:
-                msg = (
-                    "local_sizing is not supported when generating a 2D mesh "
-                    "from a line-only PolyData"
-                )
-                raise ValueError(msg)
-            if metric is not None:
-                msg = (
-                    "metric is not supported when generating a 2D mesh "
-                    "from a line-only PolyData"
-                )
-                raise ValueError(msg)
+            line_error = _line_only_remesh_error(
+                metric,
+                local_sizing,
+                parameter_file,
+            )
+            if line_error is not None:
+                raise ValueError(line_error)
             return _generate_from_line_polydata(self._dataset, options)
 
         constraints = _split_constraint_kwargs(options)
@@ -1076,9 +1106,9 @@ class MmgAccessor:
             if options:
                 msg = "pass either an options object or kwargs, not both"
                 raise TypeError(msg)
-            mesh.remesh(opts)
+            mesh.remesh(opts, parameter_file=parameter_file)
         else:
-            mesh.remesh(**options)
+            mesh.remesh(parameter_file=parameter_file, **options)
         return _to_pyvista_with_user_fields(mesh)
 
     def remesh_lagrangian(
@@ -1117,6 +1147,7 @@ class MmgAccessor:
         *,
         surface_only: bool = False,
         local_sizing: list[Mapping[str, Any]] | None = None,
+        parameter_file: str | Path | None = None,
         **options: Any,  # noqa: ANN401  -- forwarded to Mesh.remesh_levelset
     ) -> pv.UnstructuredGrid | pv.PolyData:
         """Level-set discretization remeshing.
@@ -1133,6 +1164,9 @@ class MmgAccessor:
             include the referenced boundary faces as TRIANGLE cells.
         local_sizing : list of dict, optional
             Sizing constraints; see :meth:`remesh`.
+        parameter_file : str or Path, optional
+            Native MMG local-parameter file. Explicit Python options take
+            precedence over settings loaded from the file.
         **options : object
             Forwarded to :meth:`mmgpy.Mesh.remesh_levelset`. The reserved
             constraint kwargs documented on :meth:`remesh` are honored
@@ -1149,7 +1183,12 @@ class MmgAccessor:
         _apply_constraint_markers(mesh, self._dataset, constraints)
         _apply_local_sizing_specs(mesh, local_sizing)
         _apply_pending_mmg_config(mesh, self._dataset)
-        mesh.remesh_levelset(levelset, surface_only=surface_only, **options)
+        mesh.remesh_levelset(
+            levelset,
+            surface_only=surface_only,
+            parameter_file=parameter_file,
+            **options,
+        )
         return _to_pyvista_with_user_fields(mesh, include_boundary=surface_only)
 
     def remesh_optimize(

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -593,6 +593,16 @@ def _apply_pending_mmg_config(
         mesh._impl.set_ls_base_references(list(references))  # noqa: SLF001
 
 
+def _apply_parameter_file(
+    mesh: _Mesh,
+    parameter_file: str | Path | None,
+) -> None:
+    """Parse a parameter file before explicit accessor configuration."""
+    if parameter_file is not None:
+        mesh._impl.set_input_parameter_name(parameter_file)  # noqa: SLF001
+        mesh._impl._apply_input_parameter_file()  # noqa: SLF001
+
+
 def _apply_local_sizing_specs(
     mesh: _Mesh,
     specs: list[Mapping[str, Any]] | None,
@@ -1098,6 +1108,7 @@ class MmgAccessor:
         _apply_metric_kwarg(mesh, self._dataset, metric)
         _apply_constraint_markers(mesh, self._dataset, constraints)
         _apply_local_sizing_specs(mesh, local_sizing)
+        _apply_parameter_file(mesh, parameter_file)
         _apply_pending_mmg_config(mesh, self._dataset)
         # ``renum`` is popped + handled inside ``Mesh.remesh`` (one-time
         # FutureWarning + in-place reverse Cuthill-McKee). Forwarding it
@@ -1106,9 +1117,9 @@ class MmgAccessor:
             if options:
                 msg = "pass either an options object or kwargs, not both"
                 raise TypeError(msg)
-            mesh.remesh(opts, parameter_file=parameter_file)
+            mesh.remesh(opts)
         else:
-            mesh.remesh(parameter_file=parameter_file, **options)
+            mesh.remesh(**options)
         return _to_pyvista_with_user_fields(mesh)
 
     def remesh_lagrangian(
@@ -1182,11 +1193,11 @@ class MmgAccessor:
         mesh = _build_mesh_with_mmg_fields(self._dataset)
         _apply_constraint_markers(mesh, self._dataset, constraints)
         _apply_local_sizing_specs(mesh, local_sizing)
+        _apply_parameter_file(mesh, parameter_file)
         _apply_pending_mmg_config(mesh, self._dataset)
         mesh.remesh_levelset(
             levelset,
             surface_only=surface_only,
-            parameter_file=parameter_file,
             **options,
         )
         return _to_pyvista_with_user_fields(mesh, include_boundary=surface_only)

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -597,7 +597,6 @@ def _apply_parameter_file(
     mesh: _Mesh,
     parameter_file: str | Path | None,
 ) -> None:
-    """Parse a parameter file before explicit accessor configuration."""
     if parameter_file is not None:
         mesh._impl.set_input_parameter_name(parameter_file)  # noqa: SLF001
         mesh._impl._apply_input_parameter_file()  # noqa: SLF001

--- a/src/mmgpy/_remesh.py
+++ b/src/mmgpy/_remesh.py
@@ -8,9 +8,16 @@ via ``Mesh.save()`` (PyVista).  No temporary files are created.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Sequence
+from os import PathLike, fspath
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 
 from mmgpy._generate import generate as _generate_2d
 from mmgpy._mmgpy import mmg2d as _mmg2d_cpp
@@ -32,6 +39,30 @@ class SolPaths(NamedTuple):
 
     in_path: str | Path | None = None
     out_path: str | Path | None = None
+
+
+ParameterFile = str | PathLike[str]
+
+
+class _ParameterFileOptions(TypedDict, total=False):
+    parameter_file: ParameterFile | None
+
+
+def _extract_parameter_file(options: _ParameterFileOptions) -> ParameterFile | None:
+    unexpected = set(options) - {"parameter_file"}
+    if unexpected:
+        names = ", ".join(sorted(unexpected))
+        msg = f"Unexpected keyword argument(s): {names}"
+        raise TypeError(msg)
+    parameter_file = options.get("parameter_file")
+    if parameter_file is None or isinstance(parameter_file, str):
+        return parameter_file
+    if isinstance(parameter_file, PathLike):
+        path = fspath(parameter_file)
+        if isinstance(path, str):
+            return path
+    msg = "parameter_file must be a string or path-like object"
+    raise TypeError(msg)
 
 
 def _is_native(path: str | Path | None) -> bool:
@@ -98,15 +129,14 @@ def _make_wrapped_remesh(
 ) -> Callable[..., bool]:
     """Build a wrapper bound to a specific C++ remesh entry point.
 
-    Captures ``cpp_remesh`` in the closure so the returned callable stays
-    within the ``PLR0913`` arg-count budget while still sharing one
-    implementation across the three ``mmg{2d,3d,s}.remesh`` entry points.
+    Captures ``cpp_remesh`` in the closure so one implementation is shared
+    across the three ``mmg{2d,3d,s}.remesh`` entry points.
 
     Returns
     -------
     Callable[..., bool]
-        Wrapper accepting ``(input_mesh, output_mesh=None, *, sol, options,
-        transfer_fields)`` and returning the C++ success flag.
+        Wrapper accepting file paths and remeshing options and returning the
+        C++ success flag.
 
     """
 
@@ -115,10 +145,11 @@ def _make_wrapped_remesh(
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
-        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
+        **parameter_options: Unpack[_ParameterFileOptions],
     ) -> bool:
+        parameter_file = _extract_parameter_file(parameter_options)
         sol = sol or SolPaths()
         forwarded = dict(options or {})
         do_rcm = _renum_is_truthy(forwarded.get("renum"))
@@ -183,9 +214,9 @@ class mmg3d:
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
-        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
+        **parameter_options: Unpack[_ParameterFileOptions],
     ) -> bool:
         """Remesh a 3D mesh.
 
@@ -197,7 +228,8 @@ class mmg3d:
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
             ``(in_path, out_path)`` solution file paths (.sol/.solb).
-        parameter_file : str or Path, optional
+        **parameter_options : str or Path, optional
+            Accepts ``parameter_file`` as a string or path-like object.
             Native ``.mmg3d`` parameter file. Explicit Python options override
             settings loaded from this file.
         options : dict, optional
@@ -216,9 +248,9 @@ class mmg3d:
             input_mesh,
             output_mesh,
             sol=sol,
-            parameter_file=parameter_file,
             options=options,
             transfer_fields=transfer_fields,
+            **parameter_options,
         )
 
 
@@ -233,9 +265,9 @@ class mmg2d:
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
-        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
+        **parameter_options: Unpack[_ParameterFileOptions],
     ) -> bool:
         """Remesh a 2D mesh.
 
@@ -247,7 +279,8 @@ class mmg2d:
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
             ``(in_path, out_path)`` solution file paths (.sol/.solb).
-        parameter_file : str or Path, optional
+        **parameter_options : str or Path, optional
+            Accepts ``parameter_file`` as a string or path-like object.
             Native ``.mmg2d`` parameter file. Explicit Python options override
             settings loaded from this file.
         options : dict, optional
@@ -266,9 +299,9 @@ class mmg2d:
             input_mesh,
             output_mesh,
             sol=sol,
-            parameter_file=parameter_file,
             options=options,
             transfer_fields=transfer_fields,
+            **parameter_options,
         )
 
 
@@ -281,9 +314,9 @@ class mmgs:
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
-        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
+        **parameter_options: Unpack[_ParameterFileOptions],
     ) -> bool:
         """Remesh a surface mesh.
 
@@ -295,7 +328,8 @@ class mmgs:
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
             ``(in_path, out_path)`` solution file paths (.sol/.solb).
-        parameter_file : str or Path, optional
+        **parameter_options : str or Path, optional
+            Accepts ``parameter_file`` as a string or path-like object.
             Native ``.mmgs`` parameter file. Explicit Python options override
             settings loaded from this file.
         options : dict, optional
@@ -314,7 +348,7 @@ class mmgs:
             input_mesh,
             output_mesh,
             sol=sol,
-            parameter_file=parameter_file,
             options=options,
             transfer_fields=transfer_fields,
+            **parameter_options,
         )

--- a/src/mmgpy/_remesh.py
+++ b/src/mmgpy/_remesh.py
@@ -115,6 +115,7 @@ def _make_wrapped_remesh(
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
+        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
     ) -> bool:
@@ -137,6 +138,7 @@ def _make_wrapped_remesh(
                 output_mesh=output_mesh,
                 output_sol=sol.out_path,
                 options=forwarded,
+                parameter_file=parameter_file,
             )
 
         from mmgpy._io import _read_mesh_internal as _read  # noqa: PLC0415
@@ -150,6 +152,7 @@ def _make_wrapped_remesh(
         # Leave ``renum`` in forwarded so Mesh.remesh pops it (and emits the
         # one-time FutureWarning) and applies RCM in place.
         result = mesh.remesh(
+            parameter_file=parameter_file,
             progress=False,
             transfer_fields=transfer_fields,
             **forwarded,
@@ -180,6 +183,7 @@ class mmg3d:
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
+        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
     ) -> bool:
@@ -193,6 +197,9 @@ class mmg3d:
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
             ``(in_path, out_path)`` solution file paths (.sol/.solb).
+        parameter_file : str or Path, optional
+            Native ``.mmg3d`` parameter file. Explicit Python options override
+            settings loaded from this file.
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -209,6 +216,7 @@ class mmg3d:
             input_mesh,
             output_mesh,
             sol=sol,
+            parameter_file=parameter_file,
             options=options,
             transfer_fields=transfer_fields,
         )
@@ -225,6 +233,7 @@ class mmg2d:
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
+        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
     ) -> bool:
@@ -238,6 +247,9 @@ class mmg2d:
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
             ``(in_path, out_path)`` solution file paths (.sol/.solb).
+        parameter_file : str or Path, optional
+            Native ``.mmg2d`` parameter file. Explicit Python options override
+            settings loaded from this file.
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -254,6 +266,7 @@ class mmg2d:
             input_mesh,
             output_mesh,
             sol=sol,
+            parameter_file=parameter_file,
             options=options,
             transfer_fields=transfer_fields,
         )
@@ -268,6 +281,7 @@ class mmgs:
         output_mesh: str | Path | None = None,
         *,
         sol: SolPaths | None = None,
+        parameter_file: str | Path | None = None,
         options: dict[str, Any] | None = None,
         transfer_fields: FieldTransferParam = False,
     ) -> bool:
@@ -281,6 +295,9 @@ class mmgs:
             Output mesh file. Any format supported by PyVista.
         sol : SolPaths, optional
             ``(in_path, out_path)`` solution file paths (.sol/.solb).
+        parameter_file : str or Path, optional
+            Native ``.mmgs`` parameter file. Explicit Python options override
+            settings loaded from this file.
         options : dict, optional
             Remeshing options (hmax, hmin, hausd, etc.).
         transfer_fields : bool | list[str] | None, default=False
@@ -297,6 +314,7 @@ class mmgs:
             input_mesh,
             output_mesh,
             sol=sol,
+            parameter_file=parameter_file,
             options=options,
             transfer_fields=transfer_fields,
         )

--- a/tests/api_candidates_test.py
+++ b/tests/api_candidates_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
+from mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS, mmg3d
 
 
 @pytest.mark.parametrize("mesh_type", [MmgMesh3D, MmgMesh2D, MmgMeshS])
@@ -27,6 +27,77 @@ def test_integer_parameter_getters() -> None:
     # In both public enums, zero is the verbosity parameter.
     assert isinstance(MmgMesh3D().get_iparameter(0), int)
     assert isinstance(MmgMeshS().get_iparameter(0), int)
+
+
+def _write_parameter_file(path: Path, entity: str, ref: int = 7) -> Path:
+    path.write_text(
+        f"parameters\n1\n{ref} {entity} 0.02 0.08 0.01\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_mmg3d_parameter_file_sizes_tetrahedron_reference(
+    cube_mesh: tuple[np.ndarray, np.ndarray], tmp_path: Path
+) -> None:
+    """MMG3D applies native local sizing to a tetrahedron reference."""
+    vertices, tetrahedra = cube_mesh
+    mesh = MmgMesh3D(vertices, tetrahedra)
+    mesh.set_tetrahedra(tetrahedra, np.full(len(tetrahedra), 7, dtype=np.int32))
+    parameter_file = _write_parameter_file(tmp_path / "local.mmg3d", "tetrahedra")
+
+    mesh.remesh(parameter_file=parameter_file, verbose=-1)
+
+    assert len(mesh.get_tetrahedra()) > len(tetrahedra)
+
+
+def test_mmg2d_parameter_file_sizes_triangle_reference(
+    square_mesh: tuple[np.ndarray, np.ndarray], tmp_path: Path
+) -> None:
+    """MMG2D applies native local sizing to a triangle reference."""
+    vertices, triangles = square_mesh
+    mesh = MmgMesh2D(vertices, triangles)
+    mesh.set_triangles(triangles, np.full(len(triangles), 7, dtype=np.int32))
+    parameter_file = _write_parameter_file(tmp_path / "local.mmg2d", "triangles")
+
+    mesh.remesh(parameter_file=parameter_file, verbose=-1)
+
+    assert len(mesh.get_triangles()) > len(triangles)
+
+
+def test_mmgs_parameter_file_sizes_triangle_reference(
+    tetrahedron_surface_mesh: tuple[np.ndarray, np.ndarray], tmp_path: Path
+) -> None:
+    """MMGS applies native local sizing through mmgpy's public-API parser."""
+    vertices, triangles = tetrahedron_surface_mesh
+    mesh = MmgMeshS(vertices, triangles)
+    mesh.set_triangles(triangles, np.full(len(triangles), 7, dtype=np.int32))
+    parameter_file = _write_parameter_file(tmp_path / "local.mmgs", "triangles")
+
+    mesh.remesh(parameter_file=parameter_file, verbose=-1)
+
+    assert len(mesh.get_triangles()) > len(triangles)
+
+
+def test_file_remesh_accepts_parameter_file(
+    cube_mesh: tuple[np.ndarray, np.ndarray], tmp_path: Path
+) -> None:
+    """The public file wrapper forwards path-like parameter files to C++."""
+    vertices, tetrahedra = cube_mesh
+    source = MmgMesh3D(vertices, tetrahedra)
+    source.set_tetrahedra(tetrahedra, np.full(len(tetrahedra), 7, dtype=np.int32))
+    input_mesh = tmp_path / "input.mesh"
+    output_mesh = tmp_path / "output.mesh"
+    source.save(input_mesh)
+    parameter_file = _write_parameter_file(tmp_path / "local.mmg3d", "tetrahedra")
+
+    assert mmg3d.remesh(
+        input_mesh,
+        output_mesh,
+        parameter_file=parameter_file,
+        options={"verbose": -1},
+    )
+    assert len(MmgMesh3D(output_mesh).get_tetrahedra()) > len(tetrahedra)
 
 
 def test_save_tetgen_3d(

--- a/tests/api_candidates_test.py
+++ b/tests/api_candidates_test.py
@@ -23,21 +23,31 @@ def test_set_input_parameter_name_validates_path(
 
 
 @pytest.mark.parametrize(
-    ("mesh_type", "unsafe_path"),
+    ("mesh_type", "extension", "engine"),
     [
-        (MmgMesh3D, "x" * 256 + ".mmg3d"),
-        (MmgMesh3D, "x" * 250),
-        (MmgMesh2D, "x" * 256 + ".mmg2d"),
-        (MmgMesh2D, "x" * 250),
+        (MmgMesh3D, ".mmg3d", "MMG3D"),
+        (MmgMesh2D, ".mmg2d", "MMG2D"),
+        (MmgMeshS, ".mmgs", "MMGS"),
     ],
 )
-def test_native_parameter_parser_rejects_unsafe_path_length(
-    mesh_type: type[MmgMesh3D | MmgMesh2D],
-    unsafe_path: str,
+def test_parameter_file_errors_are_consistent(
+    mesh_type: type[MmgMesh3D | MmgMesh2D | MmgMeshS],
+    extension: str,
+    engine: str,
+    tmp_path: Path,
 ) -> None:
-    """Reject overflow in both MMG's initial copy and extension append."""
-    with pytest.raises(RuntimeError, match="too long for the native parser"):
-        mesh_type().set_input_parameter_name(unsafe_path)
+    """Report unsupported parameter entities consistently."""
+    parameter_file = tmp_path / f"invalid{extension}"
+    parameter_file.write_text(
+        "parameters\n1\n7 vertex 0.02 0.08 0.01\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=rf"Invalid {engine} parameter file .* unsupported entity type 'vertex'",
+    ):
+        mesh_type().remesh(parameter_file=parameter_file, verbose=-1)
 
 
 def test_integer_parameter_getters() -> None:

--- a/tests/api_candidates_test.py
+++ b/tests/api_candidates_test.py
@@ -22,6 +22,24 @@ def test_set_input_parameter_name_validates_path(
     mesh.set_input_parameter_name(parameter_file)
 
 
+@pytest.mark.parametrize(
+    ("mesh_type", "unsafe_path"),
+    [
+        (MmgMesh3D, "x" * 256 + ".mmg3d"),
+        (MmgMesh3D, "x" * 250),
+        (MmgMesh2D, "x" * 256 + ".mmg2d"),
+        (MmgMesh2D, "x" * 250),
+    ],
+)
+def test_native_parameter_parser_rejects_unsafe_path_length(
+    mesh_type: type[MmgMesh3D | MmgMesh2D],
+    unsafe_path: str,
+) -> None:
+    """Reject overflow in both MMG's initial copy and extension append."""
+    with pytest.raises(RuntimeError, match="too long for the native parser"):
+        mesh_type().set_input_parameter_name(unsafe_path)
+
+
 def test_integer_parameter_getters() -> None:
     """MMG3D and MMGS expose their native integer-parameter getter."""
     # In both public enums, zero is the verbosity parameter.

--- a/tests/pv_plugin_test.py
+++ b/tests/pv_plugin_test.py
@@ -10,6 +10,7 @@ import pytest
 import pyvista as pv
 
 import mmgpy
+import mmgpy._pv_plugin as pv_plugin
 
 
 def _save_via_pv(grid: pv.DataSet, path: Path) -> None:
@@ -39,6 +40,85 @@ def _make_tet_mesh() -> pv.UnstructuredGrid:
 def _make_surface_mesh() -> pv.PolyData:
     """Return a triangulated cube as a PolyData surface mesh."""
     return pv.Cube().triangulate()
+
+
+@pytest.mark.parametrize("operation", ["remesh", "remesh_levelset"])
+def test_parameter_file_precedes_explicit_accessor_config(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    """Stored Python configuration is reapplied after parameter-file parsing."""
+    events: list[str] = []
+
+    class FakeImpl:
+        def set_input_parameter_name(self, path: Path) -> None:
+            events.append(f"select:{path.name}")
+
+        def _apply_input_parameter_file(self) -> None:
+            events.append("parse")
+
+        def set_multi_materials(self, materials: list[dict[str, object]]) -> None:
+            assert materials
+            events.append("materials")
+
+        def set_local_parameters(self, parameters: list[dict[str, object]]) -> None:
+            assert parameters
+            events.append("parameters")
+
+        def set_ls_base_references(self, references: list[int]) -> None:
+            assert references
+            events.append("references")
+
+    class FakeMesh:
+        def __init__(self) -> None:
+            self._impl = FakeImpl()
+
+        def remesh(self, *_args: object, **_kwargs: object) -> None:
+            events.append("remesh")
+
+        def remesh_levelset(self, *_args: object, **_kwargs: object) -> None:
+            events.append("remesh_levelset")
+
+    dataset = _make_tet_mesh()
+    dataset.user_dict["mmg_multi_materials"] = [
+        {"ref": 0, "split": 1, "ref_minus": 10, "ref_plus": 20},
+    ]
+    dataset.user_dict["mmg_local_parameters"] = [
+        {
+            "type": "tetrahedron",
+            "ref": 0,
+            "hmin": 0.01,
+            "hmax": 0.1,
+            "hausd": 0.01,
+        },
+    ]
+    dataset.user_dict["mmg_ls_base_references"] = [1]
+    fake_mesh = FakeMesh()
+    monkeypatch.setattr(pv_plugin, "_build_mesh_with_mmg_fields", lambda _: fake_mesh)
+    monkeypatch.setattr(
+        pv_plugin,
+        "_to_pyvista_with_user_fields",
+        lambda *_args, **_kwargs: dataset,
+    )
+
+    parameter_file = Path("settings.mmg3d")
+    if operation == "remesh":
+        dataset.mmg.remesh(parameter_file=parameter_file, verbose=False)
+    else:
+        dataset.mmg.remesh_levelset(
+            np.ones(dataset.n_points),
+            parameter_file=parameter_file,
+            verbose=False,
+        )
+
+    assert events == [
+        f"select:{parameter_file.name}",
+        "parse",
+        "materials",
+        "parameters",
+        "references",
+        operation,
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #373.

## What changed

- add a `parameter_file=` keyword to file-based, in-memory, level-set, and PyVista remeshing APIs
- wire native parameter-file handling through MMG3D, MMG2D, and MMGS
- use MMG's public parsers for MMG3D/MMG2D and mirror MMGS's private parser through its public API
- validate missing and unreadable files before remeshing
- apply parameter-file values first so explicit Python options take precedence
- update type stubs, API coverage, parameter docs, and the changelog
- add local-sizing integration coverage for entity references on all three engines

## Why

The low-level input-parameter filename setters were exposed, but the public remeshing paths did not parse or apply native MMG parameter files. MMGS also keeps its parser private, so it needs a small public-API-backed equivalent.

## Validation

- `cmake --build build --config Release`
- `prek run --all-files`
- focused regression suite: 86 passed
- parameter-file integration tests: 10 passed

A complete local pytest run was also attempted. It progressed through the new tests and CLI coverage, but the PyVista example suite hit an unrelated rendered-image baseline mismatch in `mmg3d-levelset_discretization` (image error 4781 vs allowed 500); the example computation itself completed successfully.