### PR TITLE
ci: run PR checks according to what changed

### DIFF
--- a/.github/scripts/check_ci_result.py
+++ b/.github/scripts/check_ci_result.py
@@ -1,0 +1,30 @@
+"""Fail the required check if selected jobs fail, cancel, or unexpectedly skip."""
+
+import json
+import os
+
+
+def failures(needs: dict) -> list[str]:
+    """Validate job outcomes against the successful selection job's outputs."""
+    if needs["select"]["result"] != "success":
+        return ["select"]
+    selected = needs["select"]["outputs"]
+    expected = {"tests", "examples", "docs", "wheels", "conda", "benchmarks"}
+    if any(selected.get(name) not in {"true", "false"} for name in expected):
+        return ["select"]
+    if not expected.union({"select", "lint"}).issubset(needs):
+        return ["missing jobs"]
+    bad = []
+    for name, job in needs.items():
+        required = name in {"select", "lint"} or selected.get(name) == "true"
+        if job["result"] != "success" and (required or job["result"] != "skipped"):
+            bad.append(name)
+    return bad
+
+
+if __name__ == "__main__":
+    failed = failures(json.loads(os.environ["CI_NEEDS"]))
+    if failed:
+        message = f"CI did not pass: {', '.join(failed)}"
+        raise SystemExit(message)
+    print("All selected CI checks passed.")

--- a/.github/scripts/check_dev_tools.py
+++ b/.github/scripts/check_dev_tools.py
@@ -1,0 +1,24 @@
+"""Run the lockfile's development tools without compiling the native package."""
+
+import subprocess
+from pathlib import Path
+
+import tomllib
+
+
+def main() -> None:
+    """Match hook isolation while testing the tool versions being updated."""
+    packages = tomllib.loads(Path("uv.lock").read_text())["package"]
+    versions = {p["name"]: p["version"] for p in packages}
+    for tool, args in (
+        ("prek", ["run", "--all-files"]),
+        ("ty", ["check", "src/mmgpy/"]),
+    ):
+        subprocess.run(  # noqa: S603 - fixed tool commands, no shell
+            ["uv", "tool", "run", "--from", f"{tool}=={versions[tool]}", tool, *args],  # noqa: S607
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/select_ci.py
+++ b/.github/scripts/select_ci.py
@@ -1,0 +1,98 @@
+"""Choose CI work from the complete PR diff; unknown changes run everything."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import tomllib
+
+CHECKS = ("tests", "examples", "docs", "wheels", "conda", "benchmarks")
+TOOLS = {"ty", "prek"}
+
+
+def tool_lock_only(before: bytes, after: bytes) -> bool:
+    """Allow only standalone development tool records to change."""
+    old, new = (tomllib.loads(data.decode()) for data in (before, after))
+    old_packages = old.pop("package")
+    new_packages = new.pop("package")
+    # Compare lists, rather than indexing by name: uv can lock multiple versions.
+    return old == new and [p for p in old_packages if p["name"] not in TOOLS] == [
+        p for p in new_packages if p["name"] not in TOOLS
+    ]
+
+
+def select(paths: list[str], *, tools_only: bool = False, full: bool = False) -> dict:
+    """Select checks conservatively, including both sides of renamed paths."""
+    result = dict.fromkeys(CHECKS, False)
+    result["full_wheels"] = False
+    if full or not paths:
+        return dict.fromkeys(result, True)
+    for path in paths:
+        if path == "uv.lock" and tools_only:
+            continue
+        if path.startswith(("docs/", "examples/")) or path == "mkdocs.yml":
+            result.update(docs=True, examples=True)
+        elif path.endswith(".md") and not path.startswith(".github/"):
+            result["docs"] = True
+        elif path.startswith("src/"):
+            result.update(tests=True, examples=True, docs=True, wheels=True)
+            if not path.startswith(("src/mmgpy/ui/", "src/mmgpy/interactive/")):
+                result["benchmarks"] = True
+            if path.startswith("src/bindings/") or path.endswith("CMakeLists.txt"):
+                result.update(full_wheels=True, conda=True)
+        elif path.startswith("tests/"):
+            result.update(tests=True, examples=True, wheels=True)
+        elif path.startswith("benchmarks/"):
+            result["benchmarks"] = True
+        elif path.startswith("conda/"):
+            result["conda"] = True
+        elif path == ".pre-commit-config.yaml":
+            continue
+        else:
+            # Includes manifests, runtime lock changes, native dependencies,
+            # workflows, build scripts, and files not covered by this policy.
+            return dict.fromkeys(result, True)
+    return result
+
+
+def git(*args: str) -> bytes:
+    """Read the repository without relying on filenames in shell commands."""
+    return subprocess.check_output(["git", *args])  # noqa: S603, S607 - fixed executable, no shell
+
+
+def main() -> None:
+    """Write the selection to GitHub job outputs and the run summary."""
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    full = os.environ["GITHUB_EVENT_NAME"] != "pull_request"
+    paths = []
+    tools_only = False
+    if not full:
+        base = event["pull_request"]["base"]["sha"]
+        head = event["pull_request"]["head"]["sha"]
+        merge_base = git("merge-base", base, head).decode().strip()
+        paths = (
+            git("diff", "--name-only", "--no-renames", "-z", merge_base, head)
+            .decode()
+            .split("\0")[:-1]
+        )
+        if "uv.lock" in paths:
+            try:
+                tools_only = tool_lock_only(
+                    git("show", f"{merge_base}:uv.lock"), git("show", f"{head}:uv.lock")
+                )
+            except (subprocess.CalledProcessError, ValueError, KeyError):
+                tools_only = False
+    result = select(paths, tools_only=tools_only, full=full)
+    print(json.dumps(result, indent=2))
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+        for key, value in result.items():
+            print(f"{key}={str(value).lower()}", file=output)
+    with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+        print("## Selected CI checks\n", file=summary)
+        for key, value in result.items():
+            print(f"- {key}: {'run' if value else 'not needed'}", file=summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_ci_policy.py
+++ b/.github/scripts/test_ci_policy.py
@@ -1,0 +1,132 @@
+"""Exercise selective CI and merge-gate failure cases without native dependencies."""
+
+# unittest keeps these checks independent of the native test environment.
+# ruff: noqa: PT009
+
+import copy
+import unittest
+
+from check_ci_result import failures
+from select_ci import CHECKS, select, tool_lock_only
+
+
+class SelectionTests(unittest.TestCase):
+    """Choose checks for representative changes."""
+
+    def test_tool_update_skips_native_work(self) -> None:
+        """Tool update skips native work."""
+        self.assertFalse(any(select(["uv.lock"], tools_only=True).values()))
+
+    def test_mixed_tool_and_source_change_keeps_tests(self) -> None:
+        """Mixed tool and source change keeps tests."""
+        result = select(["uv.lock", "src/mmgpy/metrics.py"], tools_only=True)
+        self.assertTrue(result["tests"])
+        self.assertTrue(result["benchmarks"])
+        self.assertTrue(result["wheels"])
+        self.assertFalse(result["full_wheels"])
+
+    def test_native_packaging_and_unknown_changes_run_full(self) -> None:
+        """Native packaging and unknown changes run full."""
+        for path in [
+            "uv.lock",
+            "pyproject.toml",
+            "extern/CMakeLists.txt",
+            ".github/workflows/ci.yml",
+            "unknown",
+        ]:
+            with self.subTest(path=path):
+                self.assertTrue(all(select([path]).values()))
+        self.assertTrue(select(["src/bindings/mmg3d.cpp"])["full_wheels"])
+
+    def test_docs_select_only_docs_and_examples(self) -> None:
+        """Docs select only docs and examples."""
+        result = select(["docs/tutorial.md"])
+        self.assertEqual({k for k, v in result.items() if v}, {"docs", "examples"})
+
+    def test_renamed_source_to_docs_still_runs_tests(self) -> None:
+        """Renamed source to docs still runs tests."""
+        self.assertTrue(select(["src/mmgpy/old.py", "docs/new.md"])["tests"])
+
+    def test_full_runs_ignore_paths(self) -> None:
+        """Full runs ignore paths."""
+        self.assertTrue(all(select(["docs/index.md"], full=True).values()))
+        self.assertTrue(all(select([]).values()))
+
+    def test_lock_comparison_rejects_runtime_and_metadata_changes(self) -> None:
+        """Lock comparison rejects runtime and metadata changes."""
+        old = (
+            b'version = 1\n[[package]]\nname = "ty"\nversion = "1"\n'
+            b'[[package]]\nname = "numpy"\nversion = "1"\n'
+        )
+        self.assertTrue(
+            tool_lock_only(
+                old,
+                old.replace(
+                    b'name = "ty"\nversion = "1"', b'name = "ty"\nversion = "2"'
+                ),
+            )
+        )
+        self.assertFalse(
+            tool_lock_only(
+                old,
+                old.replace(
+                    b'name = "numpy"\nversion = "1"', b'name = "numpy"\nversion = "2"'
+                ),
+            )
+        )
+        self.assertFalse(
+            tool_lock_only(old, old.replace(b"version = 1", b"version = 2"))
+        )
+        self.assertFalse(
+            tool_lock_only(old, old + b'[[package]]\nname = "numpy"\nversion = "2"\n')
+        )
+
+
+class GateTests(unittest.TestCase):
+    """Fail closed when expected checks do not succeed."""
+
+    def setUp(self) -> None:
+        """Create a successful minimal CI run."""
+        self.needs = {
+            "select": {"result": "success", "outputs": dict.fromkeys(CHECKS, "false")},
+            "lint": {"result": "success"},
+        }
+        self.needs.update({name: {"result": "skipped"} for name in CHECKS})
+
+    def test_intentional_skips_pass(self) -> None:
+        """Intentional skips pass."""
+        self.assertEqual(failures(self.needs), [])
+
+    def test_missing_outputs_or_jobs_fail(self) -> None:
+        """Reject an incomplete selection or dependency list."""
+        needs = copy.deepcopy(self.needs)
+        del needs["select"]["outputs"]["tests"]
+        self.assertEqual(failures(needs), ["select"])
+        del self.needs["tests"]
+        self.assertEqual(failures(self.needs), ["missing jobs"])
+
+    def test_selected_jobs_must_succeed(self) -> None:
+        """Selected jobs must succeed."""
+        for outcome in ["skipped", "cancelled", "failure"]:
+            with self.subTest(outcome=outcome):
+                needs = copy.deepcopy(self.needs)
+                needs["select"]["outputs"]["tests"] = "true"
+                needs["tests"]["result"] = outcome
+                self.assertEqual(failures(needs), ["tests"])
+
+    def test_selection_failure_and_lint_skip_fail_closed(self) -> None:
+        """Selection failure and lint skip fail closed."""
+        self.needs["select"]["result"] = "failure"
+        self.assertEqual(failures(self.needs), ["select"])
+        self.needs["select"]["result"] = "success"
+        self.needs["lint"]["result"] = "skipped"
+        self.assertEqual(failures(self.needs), ["lint"])
+
+    def test_unselected_failure_is_not_hidden(self) -> None:
+        """Unselected failure is not hidden."""
+        self.needs["docs"]["result"] = "failure"
+        self.assertEqual(failures(self.needs), ["docs"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,11 +1,13 @@
 name: Benchmarks
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
   workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: "Compare this branch with a base ref, for example main"
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -15,7 +17,8 @@ permissions:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    timeout-minutes: 30
+    if: github.event_name != 'pull_request' && inputs.baseline_ref == ''
     # Share the gh-pages mutex with mike deploys (docs.yml, redeploy-docs.yml,
     # build-wheels.yml deploy-versioned-docs). Without this, the benchmark
     # auto-push step can interleave with a mike push and reject it with a
@@ -53,6 +56,7 @@ jobs:
             --benchmark-disable-gc
 
       - name: Store benchmark result
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: "pytest"
@@ -73,13 +77,14 @@ jobs:
 
   benchmark-pr:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request' || inputs.baseline_ref != ''
 
     steps:
       # --- Setup ---
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.sha || inputs.baseline_ref }}
           fetch-depth: 0
 
       - name: Cache apt packages
@@ -111,7 +116,7 @@ jobs:
       # --- Phase 2: Current (PR branch) ---
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           clean: false
 
       - name: Install dependencies (PR branch)
@@ -186,6 +191,7 @@ jobs:
           EOF
 
       - name: Comment benchmark summary on PR
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,12 +1,8 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [main]
-  pull_request: # Any pull request
-  workflow_dispatch: # Allow manual triggering of the workflow
-  schedule:
-    - cron: "0 0 * * *" # Run at midnight UTC every day
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -22,6 +18,7 @@ jobs:
           - "3.14"
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -39,20 +36,6 @@ jobs:
       - run: uv run python -c "import mmgpy"
       - name: Run tests with coverage
         run: uv run pytest --ignore=tests/examples_test.py --ignore=tests/docs_test.py --cov=src/mmgpy --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
-
-      - name: Test documentation code blocks
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
-        env:
-          PYVISTA_OFF_SCREEN: "true"
-          MPLBACKEND: Agg
-        run: uv run pytest tests/docs_test.py -v
-
-      - name: Run examples
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
-        env:
-          MPLBACKEND: Agg
-          PYVISTA_OFF_SCREEN: "true"
-        run: uv run pytest tests/examples_test.py -v
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -2,10 +2,11 @@
 name: Build Wheels
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
+    inputs:
+      full:
+        type: boolean
+        default: true
   release:
     types: [published]
   workflow_dispatch:
@@ -22,6 +23,30 @@ on:
         type: boolean
 
 jobs:
+  release-lint:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
+    uses: ./.github/workflows/prek.yml
+
+  release-tests:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+
+  release-examples:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
+    uses: ./.github/workflows/examples.yml
+    secrets: inherit
+
+  release-conda:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
+    uses: ./.github/workflows/conda-build.yml
+    secrets: inherit
+
+  release-benchmarks:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
+    uses: ./.github/workflows/benchmark.yml
+    secrets: inherit
+
   build-wheels-linux-x86_64:
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +54,7 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Build manylinux_2_28 x86_64 wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && !inputs.full && 'cp310-*' || '' }}
           CIBW_ARCHS_LINUX: x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         uses: pypa/cibuildwheel@v3.4.1
@@ -57,13 +82,14 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
   build-wheels-linux-aarch64:
+    if: github.event_name != 'pull_request' || inputs.full
     runs-on: ubuntu-24.04-arm # Native ARM runner (no QEMU needed)
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Build manylinux_2_28 aarch64 wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && !inputs.full && 'cp310-*' || '' }}
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
         uses: pypa/cibuildwheel@v3.4.1
@@ -107,7 +133,7 @@ jobs:
         run: uv tool install delvewheel
       - name: Build wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && !inputs.full && 'cp310-*' || '' }}
         uses: pypa/cibuildwheel@v3.4.1
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
@@ -139,7 +165,7 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Build wheels
         env:
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp310-* cp314-*' || '' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && !inputs.full && 'cp310-*' || '' }}
         uses: pypa/cibuildwheel@v3.4.1
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7
@@ -200,7 +226,8 @@ jobs:
     # examples before tagging, not after; v0.16.0 shipped a slim install
     # that broke pytest-pyvista's PIL import and the publish chain only
     # surfaced it during the wheel-build dispatch.
-    if: github.event_name == 'pull_request' || (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
+    # Validate installed artifacts on every selected wheel run, including nightly.
+    if: ${{ !cancelled() }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -256,6 +283,11 @@ jobs:
         build-wheels-macos,
         build-sdist,
         validate-release,
+        release-lint,
+        release-tests,
+        release-examples,
+        release-conda,
+        release-benchmarks,
       ]
     runs-on: ubuntu-latest
     name: Publish to PyPI
@@ -270,10 +302,16 @@ jobs:
       actions: read
 
     steps:
-      - name: Download all artifacts
+      - name: Download wheel artifacts
         uses: actions/download-artifact@v8
         with:
+          pattern: wheels-*
           merge-multiple: true
+          path: dist/
+      - name: Download source distribution
+        uses: actions/download-artifact@v8
+        with:
+          name: sdist
           path: dist/
 
       - name: Publish to PyPI
@@ -298,6 +336,11 @@ jobs:
         build-wheels-macos,
         build-sdist,
         validate-release,
+        release-lint,
+        release-tests,
+        release-examples,
+        release-conda,
+        release-benchmarks,
       ]
     runs-on: ubuntu-latest
     name: Publish to TestPyPI
@@ -311,10 +354,16 @@ jobs:
       id-token: write
 
     steps:
-      - name: Download all artifacts
+      - name: Download wheel artifacts
         uses: actions/download-artifact@v8
         with:
+          pattern: wheels-*
           merge-multiple: true
+          path: dist/
+      - name: Download source distribution
+        uses: actions/download-artifact@v8
+        with:
+          name: sdist
           path: dist/
 
       - name: List artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Only PR runs supersede one another. Release and scheduled work must finish.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.select.outputs.tests }}
+      examples: ${{ steps.select.outputs.examples }}
+      docs: ${{ steps.select.outputs.docs }}
+      wheels: ${{ steps.select.outputs.wheels }}
+      full_wheels: ${{ steps.select.outputs.full_wheels }}
+      conda: ${{ steps.select.outputs.conda }}
+      benchmarks: ${{ steps.select.outputs.benchmarks }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: select
+        run: python .github/scripts/select_ci.py
+
+  lint:
+    uses: ./.github/workflows/prek.yml
+
+  tests:
+    needs: select
+    if: needs.select.outputs.tests == 'true'
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+
+  examples:
+    needs: select
+    if: needs.select.outputs.examples == 'true'
+    uses: ./.github/workflows/examples.yml
+
+  docs:
+    needs: select
+    if: needs.select.outputs.docs == 'true'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/docs.yml
+    secrets: inherit
+
+  wheels:
+    needs: select
+    if: needs.select.outputs.wheels == 'true'
+    permissions:
+      contents: write
+      actions: read
+      id-token: write
+      deployments: write
+      pull-requests: write
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      full: ${{ needs.select.outputs.full_wheels == 'true' }}
+    secrets: inherit
+
+  conda:
+    needs: select
+    if: needs.select.outputs.conda == 'true'
+    uses: ./.github/workflows/conda-build.yml
+
+  benchmarks:
+    needs: select
+    if: needs.select.outputs.benchmarks == 'true'
+    permissions:
+      contents: write
+      deployments: write
+      pull-requests: write
+    uses: ./.github/workflows/benchmark.yml
+    secrets: inherit
+
+  passed:
+    name: CI passed
+    if: ${{ always() }}
+    needs: [select, lint, tests, examples, docs, wheels, conda, benchmarks]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check every selected job
+        env:
+          CI_NEEDS: ${{ toJSON(needs) }}
+        run: python .github/scripts/check_ci_result.py

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,9 +1,7 @@
 name: Conda Build
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,7 @@
 name: Documentation
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
 
 permissions:
   contents: write
@@ -40,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --group docs
 
+      - name: Build documentation
+        run: uv run mkdocs build
+
       - name: Configure Git for mike
         run: |
           git config user.name "github-actions[bot]"
@@ -62,7 +62,7 @@ jobs:
       - name: Deploy PR preview
         if: >-
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         run: uv run mike deploy "pr-${{ github.event.pull_request.number }}" --push
 
       # Tokens for pull requests from forks are read-only. Build the docs without
@@ -76,7 +76,7 @@ jobs:
       - name: Comment PR preview link
         if: >-
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: actions/github-script@v9
         with:
           script: |
@@ -107,7 +107,7 @@ jobs:
       - name: Clean up stale PR previews
         if: >-
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,29 @@
+name: Documentation and examples
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  examples:
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [docs, examples]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.14"
+          enable-cache: true
+      - name: Install offscreen rendering libraries
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev libgl1-mesa-dev
+      - run: uv sync --locked --extra fem
+      - name: Run documentation or example tests
+        env:
+          MPLBACKEND: Agg
+          PYVISTA_OFF_SCREEN: "true"
+          SUITE: ${{ matrix.suite }}
+        run: uv run --locked pytest "tests/${SUITE}_test.py" -v

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -1,9 +1,8 @@
 name: prek
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   prek:
@@ -11,4 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-      - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
+      - name: Validate lockfile
+        run: uv lock --check
+      - name: Test CI selection and required-check behavior
+        run: python -m unittest discover -s .github/scripts -p 'test_ci_policy.py' -v
+      - name: Run locked development tools
+        run: uv run --no-project python .github/scripts/check_dev_tools.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,3 +260,47 @@ gdb --args python -c "import mmgpy; ..."
 - Open an [issue](https://github.com/kmarchais/mmgpy/issues) for questions
 - Join [discussions](https://github.com/kmarchais/mmgpy/discussions) for broader topics
 - Tag @kmarchais for urgent matters
+
+# CI checks
+
+Pull requests use one required check, `CI passed`. It waits for lint and every
+check selected from the complete PR diff. Failures, cancellations, missing
+selection outputs, and unexpected skips block merging.
+
+| Change                                                            | Checks                                                                                                                         |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Only `ty` or `prek` package records in `uv.lock`                  | Lockfile validation, all hooks using locked prek, and locked ty                                                                |
+| Documentation or examples                                         | Lint, docs build, documentation snippets and example tests                                                                     |
+| Python code                                                       | Lint, tests on all three operating systems, docs/examples, representative installed wheels; benchmarks for non-UI package code |
+| Native bindings                                                   | The code checks plus the full wheel matrix and conda builds                                                                    |
+| Conda recipe                                                      | Lint and conda builds                                                                                                          |
+| Benchmark code                                                    | Lint and a baseline-versus-PR comparison                                                                                       |
+| Manifests, runtime dependencies, workflows, or unrecognized files | Full validation                                                                                                                |
+
+Tool-only detection compares parsed lockfiles, including metadata and packages
+outside the tool allowlist. A mixed change still runs the checks needed by its
+other files. Ruff updates currently take the full path because its locked
+version and the pinned lint hook differ.
+
+Documentation snippets and examples run in separate jobs alongside platform
+tests. New PR commits cancel obsolete runs. Pushes to main and nightly runs
+perform full validation. Publishing to PyPI or TestPyPI also requires source
+tests, lint, examples, conda builds, benchmarks, and installed-wheel validation
+on the release checkout. Only wheel and source-distribution artifacts are
+downloaded for publishing.
+
+To request a benchmark comparison on any branch:
+
+```sh
+gh workflow run benchmark.yml --ref YOUR_BRANCH -f baseline_ref=main
+```
+
+To request the full CI suite on a branch:
+
+```sh
+gh workflow run ci.yml --ref YOUR_BRANCH
+```
+
+The source tests retain their pytest coverage threshold. Codecov uploads remain
+available for review, but external Codecov statuses are not separate required
+checks under this policy.

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -249,7 +249,7 @@ def _extract_triangles_from_polydata(mesh: pv.PolyData) -> NDArray[np.int32]:
 
     """
     if hasattr(mesh, "cells_dict") and pv.CellType.TRIANGLE in mesh.cells_dict:
-        return mesh.cells_dict[pv.CellType.TRIANGLE].astype(np.int32)
+        return mesh.cells_dict[np.uint8(pv.CellType.TRIANGLE)].astype(np.int32)
 
     faces = mesh.faces
     if len(faces) == 0:
@@ -321,7 +321,7 @@ def _line_connectivity(
     if cells_dict is None and hasattr(mesh, "cells_dict"):
         cells_dict = mesh.cells_dict
     if cells_dict is not None and pv.CellType.LINE in cells_dict:
-        edges = cells_dict[pv.CellType.LINE].astype(np.int32)
+        edges = cells_dict[np.uint8(pv.CellType.LINE)].astype(np.int32)
     elif isinstance(mesh, pv.PolyData):
         edges = _extract_lines_from_polydata(mesh)
     else:
@@ -353,7 +353,7 @@ def _triangle_connectivity_unstructured(
         cells_dict = mesh.cells_dict
     if pv.CellType.TRIANGLE not in cells_dict:
         return None
-    tris = cells_dict[pv.CellType.TRIANGLE].astype(np.int32)
+    tris = cells_dict[np.uint8(pv.CellType.TRIANGLE)].astype(np.int32)
     if len(tris) == 0:
         return None
     return tris
@@ -560,7 +560,7 @@ def _extract_mmg3d_cells(
         msg = "UnstructuredGrid must contain tetrahedra (CellType.TETRA)"
         raise ValueError(msg)
 
-    elements = cells_dict[pv.CellType.TETRA].astype(np.int32)
+    elements = cells_dict[np.uint8(pv.CellType.TETRA)].astype(np.int32)
     edges, edge_refs = _extract_edges(mesh, cells_dict=cells_dict)
     triangles = _triangle_connectivity_unstructured(mesh, cells_dict=cells_dict)
     triangle_refs = None

--- a/src/mmgpy/_pyvista.py
+++ b/src/mmgpy/_pyvista.py
@@ -249,7 +249,7 @@ def _extract_triangles_from_polydata(mesh: pv.PolyData) -> NDArray[np.int32]:
 
     """
     if hasattr(mesh, "cells_dict") and pv.CellType.TRIANGLE in mesh.cells_dict:
-        return mesh.cells_dict[np.uint8(pv.CellType.TRIANGLE)].astype(np.int32)
+        return mesh.cells_dict[pv.CellType.TRIANGLE].astype(np.int32)
 
     faces = mesh.faces
     if len(faces) == 0:

--- a/tests/pyvista_test.py
+++ b/tests/pyvista_test.py
@@ -114,6 +114,29 @@ def mmgs_mesh() -> MmgMeshS:
 class TestFromPyvista:
     """Tests for from_pyvista function."""
 
+    def test_mixed_cell_grid_preserves_each_connectivity(self) -> None:
+        """Typed VTK keys must preserve tetrahedra, boundary faces, and edges."""
+        points = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+        tetrahedra = np.array([[0, 1, 2, 3]], dtype=np.int32)
+        triangles = np.array([[0, 1, 2]], dtype=np.int32)
+        edges = np.array([[0, 1]], dtype=np.int32)
+        grid = pv.UnstructuredGrid(
+            {
+                pv.CellType.TETRA: tetrahedra,
+                pv.CellType.TRIANGLE: triangles,
+                pv.CellType.LINE: edges,
+            },
+            points,
+        )
+
+        mesh = from_pyvista(grid)
+
+        np.testing.assert_array_equal(mesh.get_elements(), tetrahedra)
+        np.testing.assert_array_equal(mesh.get_triangles(), triangles)
+        np.testing.assert_array_equal(mesh.get_edges(), edges)
+
     def test_unstructured_grid_to_mmg3d(self, tetra_grid: pv.UnstructuredGrid) -> None:
         """Test converting UnstructuredGrid to MmgMesh3D."""
         mesh = from_pyvista(tetra_grid)

--- a/tests/pyvista_test.py
+++ b/tests/pyvista_test.py
@@ -116,9 +116,12 @@ class TestFromPyvista:
 
     def test_mixed_cell_grid_preserves_each_connectivity(self) -> None:
         """Typed VTK keys must preserve tetrahedra, boundary faces, and edges."""
-        points = np.array(
-            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
-        )
+        points = np.array([
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ])
         tetrahedra = np.array([[0, 1, 2, 3]], dtype=np.int32)
         triangles = np.array([[0, 1, 2]], dtype=np.int32)
         edges = np.array([[0, 1]], dtype=np.int32)


### PR DESCRIPTION
## Summary

Select PR checks from the changes so tool and documentation updates avoid unrelated builds, while nightly and release runs keep full validation.

## Changes

- Add a fail-closed `CI passed` aggregate check, conservative diff selection, and cancellation of superseded PR runs.
- Run docs/examples alongside platform tests; select benchmarks and representative or full wheel builds as needed.
- Require tests, lint, examples, conda builds, benchmarks, and installed-wheel validation before publishing. Preserve manual benchmark comparisons.
- Run locked ty/prek versions and fix PyVista cell-key types exposed by the newer checker.

## Test Plan

- [x] Twelve policy and aggregate-check tests pass, including missing outputs, mixed changes, renames, and unexpected skips.
- [x] Actionlint, targeted Ruff checks, formatting, and ty pass locally.
- [x] The actual PR #391 diff selects only lint/tool checks.
- [x] PyVista line, triangle, and tetrahedron lookups return identical arrays with typed keys.
- [x] Full GitHub CI and both Codecov checks pass on the final commit.

## Checklist

- [x] Contributor documentation explains selection and manual runs.
- [x] Branch protection requires `CI passed` from GitHub Actions and keeps strict up-to-date checks.

