### PR TITLE
ci: limit token permissions in release validation workflows

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -22,6 +22,11 @@ on:
         default: false
         type: boolean
 
+# Builds and validation only need to read the checkout. Jobs that publish
+# results declare their additional permissions below.
+permissions:
+  contents: read
+
 jobs:
   release-lint:
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
@@ -44,6 +49,12 @@ jobs:
 
   release-benchmarks:
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (inputs.publish_to_pypi || inputs.publish_to_testpypi))
+    # Match the reusable workflow's contract; called workflows cannot elevate
+    # the permissions granted by their caller.
+    permissions:
+      contents: write
+      deployments: write
+      pull-requests: write
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   examples:
     strategy:


### PR DESCRIPTION
## Summary

Address the five CodeQL token-permission findings on #394.

## Changes

- Default wheel and example workflows to `contents: read`.
- Explicitly grant the release benchmark caller the permissions required by its reusable workflow.
- Preserve the existing job-specific publishing and docs deployment permissions.

## Test Plan

- [x] Actionlint, Prettier, and diff checks pass.
- [ ] GitHub CI and CodeQL complete.

## Checklist

- [x] No runtime code or CI selection changes.
