### PR TITLE
release: v0.17.0

### DIFF
--- a/blender_mmgpy/blender_manifest.toml
+++ b/blender_mmgpy/blender_manifest.toml
@@ -4,7 +4,7 @@
 schema_version = "1.0.0"
 
 id = "mmgpy"
-version = "0.17.0"
+version = "0.18.0-dev.0"
 name = "MMGpy - Mesh Remeshing"
 tagline = "Adaptive surface remeshing via the MMG library"
 maintainer = "Kevin Marchais <kevinmarchais@gmail.com>"

--- a/blender_mmgpy/blender_manifest.toml
+++ b/blender_mmgpy/blender_manifest.toml
@@ -4,7 +4,7 @@
 schema_version = "1.0.0"
 
 id = "mmgpy"
-version = "0.17.0-dev.0"
+version = "0.17.0"
 name = "MMGpy - Mesh Remeshing"
 tagline = "Adaptive surface remeshing via the MMG library"
 maintainer = "Kevin Marchais <kevinmarchais@gmail.com>"

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.17.0.dev0"
+  version: "0.17.0"
 
 package:
   name: mmgpy

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   # Keep in sync with pyproject.toml [project] version
-  version: "0.17.0"
+  version: "0.18.0.dev0"
 
 package:
   name: mmgpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.17.0"
+version = "0.18.0.dev0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mmgpy"
-version = "0.17.0.dev0"
+version = "0.17.0"
 description = "Python bindings for the MMG software"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1485,7 +1485,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.17.0.dev0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1485,7 +1485,7 @@ wheels = [
 
 [[package]]
 name = "mmgpy"
-version = "0.17.0"
+version = "0.18.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Two commits: the `v0.17.0` release commit (tagged), then the
dev-bump to `0.18.0.dev0` opening the next cycle.

**Merge with a merge commit, not squash.** Squashing collapses
both commits and orphans the `v0.17.0` tag from main's
history.