### PR TITLE
Guard unreliable binary multi-solution I/O

### DIFF
--- a/docs/reference/mmg-api-coverage.md
+++ b/docs/reference/mmg-api-coverage.md
@@ -727,5 +727,7 @@ Some differences do not correspond to a missing C callable:
   consistently across supported platforms; mmgpy supplies a portable, non-identical mesh
   motion workflow ([#374](https://github.com/kmarchais/mmgpy/issues/374)).
 - Text multi-solution I/O is bound. Binary `.solb` multi-solution I/O remains disabled
-  pending a reliable upstream MMG round-trip
-  ([#375](https://github.com/kmarchais/mmgpy/issues/375)).
+  for affected MMG releases, including the bundled 5.8.0. The raw bindings and Python
+  wrappers raise an actionable error instead of returning corrupted values. Follow the
+  [upstream MMG report](https://github.com/MmgTools/mmg/issues/326) and
+  [mmgpy #375](https://github.com/kmarchais/mmgpy/issues/375) for the fix.

--- a/scripts/reproduce_mmg_solb_multisols.c
+++ b/scripts/reproduce_mmg_solb_multisols.c
@@ -1,0 +1,110 @@
+/* Minimal reproducer for MmgTools/mmg#326.
+ *
+ * Build against MMG 5.8.0, then run with an output path ending in .solb.
+ * The program writes scalar, vector, and tensor vertex fields through the
+ * public MMG3D multi-solution API and reads them back.  MMG 5.8.0 corrupts
+ * every vertex after the first because MMG3D_saveAllSols writes an ASCII
+ * newline after each binary record.
+ */
+
+#include "mmg/mmg3d/libmmg3d.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK(call)                                                            \
+  do {                                                                         \
+    if ((call) != 1) {                                                         \
+      fprintf(stderr, "%s failed\n", #call);                                   \
+      status = EXIT_FAILURE;                                                   \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0)
+
+static int same_values(const double *actual, const double *expected,
+                       int count) {
+  int i;
+  for (i = 0; i < count; ++i) {
+    if (fabs(actual[i] - expected[i]) > 1.0e-12) {
+      fprintf(stderr, "mismatch at component %d: expected %.17g, got %.17g\n",
+              i, expected[i], actual[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main(int argc, char **argv) {
+  MMG5_pMesh mesh = NULL;
+  MMG5_pSol metric = NULL;
+  MMG5_pSol written = NULL;
+  MMG5_pSol loaded = NULL;
+  MMG5_int entity_count = 0;
+  int loaded_count = 0;
+  int loaded_types[MMG5_NSOLS_MAX] = {0};
+  int status = EXIT_SUCCESS;
+  int types[] = {MMG5_Scalar, MMG5_Vector, MMG5_Tensor};
+  double scalar[] = {1.0, 2.0, 3.0, 4.0};
+  double vector[] = {1.0, 2.0, 3.0, 4.0,  5.0,  6.0,
+                     7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
+  double tensor[] = {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+                     9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+                     17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0};
+  double actual[24] = {0.0};
+  const char *filename = argc > 1 ? argv[1] : "mmg-multisols.solb";
+
+  CHECK(MMG3D_Init_mesh(MMG5_ARG_start, MMG5_ARG_ppMesh, &mesh, MMG5_ARG_ppMet,
+                        &metric, MMG5_ARG_end));
+  CHECK(MMG3D_Set_meshSize(mesh, 4, 1, 0, 0, 0, 0));
+  CHECK(MMG3D_Set_vertex(mesh, 0.0, 0.0, 0.0, 0, 1));
+  CHECK(MMG3D_Set_vertex(mesh, 1.0, 0.0, 0.0, 0, 2));
+  CHECK(MMG3D_Set_vertex(mesh, 0.0, 1.0, 0.0, 0, 3));
+  CHECK(MMG3D_Set_vertex(mesh, 0.0, 0.0, 1.0, 0, 4));
+  CHECK(MMG3D_Set_tetrahedron(mesh, 1, 2, 3, 4, 0, 1));
+
+  CHECK(MMG3D_Set_solsAtVerticesSize(mesh, &written, 3, 4, types));
+  CHECK(MMG3D_Set_ithSols_inSolsAtVertices(written, 1, scalar));
+  CHECK(MMG3D_Set_ithSols_inSolsAtVertices(written, 2, vector));
+  CHECK(MMG3D_Set_ithSols_inSolsAtVertices(written, 3, tensor));
+  CHECK(MMG3D_saveAllSols(mesh, &written, filename));
+  CHECK(MMG3D_loadAllSols(mesh, &loaded, filename));
+  CHECK(MMG3D_Get_solsAtVerticesSize(mesh, &loaded, &loaded_count,
+                                     &entity_count, loaded_types));
+
+  if (loaded_count != 3 || entity_count != 4 || loaded_types[0] != types[0] ||
+      loaded_types[1] != types[1] || loaded_types[2] != types[2]) {
+    fprintf(stderr, "round-trip changed the multi-solution header\n");
+    status = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  CHECK(MMG3D_Get_ithSols_inSolsAtVertices(loaded, 1, actual));
+  if (!same_values(actual, scalar, 4)) {
+    status = EXIT_FAILURE;
+    goto cleanup;
+  }
+  CHECK(MMG3D_Get_ithSols_inSolsAtVertices(loaded, 2, actual));
+  if (!same_values(actual, vector, 12)) {
+    status = EXIT_FAILURE;
+    goto cleanup;
+  }
+  CHECK(MMG3D_Get_ithSols_inSolsAtVertices(loaded, 3, actual));
+  if (!same_values(actual, tensor, 24)) {
+    status = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  puts("binary multi-solution round-trip succeeded");
+
+cleanup:
+  if (loaded != NULL) {
+    MMG3D_Free_allSols(mesh, &loaded);
+  }
+  if (written != NULL) {
+    MMG3D_Free_allSols(mesh, &written);
+  }
+  MMG3D_Free_all(MMG5_ARG_start, MMG5_ARG_ppMesh, &mesh, MMG5_ARG_ppMet,
+                 &metric, MMG5_ARG_end);
+  return status;
+}

--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -248,7 +248,8 @@ PYBIND11_MODULE(_mmgpy, m) {
             return self.load_all_sols(path_to_variant(path));
           },
           py::arg("path"),
-          "Load every solution block from a Medit .sol/.solb file. Returns a "
+          "Load every solution block from a Medit .sol file. Binary .solb "
+          "is rejected for affected MMG releases (MmgTools/mmg#326). Returns a "
           "list of (mmg_type, ndarray) tuples in file order. "
           "mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def(
@@ -258,8 +259,9 @@ PYBIND11_MODULE(_mmgpy, m) {
             self.save_all_sols(path_to_variant(path), sols);
           },
           py::arg("path"), py::arg("sols"),
-          "Write a list of (mmg_type, ndarray) tuples as a multi-block "
-          ".sol/.solb file. mmg_type is 1=scalar, 2=vector, 3=tensor.")
+          "Write a list of (mmg_type, ndarray) tuples as a multi-block .sol "
+          "file. Binary .solb is rejected for affected MMG releases "
+          "(MmgTools/mmg#326). mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def_property_readonly("is_corrupted", &MmgMesh::is_corrupted)
       .def(
           "remesh",
@@ -452,7 +454,8 @@ PYBIND11_MODULE(_mmgpy, m) {
             return self.load_all_sols(path_to_variant(path));
           },
           py::arg("path"),
-          "Load every solution block from a Medit .sol/.solb file. Returns a "
+          "Load every solution block from a Medit .sol file. Binary .solb "
+          "is rejected for affected MMG releases (MmgTools/mmg#326). Returns a "
           "list of (mmg_type, ndarray) tuples in file order. "
           "mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def(
@@ -462,8 +465,9 @@ PYBIND11_MODULE(_mmgpy, m) {
             self.save_all_sols(path_to_variant(path), sols);
           },
           py::arg("path"), py::arg("sols"),
-          "Write a list of (mmg_type, ndarray) tuples as a multi-block "
-          ".sol/.solb file. mmg_type is 1=scalar, 2=vector, 3=tensor.")
+          "Write a list of (mmg_type, ndarray) tuples as a multi-block .sol "
+          "file. Binary .solb is rejected for affected MMG releases "
+          "(MmgTools/mmg#326). mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def_property_readonly("is_corrupted", &MmgMesh2D::is_corrupted)
       .def(
           "remesh",
@@ -642,7 +646,8 @@ PYBIND11_MODULE(_mmgpy, m) {
             return self.load_all_sols(path_to_variant(path));
           },
           py::arg("path"),
-          "Load every solution block from a Medit .sol/.solb file. Returns a "
+          "Load every solution block from a Medit .sol file. Binary .solb "
+          "is rejected for affected MMG releases (MmgTools/mmg#326). Returns a "
           "list of (mmg_type, ndarray) tuples in file order. "
           "mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def(
@@ -652,8 +657,9 @@ PYBIND11_MODULE(_mmgpy, m) {
             self.save_all_sols(path_to_variant(path), sols);
           },
           py::arg("path"), py::arg("sols"),
-          "Write a list of (mmg_type, ndarray) tuples as a multi-block "
-          ".sol/.solb file. mmg_type is 1=scalar, 2=vector, 3=tensor.")
+          "Write a list of (mmg_type, ndarray) tuples as a multi-block .sol "
+          "file. Binary .solb is rejected for affected MMG releases "
+          "(MmgTools/mmg#326). mmg_type is 1=scalar, 2=vector, 3=tensor.")
       .def_property_readonly("is_corrupted", &MmgMeshS::is_corrupted)
       .def(
           "remesh",

--- a/src/bindings/mmg_multisol.hpp
+++ b/src/bindings/mmg_multisol.hpp
@@ -2,7 +2,10 @@
 #define MMG_MULTISOL_HPP
 
 #include "mmg/common/libmmgtypes.h"
+#include "mmg/common/mmgversion.h"
 #include "mmg_common.hpp"
+#include <algorithm>
+#include <cctype>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -10,6 +13,33 @@
 #include <vector>
 
 namespace py = pybind11;
+
+inline bool has_solb_extension(const std::string &fname) {
+  const std::size_t dot = fname.find_last_of('.');
+  if (dot == std::string::npos) {
+    return false;
+  }
+  std::string extension = fname.substr(dot);
+  std::transform(extension.begin(), extension.end(), extension.begin(),
+                 [](unsigned char value) {
+                   return static_cast<char>(std::tolower(value));
+                 });
+  return extension == ".solb";
+}
+
+inline void reject_unreliable_solb_multisol(const std::string &fname) {
+  if (!has_solb_extension(fname)) {
+    return;
+  }
+  PyErr_Format(
+      PyExc_NotImplementedError,
+      "Binary .solb multi-solution I/O is disabled for MMG %s because its "
+      "writer corrupts binary records. Track the upstream fix at "
+      "https://github.com/MmgTools/mmg/issues/326 and use .sol (text) until "
+      "a fixed MMG release is bundled.",
+      MMG_VERSION_RELEASE);
+  throw py::error_already_set();
+}
 
 // Function pointer signatures shared by MMG3D/MMG2D/MMGS multi-sol API.
 using SetSolsAtVerticesSizeFn = int (*)(MMG5_pMesh, MMG5_pSol *, int, MMG5_int,
@@ -56,6 +86,7 @@ inline int components_for_type(int type, int dim) {
 inline py::list load_all_sols_vertices(MMG5_pMesh mesh,
                                        const std::string &fname,
                                        const MultiSolApi &api) {
+  reject_unreliable_solb_multisol(fname);
   MMG5_pSol sols = nullptr;
   int ret = api.load_all_sols(mesh, &sols, fname.c_str());
   if (ret != 1) {
@@ -181,6 +212,7 @@ inline void save_all_sols_vertices(MMG5_pMesh mesh, MMG5_int nentities,
                                    const std::string &fname,
                                    const py::list &sols,
                                    const MultiSolApi &api) {
+  reject_unreliable_solb_multisol(fname);
   int nsols = static_cast<int>(py::len(sols));
   if (nsols <= 0) {
     throw std::invalid_argument("save_all_sols: empty solution list");

--- a/src/mmgpy/_mesh.py
+++ b/src/mmgpy/_mesh.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 import numpy as np
 import pyvista as pv
 
-from mmgpy._mmgpy import MmgMesh2D, MmgMesh3D, MmgMeshS
+from mmgpy._mmgpy import MMG_VERSION, MmgMesh2D, MmgMesh3D, MmgMeshS
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable, Sequence
@@ -53,11 +53,25 @@ _TETRA_VERTS = 4
 _TRI_VERTS = 3
 _EDGE_VERTS = 2
 _2D_DETECTION_TOLERANCE = 1e-8
+_SOLB_MULTISOL_UPSTREAM_ISSUE = "https://github.com/MmgTools/mmg/issues/326"
 
 ValidationCheck = Literal["geometry", "topology", "quality"]
 _ALL_CHECKS: frozenset[ValidationCheck] = frozenset(
     ("geometry", "topology", "quality"),
 )
+
+
+def _reject_unreliable_solb_multisol(path: str | Path) -> None:
+    """Reject binary multi-solution I/O for the bundled, affected MMG."""
+    if Path(path).suffix.lower() != ".solb":
+        return
+    msg = (
+        f"Binary .solb multi-solution I/O is disabled for MMG {MMG_VERSION} "
+        "because its writer corrupts binary records. Track the upstream fix at "
+        f"{_SOLB_MULTISOL_UPSTREAM_ISSUE} and use .sol (text) until a fixed MMG "
+        "release is bundled."
+    )
+    raise NotImplementedError(msg)
 
 
 @cache
@@ -1877,14 +1891,7 @@ class Mesh:
             ``(N, dim*(dim+1)/2)``.
 
         """
-        from pathlib import Path as _Path  # noqa: PLC0415
-
-        if _Path(filename).suffix.lower() == ".solb":
-            msg = (
-                "Binary .solb is not supported: MMG's multi-sol .solb "
-                "round-trip is broken at the library level."
-            )
-            raise NotImplementedError(msg)
+        _reject_unreliable_solb_multisol(filename)
         raw = self._impl.load_all_sols(filename)
         out: dict[str, NDArray[np.float64]] = {}
         type_counts = {1: 0, 2: 0, 3: 0}
@@ -1926,23 +1933,14 @@ class Mesh:
 
         Raises
         ------
-        NotImplementedError
-            If a binary ``.solb`` path is given.
         ValueError
             If ``arrays`` is empty, or any block's shape does not match
             a scalar / vector / tensor layout for the mesh dimension.
 
         """
-        from pathlib import Path as _Path  # noqa: PLC0415
-
         from mmgpy._sol import infer_sol_type  # noqa: PLC0415
 
-        if _Path(filename).suffix.lower() == ".solb":
-            msg = (
-                "Binary .solb is not supported: MMG's multi-sol .solb "
-                "round-trip is broken at the library level."
-            )
-            raise NotImplementedError(msg)
+        _reject_unreliable_solb_multisol(filename)
         if not arrays:
             msg = "save_all_sols: arrays must contain at least one block"
             raise ValueError(msg)

--- a/src/mmgpy/_mmgpy.pyi
+++ b/src/mmgpy/_mmgpy.pyi
@@ -1173,11 +1173,14 @@ class MmgMesh3D:
         self,
         path: str | Path,
     ) -> list[tuple[int, NDArray[np.float64]]]:
-        """Load every vertex-located solution block from a Medit .sol/.solb file.
+        """Load every vertex-located solution block from a Medit .sol file.
 
         Returns a list of ``(mmg_type, ndarray)`` tuples in file order;
         ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. Scalar
         arrays are 1D; vector and tensor arrays are 2D.
+
+        Binary ``.solb`` is rejected for affected MMG releases; see
+        https://github.com/MmgTools/mmg/issues/326.
         """
 
     def save_all_sols(
@@ -1189,6 +1192,9 @@ class MmgMesh3D:
 
         ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. All
         arrays must share the vertex count.
+
+        Binary ``.solb`` is rejected for affected MMG releases; see
+        https://github.com/MmgTools/mmg/issues/326.
         """
 
     def remesh(
@@ -2043,11 +2049,14 @@ class MmgMesh2D:
         self,
         path: str | Path,
     ) -> list[tuple[int, NDArray[np.float64]]]:
-        """Load every vertex-located solution block from a Medit .sol/.solb file.
+        """Load every vertex-located solution block from a Medit .sol file.
 
         Returns a list of ``(mmg_type, ndarray)`` tuples in file order;
         ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. Scalar
         arrays are 1D; vector and tensor arrays are 2D.
+
+        Binary ``.solb`` is rejected for affected MMG releases; see
+        https://github.com/MmgTools/mmg/issues/326.
         """
 
     def save_all_sols(
@@ -2059,6 +2068,9 @@ class MmgMesh2D:
 
         ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. All
         arrays must share the vertex count.
+
+        Binary ``.solb`` is rejected for affected MMG releases; see
+        https://github.com/MmgTools/mmg/issues/326.
         """
 
     def remesh(
@@ -2837,11 +2849,14 @@ class MmgMeshS:
         self,
         path: str | Path,
     ) -> list[tuple[int, NDArray[np.float64]]]:
-        """Load every vertex-located solution block from a Medit .sol/.solb file.
+        """Load every vertex-located solution block from a Medit .sol file.
 
         Returns a list of ``(mmg_type, ndarray)`` tuples in file order;
         ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. Scalar
         arrays are 1D; vector and tensor arrays are 2D.
+
+        Binary ``.solb`` is rejected for affected MMG releases; see
+        https://github.com/MmgTools/mmg/issues/326.
         """
 
     def save_all_sols(
@@ -2853,6 +2868,9 @@ class MmgMeshS:
 
         ``mmg_type`` is ``1=scalar``, ``2=vector``, ``3=tensor``. All
         arrays must share the vertex count.
+
+        Binary ``.solb`` is rejected for affected MMG releases; see
+        https://github.com/MmgTools/mmg/issues/326.
         """
 
     def remesh(

--- a/src/mmgpy/_pv_plugin.py
+++ b/src/mmgpy/_pv_plugin.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 import pyvista as pv
 
-from mmgpy._mesh import _ALL_CHECKS
+from mmgpy._mesh import _ALL_CHECKS, _reject_unreliable_solb_multisol
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -1484,13 +1484,7 @@ class MmgAccessor:
 
         """
         sol_path = Path(path)
-        if sol_path.suffix.lower() == ".solb":
-            msg = (
-                "Binary .solb files are not supported via "
-                "mesh.mmg.load_all_sols() — MMG's .solb round-trip is "
-                "broken at the library level."
-            )
-            raise NotImplementedError(msg)
+        _reject_unreliable_solb_multisol(sol_path)
         _attach_sol_fields(self._dataset, sol_path)
 
     def save_all_sols(
@@ -1525,8 +1519,6 @@ class MmgAccessor:
 
         Raises
         ------
-        NotImplementedError
-            If ``path`` is a binary ``.solb`` file.
         ValueError
             If no eligible point or cell arrays are available to write.
 
@@ -1535,13 +1527,7 @@ class MmgAccessor:
         from mmgpy._sol import write_sol_file  # noqa: PLC0415
 
         sol_path = Path(path)
-        if sol_path.suffix.lower() == ".solb":
-            msg = (
-                "Binary .solb files are not supported via "
-                "mesh.mmg.save_all_sols() — MMG's .solb writer interleaves "
-                "stray newlines that break round-trip. Use .sol (text)."
-            )
-            raise NotImplementedError(msg)
+        _reject_unreliable_solb_multisol(sol_path)
 
         mesh = _build_mesh_with_mmg_fields(self._dataset)
         dim = mesh.solution_dim

--- a/tests/multi_sol_test.py
+++ b/tests/multi_sol_test.py
@@ -11,7 +11,7 @@ Covers:
   ``point_data`` / ``cell_data`` slots.
 * Binary ``.solb`` is explicitly unsupported here because MMG itself emits
   stray newlines in its binary writer (even the existing single-channel
-  ``.solb`` round-trip is broken at the library level).
+  ``.solb`` round-trip is broken at the library level; see MmgTools/mmg#326).
 """
 
 from __future__ import annotations
@@ -160,6 +160,35 @@ def test_cpp_binding_rejects_wrong_column_count(tmp_path: Path) -> None:
         impl.save_all_sols(tmp_path / "bad.sol", [(3, bad)])
 
 
+@pytest.mark.parametrize(
+    "make_impl",
+    [_make_3d_impl, _make_2d_impl, _make_s_impl],
+    ids=["mmg3d", "mmg2d", "mmgs"],
+)
+@pytest.mark.parametrize("operation", ["load", "save"])
+def test_cpp_binding_rejects_solb_with_upstream_issue(
+    make_impl,
+    operation: str,
+    tmp_path: Path,
+) -> None:
+    """Every raw binding blocks corrupt MMG 5.8.0 binary multi-sol I/O."""
+    impl = make_impl()
+    path = tmp_path / "multi.SOLB"
+    scalar = np.arange(impl.get_mesh_size()[0], dtype=np.float64)
+
+    def call() -> None:
+        if operation == "load":
+            impl.load_all_sols(path)
+        else:
+            impl.save_all_sols(path, [(1, scalar)])
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"MMG 5\.8\.0.*MmgTools/mmg/issues/326",
+    ):
+        call()
+
+
 # ---------------------------------------------------------------------------
 # Mesh-level wrapper
 # ---------------------------------------------------------------------------
@@ -183,9 +212,9 @@ def test_mesh_save_load_roundtrip_with_positional_names(tmp_path: Path) -> None:
 
 
 def test_mesh_save_rejects_solb(tmp_path: Path) -> None:
-    """Mesh-level writer refuses .solb (MMG library bug)."""
+    """Mesh-level writer reports the affected MMG version and upstream issue."""
     mesh = _read_mesh_internal(_tet_pv_dataset())
-    with pytest.raises(NotImplementedError, match="\\.solb"):
+    with pytest.raises(NotImplementedError, match="MmgTools/mmg/issues/326"):
         mesh.save_all_sols(
             tmp_path / "x.solb",
             {"f": np.zeros(mesh._impl.get_mesh_size()[0])},
@@ -193,9 +222,9 @@ def test_mesh_save_rejects_solb(tmp_path: Path) -> None:
 
 
 def test_mesh_load_rejects_solb(tmp_path: Path) -> None:
-    """Mesh-level reader refuses .solb (MMG library bug)."""
+    """Mesh-level reader reports the affected MMG version and upstream issue."""
     mesh = _read_mesh_internal(_tet_pv_dataset())
-    with pytest.raises(NotImplementedError, match="\\.solb"):
+    with pytest.raises(NotImplementedError, match="MmgTools/mmg/issues/326"):
         mesh.load_all_sols(tmp_path / "x.solb")
 
 
@@ -296,17 +325,17 @@ def test_accessor_save_explicit_keys_raise_on_missing(tmp_path: Path) -> None:
 
 
 def test_accessor_save_solb_raises(tmp_path: Path) -> None:
-    """Accessor writer refuses .solb due to the upstream MMG bug."""
+    """Accessor writer links the upstream MMG bug."""
     grid = _tet_pv_dataset()
     grid.point_data["scalar"] = np.arange(grid.n_points, dtype=np.float64)
-    with pytest.raises(NotImplementedError, match="\\.solb"):
+    with pytest.raises(NotImplementedError, match="MmgTools/mmg/issues/326"):
         grid.mmg.save_all_sols(tmp_path / "x.solb")
 
 
 def test_accessor_load_solb_raises(tmp_path: Path) -> None:
-    """Accessor reader refuses .solb due to the upstream MMG bug."""
+    """Accessor reader links the upstream MMG bug."""
     grid = _tet_pv_dataset()
-    with pytest.raises(NotImplementedError, match="\\.solb"):
+    with pytest.raises(NotImplementedError, match="MmgTools/mmg/issues/326"):
         grid.mmg.load_all_sols(tmp_path / "x.solb")
 
 


### PR DESCRIPTION
## Summary

- add a standalone MMG3D C reproducer for binary scalar, vector, and tensor multi-solution corruption
- reject `.solb` multi-solution loads and saves in the raw MMG3D, MMG2D, and MMGS bindings before MMG can return corrupted data
- share a version-specific, actionable Python error that links the upstream MMG report and recommends `.sol` text files
- update binding docs, type stubs, API coverage notes, and regression tests

## Root cause

MMG 5.8.0 and current upstream `master` unconditionally write ASCII newlines between solution records even when `saveAllSols` is producing binary output. The matching loaders do not consume those bytes, so records after the first are desynchronized.

Reported upstream as [MmgTools/mmg#326](https://github.com/MmgTools/mmg/issues/326). This draft intentionally keeps binary multi-solution I/O disabled until a reliable upstream release is available; text `.sol` behavior is unchanged.

## User impact

Affected entry points now raise `NotImplementedError` with the bundled MMG version, upstream issue URL, and `.sol` workaround instead of silently returning garbage. The raw bindings also enforce the guard, so callers cannot accidentally bypass the Python wrappers.

## Validation

- `uv run pytest tests/multi_sol_test.py -q --basetemp build\\pytest-issue-375-final -o cache_dir=build\\pytest-cache-issue-375-final` — 24 passed
- `uv run ty check src/mmgpy/_mesh.py src/mmgpy/_pv_plugin.py` — passed
- `clang-format --dry-run --Werror` on changed C/C++ sources — passed
- standalone C reproducer compiled cleanly against MMG 5.8.0 and reproduced the corruption (`expected 2`, `got 4.9406564584124654e-323`)
- broad fail-fast suite reached 140 passed, 1 skipped before an unrelated PyVista image-baseline size mismatch in `tests/examples_test.py::test_pyvista_example[mmg2d-levelset_discretization]`

Progresses #375. Final `.solb` enablement remains blocked on MmgTools/mmg#326 and a fixed MMG release.